### PR TITLE
ZFIN-7690

### DIFF
--- a/source/org/zfin/db/postGmakePostloaddb/1125/db.changelog.master.xml
+++ b/source/org/zfin/db/postGmakePostloaddb/1125/db.changelog.master.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <include file="source/org/zfin/db/postGmakePostloaddb/1125/fix_genotype_names_with_extra_spaces.sql"/>
+
+
+</databaseChangeLog>

--- a/source/org/zfin/db/postGmakePostloaddb/1125/fix_genotype_names_with_extra_spaces.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1125/fix_genotype_names_with_extra_spaces.sql
@@ -1,0 +1,18 @@
+-- This SQL basically queries for any rows in the genotype table where the display_name doesn't match 
+-- the computed display_name (get_genotype_display).  Additionally, I'm filtering further to only rows
+-- where the only difference between the computed name and the existing name is the space preceding
+-- a semicolon.  Once only those rows are returned, we can update the display_name to match the computed name
+
+UPDATE genotype
+SET geno_display_name = subq2.computed_genotype_name FROM
+( SELECT * FROM
+        ( SELECT geno_zdb_id,
+                geno_display_name AS current_genotype_name,
+                get_genotype_display ( geno_zdb_id ) AS computed_genotype_name,
+                REPLACE ( geno_display_name, ' ;', ';' ) AS space_removed
+                FROM genotype ) AS subq
+WHERE
+        current_genotype_name <> computed_genotype_name AND
+        space_removed = computed_genotype_name) as subq2
+
+WHERE subq2.geno_zdb_id = genotype.geno_zdb_id

--- a/source/org/zfin/db/postGmakePostloaddb/db.changelog.master.xml
+++ b/source/org/zfin/db/postGmakePostloaddb/db.changelog.master.xml
@@ -65,5 +65,6 @@
     <include file="source/org/zfin/db/postGmakePostloaddb/1122/db.changelog.master.xml"/>
     <include file="source/org/zfin/db/postGmakePostloaddb/1123/db.changelog.master.xml"/>
     <include file="source/org/zfin/db/postGmakePostloaddb/1124/db.changelog.master.xml"/>
+    <include file="source/org/zfin/db/postGmakePostloaddb/1125/db.changelog.master.xml"/>
 <!-- starting fresh with migration to postgres -->
 </databaseChangeLog>


### PR DESCRIPTION
ZFIN-7690:

Liquibase sql update to fix genotype names with extra spaces preceding semicolons.