### PR TITLE
ZFIN-7614

### DIFF
--- a/server_apps/data_transfer/SWISS-PROT/backupTables.sh
+++ b/server_apps/data_transfer/SWISS-PROT/backupTables.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -e
+
+# This script can be useful for troubleshooting a uniprot load
+# It captures the state of all the tables that are likely to change during the course of the uniprot run
+# This way you can easily compare a before and after state of each table
+# Also, if you need to revert back to the DB state from before a uniprot run, you can do that more quickly
+# than with a gradle loaddb full restore.
+#
+
+if [ -z "$DBNAME" ]; then
+	echo "No DBNAME"
+	exit 1
+fi
+
+TIMESTAMP=`date +%Y-%m-%d-%H-%M-%S`
+DIRECTORY=archives/db/$TIMESTAMP
+mkdir -p $DIRECTORY/csv
+mkdir -p $DIRECTORY/sql
+TABLES_WITH_1_COLUMN="zdb_active_data"
+TABLES_WITH_2_COLUMN="noctua_model_annotation marker_go_term_annotation_extension_group"
+TABLES="db_link external_note inference_group_member interpro_protein marker_go_term_annotation_extension marker_go_term_evidence marker_to_protein pg_stat_statements protein protein_to_interpro protein_to_pdb pub_tracking_history record_attribution tables_in_trouble updates "
+
+echo "Making csv backups "  $(date "+%Y-%m-%d %H:%M:%S")
+for t in $TABLES
+do
+  echo " $t to $DIRECTORY/csv/$t.csv"
+  echo "copy (select * from $t order by 1,2,3) to stdout with csv header" | psql $DBNAME > $DIRECTORY/csv/$t.csv
+done
+
+for t in $TABLES_WITH_1_COLUMN
+do
+  echo " $t to $DIRECTORY/csv/$t.csv"
+  echo "copy (select * from $t order by 1) to stdout with csv header" | psql $DBNAME > $DIRECTORY/csv/$t.csv
+done
+
+for t in $TABLES_WITH_2_COLUMN
+do
+  echo " $t to $DIRECTORY/csv/$t.csv"
+  echo "copy (select * from $t order by 1,2) to stdout with csv header" | psql $DBNAME > $DIRECTORY/csv/$t.csv
+done
+
+echo "Making sql backups "  $(date "+%Y-%m-%d %H:%M:%S")
+for t in $TABLES $TABLES_WITH_1_COLUMN $TABLES_WITH_2_COLUMN
+do
+  echo " $t to $DIRECTORY/sql/$t.sql"
+  pg_dump -d $DBNAME --table $t > $DIRECTORY/sql/$t.sql
+done
+
+echo "Finished "  $(date "+%Y-%m-%d %H:%M:%S")
+
+touch "$DIRECTORY/README.txt"
+
+echo "Consider adding context information to $DIRECTORY/README.txt about this snapshot."

--- a/server_apps/data_transfer/SWISS-PROT/loadsp.pl
+++ b/server_apps/data_transfer/SWISS-PROT/loadsp.pl
@@ -19,6 +19,7 @@ use DBI;
 use lib "<!--|ROOT_PATH|-->/server_apps/";
 use ZFINPerlModules;
 use Try::Tiny;
+use POSIX;
 
 # ----------------- Send Error Report -------------
 # Parameter
@@ -93,6 +94,8 @@ if (!-e "okfile" || !-e "ok2file" || !-e "spkw2go" || !-e "interpro2go" || !-e "
    print "One or more required file(s) not exisiting. Exit.\n";
    exit;
 }
+
+print("Preparing metrics at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n");
 
 #--------------------------- record counts before loading starts ----------------------------
 $sql = "select * from db_link where dblink_info like '%Swiss-Prot%';";
@@ -216,6 +219,7 @@ $sql = "select distinct mrkr_zdb_id from marker, marker_go_term_evidence, term
 $numMrkrProcessBefore = countData($sql);
 
 #--------------- Delete records from last SWISS-PROT loading-----
