### PR TITLE
ZFIN-7722

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2586,9 +2586,9 @@
       }
     },
     "angular": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.2.tgz",
-      "integrity": "sha512-IauMOej2xEe7/7Ennahkbb5qd/HFADiNuLSESz9Q27inmi32zB0lnAsFeLEWcox3Gd1F6YhNd1CP7/9IukJ0Gw=="
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.5.8.tgz",
+      "integrity": "sha1-klpTkrjCEtCVctxEbbfgEmTglMs="
     },
     "ansi-escapes": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@babel/preset-react": "^7.14.5",
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@geneontology/ribbon": "1.11.2",
-    "angular": "^1.8.2",
+    "angular": "1.5.8",
     "babel-loader": "^8.2.2",
     "bootstrap": "^4.6.0",
     "bootstrap-datepicker": "^1.8.0",


### PR DESCRIPTION
Revert back to earlier angular version for hotfix.

Information on angular upgrade breaking change:

https://docs.angularjs.org/guide/migration#:~:text=Due%20to%20b54a39%2C%20%24http%27s%20deprecated%20custom%20callback%20methods%20-%20success()%20and%20error()%20-%20have%20been%20removed.%20You%20can%20use%20the%20standard%20then()/catch()%20promise%20methods%20instead%2C%20but%20note%20that%20the%20method%20signatures%20and%20return%20values%20are%20different

