### PR TITLE
ZFIN-7501

### DIFF
--- a/source/org/zfin/gwt/root/server/MarkerRPCServiceImpl.java
+++ b/source/org/zfin/gwt/root/server/MarkerRPCServiceImpl.java
@@ -30,11 +30,9 @@ import org.zfin.marker.Marker;
 import org.zfin.marker.MarkerAlias;
 import org.zfin.marker.MarkerRelationship;
 import org.zfin.marker.repository.MarkerRepository;
+import org.zfin.marker.service.MarkerAttributionService;
 import org.zfin.marker.service.MarkerService;
-import org.zfin.mutant.DiseaseAnnotation;
-import org.zfin.mutant.DiseaseAnnotationModel;
-import org.zfin.mutant.Fish;
-import org.zfin.mutant.Genotype;
+import org.zfin.mutant.*;
 import org.zfin.profile.MarkerSupplier;
 import org.zfin.profile.Organization;
 import org.zfin.publication.Publication;
@@ -1173,17 +1171,10 @@ public class MarkerRPCServiceImpl extends ZfinRemoteServiceServlet implements Ma
 
     @Override
     public void addAttributionForMarkerName(String markerAbbrev, String pubZdbID) throws TermNotFoundException, DuplicateEntryException {
-        Marker m = RepositoryFactory.getMarkerRepository().getMarkerByAbbreviation(markerAbbrev);
-        if (m == null) {
-            throw new TermNotFoundException(markerAbbrev, "Marker");
-        }
-        String markerZdbID = m.getZdbID();
-        if (infrastructureRepository.getRecordAttribution(markerZdbID, pubZdbID, RecordAttribution.SourceType.STANDARD) != null) {
-            throw new DuplicateEntryException(m.getAbbreviation() + " is already attributed.");
-        }
         HibernateUtil.createTransaction();
-        infrastructureRepository.insertRecordAttribution(markerZdbID, pubZdbID);
-        infrastructureRepository.insertUpdatesTable(markerZdbID, "record attribution", "", pubZdbID, "Added direct attribution");
+
+        MarkerAttributionService.addAttributionForMarkerName(markerAbbrev, pubZdbID);
+
         HibernateUtil.flushAndCommitCurrentSession();
         HibernateUtil.closeSession();
     }

--- a/source/org/zfin/marker/service/MarkerAttributionService.java
+++ b/source/org/zfin/marker/service/MarkerAttributionService.java
@@ -1,0 +1,66 @@
+package org.zfin.marker.service;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.zfin.framework.HibernateUtil;
+import org.zfin.gwt.root.dto.TermNotFoundException;
+import org.zfin.gwt.root.ui.DuplicateEntryException;
+import org.zfin.infrastructure.ActiveData;
+import org.zfin.infrastructure.RecordAttribution;
+import org.zfin.infrastructure.repository.InfrastructureRepository;
+import org.zfin.marker.Marker;
+import org.zfin.marker.MarkerType;
+import org.zfin.mutant.SequenceTargetingReagent;
+import org.zfin.repository.RepositoryFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.zfin.repository.RepositoryFactory.getMarkerRepository;
+
+public class MarkerAttributionService {
+    private static transient InfrastructureRepository infrastructureRepository = RepositoryFactory.getInfrastructureRepository();
+    private static transient Logger logger = LogManager.getLogger(MarkerAttributionService.class);
+
+    public static void addAttributionForMarkerName(String markerAbbrev, String pubZdbID) throws TermNotFoundException, DuplicateEntryException {
+        Marker m = RepositoryFactory.getMarkerRepository().getMarkerByAbbreviation(markerAbbrev);
+        if (m == null) {
+            throw new TermNotFoundException(markerAbbrev, "Marker");
+        }
+        String markerZdbID = m.getZdbID();
+        if (infrastructureRepository.getRecordAttribution(markerZdbID, pubZdbID, RecordAttribution.SourceType.STANDARD) != null) {
+            throw new DuplicateEntryException(m.getAbbreviation() + " is already attributed.");
+        }
+
+        infrastructureRepository.insertRecordAttribution(markerZdbID, pubZdbID);
+        infrastructureRepository.insertUpdatesTable(markerZdbID, "record attribution", "", pubZdbID, "Added direct attribution");
+
+        List<Marker> targetedGenes = getTargetedGenes(m);
+        for(Marker gene : targetedGenes) {
+            infrastructureRepository.insertRecordAttribution(gene.getZdbID(), pubZdbID);
+            infrastructureRepository.insertUpdatesTable(gene.getZdbID(), "record attribution", "", pubZdbID, "Added inferred gene attribution");
+        }
+
+    }
+
+    private static List<Marker> getTargetedGenes(Marker m) {
+        ArrayList<Marker> results = new ArrayList<Marker>();
+        SequenceTargetingReagent str = getMarkerRepository().getSequenceTargetingReagent(m.zdbID);
+
+        //Guard Clause: check for null returned from DB for marker
+        if (str == null) {
+            return results;
+        }
+
+        //Guard Clause: check the type of marker is one of (MRPHLNO, CRISPR, TALEN)
+        ActiveData.Type activeDataType = ActiveData.validateID(str.getZdbID());
+        if ( !(activeDataType == ActiveData.Type.MRPHLNO ||
+                activeDataType == ActiveData.Type.CRISPR ||
+                activeDataType == ActiveData.Type.TALEN)) {
+            return results;
+        }
+
+        return str.getTargetGenes();
+    }
+
+}

--- a/test/org/zfin/DbUnitTests.java
+++ b/test/org/zfin/DbUnitTests.java
@@ -32,6 +32,7 @@ import org.zfin.gwt.root.server.DTOConversionServiceTest;
 import org.zfin.infrastructure.InfrastructureRepositoryTest;
 import org.zfin.infrastructure.delete.DeleteRuleTest;
 import org.zfin.mapping.repository.LinkageRepositoryTest;
