### PR TITLE
DOCKER:

### DIFF
--- a/docker/compile/Dockerfile
+++ b/docker/compile/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:jdk14
+FROM gradle:jdk15
 
 RUN apt update && apt install -y --no-install-recommends \
        ant groovy nodejs npm postgresql-client tcsh sudo \
@@ -15,9 +15,6 @@ RUN mkdir -p /opt/zfin/tls/certs
 RUN mkdir -p /opt/zfin/tls/private
 RUN mkdir -p /opt/zfin/catalina_bases/zfin.org
 RUN chown -R gradle:gradle /opt/zfin/
-
-#Compatibility links because /usr/bin and /bin are different in jdk14 based images
-RUN ln -s /usr/bin/sudo /bin/sudo
 
 RUN groupmod -n zfin gradle
 RUN groupadd -g 8983 solr 


### PR DESCRIPTION
Use the jdk15 base image.  Remove symlink hack for sudo for previous image.