### PR TITLE
ZFIN-7614

### DIFF
--- a/server_apps/ZFINPerlModules.pm
+++ b/server_apps/ZFINPerlModules.pm
@@ -20,6 +20,9 @@ my %monthDisplays = (
     "Dec" => "12"
 );
 
+#------ Global variables for "whirleygig" to indicate busy working (https://www.perlmonks.org/?node_id=4943)
+my $WHIRLEY_COUNT=-1;
+my @WHIRLEY=('-', '\\', '|', '/');
 
 sub doSystemCommand {                  
 
@@ -146,5 +149,13 @@ sub month3LettersToNumber() {
   }
 }
 
+# ====================================
+#
+# "Whirleygig" progress indicator
+#
+sub whirley {
+  $WHIRLEY_COUNT = ($WHIRLEY_COUNT + 1) % @WHIRLEY;
+  return @WHIRLEY[$WHIRLEY_COUNT];
+}
 
 1;

--- a/server_apps/data_transfer/SWISS-PROT/pre_loadsp.pl
+++ b/server_apps/data_transfer/SWISS-PROT/pre_loadsp.pl
@@ -101,7 +101,7 @@ sub select_zebrafish {
     };
 
     try {
-      print("Extracting\n")
+      print("Extracting\n");
       system("gunzip uniprot_trembl_vertebrates.dat.gz");
     } catch {
       chomp $_;
@@ -126,7 +126,7 @@ sub select_zebrafish {
     };
 
     try {
-      print("Extracting\n")
+      print("Extracting\n");
       system("gunzip uniprot_sprot_vertebrates.dat.gz");
     } catch {
       chomp $_;
@@ -149,7 +149,7 @@ sub select_zebrafish {
     print("Processing uniprot_trembl_vertebrates.dat\n");
     my $record;
     while ($record = <DAT1>){
-       print STDERR "Processing " . whirley() . "\r";
+       print STDERR "Processing " . ZFINPerlModules->whirley() . "\r";
        print OUTPUT "$record" if $record =~ m/OS   Danio rerio/;
     }
     close(DAT1) ;
@@ -157,7 +157,7 @@ sub select_zebrafish {
     print("Processing uniprot_sprot_vertebrates.dat\n");
     open(DAT2, "uniprot_sprot_vertebrates.dat") || die("Could not open uniprot_sprot_vertebrates.dat!");
     while ($record = <DAT2>){
-       print STDERR "Processing " . whirley() . "\r";
+       print STDERR "Processing " . ZFINPerlModules->whirley() . "\r";
        print OUTPUT "$record" if $record =~ m/OS   Danio rerio/;
     }
 
@@ -167,16 +167,6 @@ sub select_zebrafish {
     close(OUTPUT) ;
 }
 
-# ====================================
-#
-# "Whirleygig" progress indicator
-#
-sub whirley {
-  our $WHIRLEY_COUNT;
-  our @WHIRLEY;
-  $WHIRLEY_COUNT = ($WHIRLEY_COUNT + 1) % @WHIRLEY;
-  return @WHIRLEY[$WHIRLEY_COUNT];
-}
 
 #=======================================================
 #
@@ -206,10 +196,6 @@ system("mkdir ./ccnote");
 my $dbname = "<!--|DB_NAME|-->";
 my $username = "";
 my $password = "";
-
-#------ Global variables for "whirleygig" to indicate busy working (https://www.perlmonks.org/?node_id=4943)
-our $WHIRLEY_COUNT=-1;
-our @WHIRLEY=('-', '\\', '|', '/');
 
 ########################################################################################################
 #
@@ -280,7 +266,7 @@ my $numInvalidUniProtIDs = 0;
 if ($ctManuallyEnteredUniProtIDs > 0) {
   print("Checking for invalid manually entered uniprot IDs\n");
   foreach $uniprotId (@manuallyEnteredUniProtIDs) {
-     print STDERR "Processing " . whirley() . "\r";
+     print STDERR "Processing " . ZFINPerlModules->whirley() . "\r";
      $url = $uniProtURL . $uniprotId;
      my $status_code = getstore($url, "/dev/null");
      if ($status_code != 200) {

--- a/server_apps/data_transfer/SWISS-PROT/runUniprotPreload.sh
+++ b/server_apps/data_transfer/SWISS-PROT/runUniprotPreload.sh
@@ -1,21 +1,22 @@
 #!/bin/bash -e
 
 echo "#########################################################################"
-
-echo "run pre_loadsp.pl"
+echo "run pre_loadsp.pl " $(date "+%Y-%m-%d %H:%M:%S")
 
 pre_loadsp.pl ;
 
-echo "run sp_check.pl"
+echo "run sp_check.pl " $(date "+%Y-%m-%d %H:%M:%S")
 
 sp_check.pl ;
 
-echo "/bin/cat prob1 prob2 prob3 prob4 prob5 prob6 prob7 prob8 > allproblems.txt"
+echo "/bin/cat prob1 prob2 prob3 prob4 prob5 prob6 prob7 prob8 > allproblems.txt " $(date "+%Y-%m-%d %H:%M:%S")
 
 /bin/cat prob1 prob2 prob3 prob4 prob5 prob6 prob7 prob8 > allproblems.txt ;
 
-echo "run sp_match.pl manuallyCuratedUniProtIDs.txt"
+echo "run sp_match.pl manuallyCuratedUniProtIDs.txt " $(date "+%Y-%m-%d %H:%M:%S")
 
 sp_match.pl manuallyCuratedUniProtIDs.txt ;
 
-
+echo "#########################################################################"
+echo "## FINISHED runUniprotPreload.sh "      $(date "+%Y-%m-%d %H:%M:%S")
+echo "#########################################################################"

--- a/server_apps/data_transfer/SWISS-PROT/sp_check.pl
+++ b/server_apps/data_transfer/SWISS-PROT/sp_check.pl
@@ -15,21 +15,10 @@
 # look into.
 
 use DBI;
+use lib "<!--|ROOT_PATH|-->/server_apps/";
+use ZFINPerlModules;
 
-# ====================================
-#
-# "Whirleygig" progress indicator
-#
-#------ Global variables for "whirleygig" to indicate busy working (https://www.perlmonks.org/?node_id=4943)
-my $WHIRLEY_COUNT=-1;
-my @WHIRLEY=('-', '\\', '|', '/');
-sub whirley {
-  $WHIRLEY_COUNT = ($WHIRLEY_COUNT + 1) % @WHIRLEY;
-  return @WHIRLEY[$WHIRLEY_COUNT];
-}
-# END OF Whirleygig
-
-# Take a SP file as input (content format restricted). 
+# Take a SP file as input (content format restricted).
 
 # Create the output files and give them titles. 
 init_files();
@@ -51,7 +40,7 @@ open PUB, ">pubmed_not_in_zfin" or die "Cannot open the pubmed_not_in_zfin:$!";
 $/ = "//\n";
 open (UNPT, "zfin.dat") ||  die "Cannot open zfin.dat : $!\n";
 while (<UNPT>) {
-    print STDERR "Processing zfin.dat " . whirley() . "\r";
+    print STDERR "Processing zfin.dat " . ZFINPerlModules->whirley() . "\r";
 
     init_var ();     # Initialize the variables and arrays 
 

--- a/server_apps/data_transfer/SWISS-PROT/sp_check.pl
+++ b/server_apps/data_transfer/SWISS-PROT/sp_check.pl
@@ -16,6 +16,19 @@
 
 use DBI;
 
+# ====================================
+#
+# "Whirleygig" progress indicator
+#
+#------ Global variables for "whirleygig" to indicate busy working (https://www.perlmonks.org/?node_id=4943)
+my $WHIRLEY_COUNT=-1;
+my @WHIRLEY=('-', '\\', '|', '/');
+sub whirley {
+  $WHIRLEY_COUNT = ($WHIRLEY_COUNT + 1) % @WHIRLEY;
+  return @WHIRLEY[$WHIRLEY_COUNT];
+}
+# END OF Whirleygig
+
 # Take a SP file as input (content format restricted). 
 
 # Create the output files and give them titles. 
@@ -37,10 +50,9 @@ open PUB, ">pubmed_not_in_zfin" or die "Cannot open the pubmed_not_in_zfin:$!";
 
 $/ = "//\n";
 open (UNPT, "zfin.dat") ||  die "Cannot open zfin.dat : $!\n";
-@records = <UNPT>;
-close UNPT;
-foreach (@records) {
-   
+while (<UNPT>) {
+    print STDERR "Processing zfin.dat " . whirley() . "\r";
+
     init_var ();     # Initialize the variables and arrays 
 
     # records in probfile contains AC, RX, DR EMBL lines
@@ -222,6 +234,8 @@ foreach (@records) {
     unlink $probrecd;	
 
 }   # for loop for SP file
+close UNPT;
+
 close PUB;
 
 open CHECKREP, ">checkreport.txt" or die "Cannot open checkreport.txt:$!";


### PR DESCRIPTION
Uniprot load issues:

- Changed the perl script to read .dat files line-by-line instead of slurping up the entire file into memory (which was crashing the script).
- Fixed issue with checking uniprot database for invalid IDs (was scraping http://www.uniprot.org/uniprot/{id}, but always returned true)
- Added a somewhat silly "whirley" progress indicator
- Add some more output to indicate the current state of the script (even more would be nice). Including timestamps so we can track how long each step takes typically