+print("Running sp_addbackattr.sql at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n");
 try {
   system("psql -d <!--|DB_NAME|--> -a -f sp_addbackattr.sql >addBackAttributionReport.txt");
 } catch {
@@ -354,7 +358,7 @@ while( !( -e "ec_mrkrgoterm.unl")) {
 
 
 # ------------ Loading ---------------------
-print "\nloading...\n";
+print "\nloading... at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n";
 try {
   system("psql -d <!--|DB_NAME|--> -a -f sp_load.sql > report.txt");
 } catch {
@@ -365,6 +369,7 @@ try {
 
 #--------------------------- record counts after loading finishes ----------------------------
 
+print "\nPreparing post-load metrics at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n";
 $sql = "select * from db_link where dblink_info like '%Swiss-Prot%';";
 
 $numDblinkAfter = countData($sql);
@@ -588,7 +593,7 @@ print POSTLOADREPORT "$numMrkrProcessBefore         \t";
 print POSTLOADREPORT "$numMrkrProcessAfter         \t";
 printf POSTLOADREPORT "%.2f\n", ($numMrkrProcessAfter - $numMrkrProcessBefore) / $numMrkrProcessBefore * 100 if ($numMrkrProcessBefore > 0);
 
-print "All done \n";
+print "All done at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n";
 close (POSTLOADREPORT);
 
 #------------------ Send statistics of changes of record counts with the load ----------------
@@ -600,9 +605,7 @@ ZFINPerlModules->sendMailWithAttachedReport('<!--|SWISSPROT_EMAIL_ERR|-->',"$sub
 $subject = "Auto from $dbname: " . "UniProt load log";
 ZFINPerlModules->sendMailWithAttachedReport('<!--|SWISSPROT_EMAIL_ERR|-->',"$subject","report.txt");
 
-print "\n create_file_for_swiss_prot.pl\n";
+print "\n create_file_for_swiss_prot.pl at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n";
 system ("<!--|ROOT_PATH|-->/server_apps/data_transfer/SWISS-PROT/create_file_for_swiss_prot.pl");
 
 exit;
-
-

--- a/server_apps/data_transfer/SWISS-PROT/runUniprotPreload.sh
+++ b/server_apps/data_transfer/SWISS-PROT/runUniprotPreload.sh
@@ -1,13 +1,27 @@
 #!/bin/bash -e
+#
+# Use environment variable "SKIP_DOWNLOADS" to tell script not to download anything and instead assume files exist locally (will exit if no file exists)
+# Use environment variable "SKIP_MANUAL_CHECK" to tell script not to scan uniprot for IDs gone bad
+# Use environment variable "SKIP_CLEANUP" to tell script not to remove old files
+# Use environment variable "SKIP_SLEEP" to tell script not to sleep for 500 seconds at various parts
+# Use environment variable "ARCHIVE_ARTIFACTS" to tell script to save a copy of all generated artifacts
+# Flags are useful for being a good citizen and not putting too much strain on servers.
+#
+# Can run with those env vars in tcsh like so: (https://stackoverflow.com/questions/5946736/)
+#    env SKIP_DOWNLOADS=1 env SKIP_MANUAL_CHECK=1 ./runUniprotPreload.sh
+# or
+#     ( setenv SKIP_DOWNLOADS 1 ; setenv SKIP_MANUAL_CHECK 1; setenv SKIP_CLEANUP 1 ; ./runUniprotPreload.sh )
+#     ( setenv SKIP_MANUAL_CHECK 1 ; setenv SKIP_CLEANUP 1 ; setenv SKIP_SLEEP 1 ; setenv SKIP_PRE_ZFIN_GEN 1 ; setenv SKIP_DOWNLOADS 1 ; setenv ARCHIVE_ARTIFACTS 1; ./runUniprotPreload.sh )
 
+main() {
 echo "#########################################################################"
 echo "run pre_loadsp.pl " $(date "+%Y-%m-%d %H:%M:%S")
 
-pre_loadsp.pl ;
+./pre_loadsp.pl ;
 
 echo "run sp_check.pl " $(date "+%Y-%m-%d %H:%M:%S")
 
-sp_check.pl ;
+./sp_check.pl ;
 
 echo "/bin/cat prob1 prob2 prob3 prob4 prob5 prob6 prob7 prob8 > allproblems.txt " $(date "+%Y-%m-%d %H:%M:%S")
 
@@ -15,8 +29,11 @@ echo "/bin/cat prob1 prob2 prob3 prob4 prob5 prob6 prob7 prob8 > allproblems.txt
 
 echo "run sp_match.pl manuallyCuratedUniProtIDs.txt " $(date "+%Y-%m-%d %H:%M:%S")
 
-sp_match.pl manuallyCuratedUniProtIDs.txt ;
+./sp_match.pl manuallyCuratedUniProtIDs.txt ;
 
 echo "#########################################################################"
 echo "## FINISHED runUniprotPreload.sh "      $(date "+%Y-%m-%d %H:%M:%S")
 echo "#########################################################################"
+}
+
+main 2>&1 | tee preload_log_$(date "+%Y-%m-%d_%H-%M-%S").txt

--- a/server_apps/data_transfer/SWISS-PROT/runUniprotProd.sh
+++ b/server_apps/data_transfer/SWISS-PROT/runUniprotProd.sh
@@ -5,30 +5,57 @@
 # this script only runs on almost and production (automates the prod steps
 # of the UniProt load.  See case 2799 for details.
 
+# Use environment variable "SKIP_CLEANUP" to tell script not to remove old files (and copy over server files) -- for troubleshooting
+#
+# Can run with those env vars in tcsh like so: (https://stackoverflow.com/questions/5946736/)
+#     (  setenv SKIP_CLEANUP 1; ./runUniprotProd.sh )
+
+main() {
+if [ -z "$SKIP_CLEANUP" ]
+then
+
+	echo "#########################################################################"
+
+	echo "Remove old files: okfile, *2go " $(date "+%Y-%m-%d %H:%M:%S")
+	/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/okfile
+	/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/ok2file
+	/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/ec2go
+	/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/interpro2go
+	/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/spkw2go
+	/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/*.txt
+
+	echo "#########################################################################"
+
+	echo "Copy new files from /research/zarchive/load_files/UniProt/" 
+	/usr/bin/scp /research/zarchive/load_files/UniProt/* <!--|ROOT_PATH|-->/server_apps/data_transfer/SWISS-PROT/
+else
+	echo "Skipping copying files from server"
+fi
+
 echo "#########################################################################"
 
-echo "Remove old files: okfile, *2go" 
-/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/okfile
-/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/ok2file
-/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/ec2go
-/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/interpro2go
-/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/spkw2go
-/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/*.txt
+echo "MD5 sums of data input files"
+
+md5sum /research/zarchive/load_files/UniProt/*
 
 echo "#########################################################################"
-
-echo "Copy new files from /research/zarchive/load_files/UniProt/" 
-/usr/bin/scp /research/zarchive/load_files/UniProt/* <!--|ROOT_PATH|-->/server_apps/data_transfer/SWISS-PROT/
-
+echo "MD5 sums of data files after copy (should match)"
+ls /research/zarchive/load_files/UniProt/ | xargs md5sum 
 echo "#########################################################################"
 
-echo "running loadsp.pl"
+echo "running loadsp.pl " $(date "+%Y-%m-%d %H:%M:%S")
 ./loadsp.pl ;
 
-echo "running protein_domain_info_load.pl"
+echo "running protein_domain_info_load.pl " $(date "+%Y-%m-%d %H:%M:%S")
 ./protein_domain_info_load.pl ;
 
-echo "running go.pl"
+echo "running go.pl " $(date "+%Y-%m-%d %H:%M:%S")
 cd <!--|TARGETROOT|-->/server_apps/data_transfer/GO;
 ./go.pl ;
 
+echo "#########################################################################"
+echo "## FINISHED runUniprotProd.sh "      $(date "+%Y-%m-%d %H:%M:%S")
+echo "#########################################################################"
+}
+
+main 2>&1 | tee load_log_$(date "+%Y-%m-%d_%H-%M-%S").txt

--- a/server_apps/data_transfer/SWISS-PROT/sp_match.pl
+++ b/server_apps/data_transfer/SWISS-PROT/sp_match.pl
@@ -8,6 +8,7 @@
 
 use lib "<!--|ROOT_PATH|-->/server_apps/";
 use ZFINPerlModules;
+use POSIX;
 
 if (@ARGV < 1) {
     die "Please enter the accession file name. \n";
@@ -45,3 +46,24 @@ close OK;
   #----- Another mail send out problem files ----
   $subject = "Auto from $dbname: report of processing pre_zfin.org";
   ZFINPerlModules->sendMailWithAttachedReport('<!--|SWISSPROT_EMAIL_REPORT|-->',"$subject","redGeneReport.txt");
+
+
+print("Checksums and file info of important files:\n");
+system("md5sum  *.ontology *2go prob* okfile pubmed_not_in_zfin *.unl *.txt *.dat *.dat.gz");
+system("ls -al  *.ontology *2go prob* okfile pubmed_not_in_zfin *.unl *.txt *.dat *.dat.gz");
+
+if ($ENV{'ARCHIVE_ARTIFACTS'}) {
+    print("Archiving artifacts\n");
+    my $directory = "archives/" . strftime("%Y-%m-%d-%H-%M-%S", localtime(time()));
+    system("mkdir -p $directory");
+    system("cp -rp ./ccnote $directory");
+    system("cp -p *.ontology $directory");
+    system("cp -p *2go $directory");
+    system("cp -p prob* $directory");
+    system("cp -p okfile $directory");
+    system("cp -p pubmed_not_in_zfin $directory");
+    system("cp -p *.unl $directory");
+    system("cp -p *.txt $directory");
+    system("cp -p *.dat $directory");
+    print(" Not archiving *.dat.gz to $directory due to likely large size\n");
+}


### PR DESCRIPTION
Uniprot Changes:

- Changed the perl script to read .dat files line-by-line instead of slurping up the entire file into memory (which was crashing the script).
- Fixed issue with checking uniprot database for invalid IDs (was scraping http://www.uniprot.org/uniprot/{id}, but always returned true).
- Added a "whirley" progress indicator (Extract whirleygig code into the ZFINPerlModules.pm module).
- Add some more output to indicate the current state of the script .
- Allow environment variables to prevent re-downloading files to save us some time and save the servers some bandwidth.  Also other variables for help with debugging, including archiving artifacts.
- Instead of extracting downloaded gzip files, just process them in place using piped output of gunzip.
- Add more environment variable options to skip pre_zfin.dat file generation while debugging.
- Preserve timestamps on copy.
- Show md5sums of source files for troubleshooting.
- Include a helpful troubleshooting script to take a snapshot of relevant tables for before and after uniprot load.
- Make the table exports sort in a deterministic way for CSVs.
- Include stderr in log file.
- Add timestamps to output.