### PR TITLE
Spock Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -723,6 +723,7 @@ dependencies {
 
     //testImplementation('org.codehaus.groovy:groovy-all:3.0.6')
     testImplementation group: 'org.spockframework', name: 'spock-junit4', version: '2.0-groovy-3.0'
+    testImplementation group: 'org.spockframework', name: 'spock-spring', version: '2.0-groovy-3.0'
     //changed this from groovy-2.4
     testImplementation('org.spockframework:spock-core:1.0-groovy-3.0')
 

--- a/test/org/zfin/ZfinIntegrationSpec.groovy
+++ b/test/org/zfin/ZfinIntegrationSpec.groovy
@@ -1,7 +1,9 @@
 package org.zfin
 
 import org.hibernate.SessionFactory
+import org.junit.runner.RunWith
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
 import org.springframework.test.context.web.WebAppConfiguration
 import org.zfin.framework.HibernateSessionCreator
 import org.zfin.framework.HibernateUtil
@@ -9,6 +11,7 @@ import spock.lang.Specification
 
 @WebAppConfiguration
 @ContextConfiguration(locations = "file:home/WEB-INF/spring/mvc-webapp.xml")
+@RunWith(SpringJUnit4ClassRunner.class)
 abstract class ZfinIntegrationSpec extends Specification {
 
     public def setupSpec() {


### PR DESCRIPTION
These changes fix some of the issues with the spock tests. In particular if a null pointer was thrown because an @Autowired bean wasn't available or the TemporaryFolder didn't get set up right, those issues should now be fixed.  There are still some remaining tests that are failing though.