+import org.zfin.marker.MarkerAttributionServiceTest;
 import org.zfin.marker.MarkerServiceTest;
 import org.zfin.marker.MergeMarkerDBTest;
 import org.zfin.marker.presentation.GeneAddFormBeanValidatorSpec;
@@ -116,6 +117,7 @@ import org.zfin.wiki.service.AntibodyWikiWebServiceTest;
         MarkerGoTermEvidenceRepositoryTest.class,
         MarkerRepositoryTest.class,
         MarkerServiceTest.class,
+        MarkerAttributionServiceTest.class,
         MarkerSoapDbTest.class,
         MergeMarkerDBTest.class,
 //        MicroArrayTest.class,     // Takes 1.5 min to run, but works.

--- a/test/org/zfin/marker/MarkerAttributionServiceTest.java
+++ b/test/org/zfin/marker/MarkerAttributionServiceTest.java
@@ -1,0 +1,93 @@
+package org.zfin.marker;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.zfin.AbstractDatabaseTest;
+import org.zfin.AppConfig;
+import org.zfin.gwt.root.dto.TermNotFoundException;
+import org.zfin.gwt.root.ui.DuplicateEntryException;
+import org.zfin.infrastructure.RecordAttribution;
+import org.zfin.infrastructure.repository.InfrastructureRepository;
+import org.zfin.marker.service.MarkerAttributionService;
+import org.zfin.mutant.SequenceTargetingReagent;
+import org.zfin.publication.Publication;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.zfin.repository.RepositoryFactory.*;
+
+/**
+ * Tests for org.zfin.marker.service.MarkerAttributionService
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {AppConfig.class})
+@WebAppConfiguration
+public class MarkerAttributionServiceTest extends AbstractDatabaseTest {
+
+    @Test
+    public void morpholinoAttributionTriggersGeneTargetAttributionTest() {
+        InfrastructureRepository infrastructureRepository = getInfrastructureRepository();
+
+        // morpholino MO1-a2ml
+        Marker m = getMarkerRepository().getMarkerByID("ZDB-MRPHLNO-090212-1");
+
+        // Pfeffer
+        Publication publication = getPublicationRepository().getPublication("ZDB-PUB-980916-4");
+
+        try {
+            MarkerAttributionService.addAttributionForMarkerName(m.getAbbreviation(), publication.getZdbID());
+        } catch (TermNotFoundException e) {
+            fail("Caught TermNotFoundException");
+        } catch (DuplicateEntryException e) {
+            fail("Caught DuplicateEntryException");
+        }
+
+        //assert the record attribution now exists for the morpholino and publication:
+        RecordAttribution morpholinoRecordAttribution = infrastructureRepository.getRecordAttribution(m.getZdbID(), publication.getZdbID(), RecordAttribution.SourceType.STANDARD);
+        assertNotNull("morpholino record should be found", morpholinoRecordAttribution);
+        assertEquals("morpholino ID should match", m.getZdbID(), morpholinoRecordAttribution.getDataZdbID());
+
+        //assert MO's related gene(s) are now associated with the publication
+        SequenceTargetingReagent str = getMarkerRepository().getSequenceTargetingReagent(m.zdbID);
+        List<Marker> genes = str.getTargetGenes();
+        assertEquals("Should get 2 genes for this morpholino", 2, genes.size());
+        for(Marker gene : genes) {
+            RecordAttribution geneRecordAttribution = infrastructureRepository.getRecordAttribution(gene.getZdbID(), publication.getZdbID(), RecordAttribution.SourceType.STANDARD);
+            assertNotNull("gene retrieved from attribution should not be null", geneRecordAttribution.getDataZdbID());
+            assertEquals("gene ID should match", gene.getZdbID(), geneRecordAttribution.getDataZdbID());
+        }
+    }
+
+    @Test
+    public void nonStrAttributionDoesNotTriggerGeneTargetAttributionTest() {
+        InfrastructureRepository infrastructureRepository = getInfrastructureRepository();
+
+        // Antibody Ab1-opn4
+        Marker antibody = getMarkerRepository().getMarkerByID("ZDB-ATB-120124-1");
+
+        // Pfeffer
+        Publication publication = getPublicationRepository().getPublication("ZDB-PUB-980916-4");
+
+        try {
+            MarkerAttributionService.addAttributionForMarkerName(antibody.getAbbreviation(), publication.getZdbID());
+        } catch (TermNotFoundException e) {
+            fail("Caught TermNotFoundException");
+        } catch (DuplicateEntryException e) {
+            fail("Caught DuplicateEntryException");
+        }
+
+        //assert the record attribution now exists for the morpholino and publication:
+        RecordAttribution recordAttribution = infrastructureRepository.getRecordAttribution(antibody.getZdbID(), publication.getZdbID(), RecordAttribution.SourceType.STANDARD);
+        assertNotNull("antibody record should be found", recordAttribution);
+        assertEquals("antibody ID should match", antibody.getZdbID(), recordAttribution.getDataZdbID());
+
+        //assert antibody's related gene(s) are not associated with the publication
+        SequenceTargetingReagent str = getMarkerRepository().getSequenceTargetingReagent(antibody.zdbID);
+        assertNull(str);
+    }
+
+}


### PR DESCRIPTION
ZFIN-7501

When adding a marker to a publication, we also directly add the attributions for any genes targeted by the marker.  This only applies to TALENs, Morpholinos, and CRISPRs.

https://user-images.githubusercontent.com/90803397/136818461-d4ff5806-c5a9-436d-8f79-49d61b96bcfb.mp4

