### PR TITLE
ZFIN-7773: Update immer package

### DIFF
--- a/home/javascript/react/components/data-table/CollapseTable.js
+++ b/home/javascript/react/components/data-table/CollapseTable.js
@@ -6,7 +6,9 @@ import useTableDataFetch from '../../hooks/useTableDataFetch';
 import LoadingSpinner from '../LoadingSpinner';
 import Table from './Table';
 import SortByDropdown from './SortByDropdown';
-import produce from 'immer';
+import produce, {setAutoFreeze} from 'immer';
+setAutoFreeze(false);
+
 import NoData from '../NoData';
 
 const CollapseTable = ({

--- a/home/javascript/react/components/data-table/DataList.js
+++ b/home/javascript/react/components/data-table/DataList.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import DataProvider from './DataProvider';
 import List from './List';
 import {downloadOptionType} from '../../utils/types';
-import produce from 'immer';
+import produce, {setAutoFreeze} from 'immer';
+setAutoFreeze(false);
+
 import useTableState from '../../hooks/useTableState';
 import TextBoxFilter from './TextBoxFilter';
 

--- a/home/javascript/react/components/data-table/DataProvider.js
+++ b/home/javascript/react/components/data-table/DataProvider.js
@@ -4,7 +4,9 @@ import useTableState from '../../hooks/useTableState';
 import GenericErrorMessage from '../GenericErrorMessage';
 import LoadingSpinner from '../LoadingSpinner';
 import NoData from '../NoData';
-import produce from 'immer';
+import produce, {setAutoFreeze} from 'immer';
+setAutoFreeze(false);
+
 import PropTypes from 'prop-types';
 import {downloadOptionType, sortOptionType, tableStateType} from '../../utils/types';
 import {isEmptyObject} from '../../utils';

--- a/home/javascript/react/components/data-table/DataTable.js
+++ b/home/javascript/react/components/data-table/DataTable.js
@@ -4,7 +4,9 @@ import {columnDefinitionType, downloadOptionType, sortOptionType, tableStateType
 import DataProvider from './DataProvider';
 import Table from './Table';
 import HeaderCell from './HeaderCell';
-import produce from 'immer';
+import produce, {setAutoFreeze} from 'immer';
+setAutoFreeze(false);
+
 import useTableState from '../../hooks/useTableState';
 
 const DataTable = ({

--- a/home/javascript/react/components/marker-edit/EditOrthologyTable.js
+++ b/home/javascript/react/components/marker-edit/EditOrthologyTable.js
@@ -5,7 +5,9 @@ import LoadingSpinner from '../../components/LoadingSpinner';
 import Table from '../../components/data-table/Table';
 import EditOrthologyEvidenceCell from '../../components/marker-edit/EditOrthologyEvidenceCell';
 import http from '../../utils/http';
-import produce from 'immer';
+import produce, {setAutoFreeze} from 'immer';
+setAutoFreeze(false);
+
 import Modal from '../../components/Modal';
 import LoadingButton from '../../components/LoadingButton';
 import useCurationTabLoadEvent from '../../hooks/useCurationTabLoadEvent';

--- a/home/javascript/react/containers/CuratingBin.js
+++ b/home/javascript/react/containers/CuratingBin.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import produce from 'immer';
+import produce, {setAutoFreeze} from 'immer';
+setAutoFreeze(false);
 
 import {getLocations, searchPubStatus, updateStatus} from '../api/publication';
 import intertab from '../utils/intertab';

--- a/home/javascript/react/containers/GeneExpressionRibbon.js
+++ b/home/javascript/react/containers/GeneExpressionRibbon.js
@@ -10,7 +10,8 @@ import {
     GeneExpressionFigureGallery,
 } from '../components/gene-expression';
 import Checkbox from '../components/Checkbox';
-import produce from 'immer';
+import produce, {setAutoFreeze} from 'immer';
+setAutoFreeze(false);
 
 const GeneExpressionRibbon = ({geneId}) => {
     const [summaryTableState, setSummaryTableState] = useTableState();

--- a/home/javascript/react/containers/GeneOntologyRibbon.js
+++ b/home/javascript/react/containers/GeneOntologyRibbon.js
@@ -9,7 +9,9 @@ import DataTable from '../components/data-table';
 import NoData from '../components/NoData';
 import {Ribbon, getSelectedTermQueryParams} from '../components/ribbon';
 import GenericErrorMessage from '../components/GenericErrorMessage';
-import {produce} from 'immer';
+import produce, {setAutoFreeze} from 'immer';
+setAutoFreeze(false);
+
 import PublicationCitationLink from '../components/PublicationCitationLink';
 
 const GeneOntologyRibbon = ({geneId}) => {

--- a/home/javascript/react/containers/IndexingBin.js
+++ b/home/javascript/react/containers/IndexingBin.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import produce from 'immer';
+import produce, {setAutoFreeze} from 'immer';
+setAutoFreeze(false);
 
 import {getLocations, searchPubStatus, updateStatus} from '../api/publication';
 

--- a/home/javascript/react/containers/PhenotypeRibbon.js
+++ b/home/javascript/react/containers/PhenotypeRibbon.js
@@ -10,7 +10,8 @@ import {
     PhenotypeFigureGallery,
 } from '../components/phenotype';
 import Checkbox from '../components/Checkbox';
-import produce from 'immer';
+import produce, {setAutoFreeze} from 'immer';
+setAutoFreeze(false);
 
 const PhenotypeRibbon = ({geneId}) => {
     const [summaryTableState, setSummaryTableState] = useTableState();

--- a/home/javascript/react/containers/ProcessingBin.js
+++ b/home/javascript/react/containers/ProcessingBin.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import produce from 'immer';
+import produce, {setAutoFreeze} from 'immer';
+setAutoFreeze(false);
 
 import {searchPubStatus, updateStatus} from '../api/publication';
 import Pagination from '../components/Pagination';

--- a/home/javascript/react/containers/PubTracker.js
+++ b/home/javascript/react/containers/PubTracker.js
@@ -19,7 +19,9 @@ import {
     validate
 } from '../api/publication';
 import intertab from '../utils/intertab';
-import produce from 'immer';
+import produce, {setAutoFreeze} from 'immer';
+setAutoFreeze(false);
+
 import DataPage from '../components/layout/DataPage';
 import Section from '../components/layout/Section';
 import {

--- a/home/javascript/react/hooks/useAppendingFetch.js
+++ b/home/javascript/react/hooks/useAppendingFetch.js
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import qs from 'qs';
-import produce from 'immer';
+import produce, {setAutoFreeze} from 'immer';
+setAutoFreeze(false);
+
 import http from '../utils/http';
 import { DEFAULT_FETCH_STATE } from './constants';
 

--- a/home/javascript/react/hooks/useFetch.js
+++ b/home/javascript/react/hooks/useFetch.js
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
-import produce from 'immer';
+import produce, {setAutoFreeze} from 'immer';
+setAutoFreeze(false);
+
 import http from '../utils/http';
 import { DEFAULT_FETCH_STATE } from './constants';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4560,9 +4560,9 @@
       }
     },
     "immer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-5.2.0.tgz",
-      "integrity": "sha512-fstQQo9692Y7ET02wKp5iq5HoHAty+3jouMzVvjloQYHtIs6STzNHXvxLPCRprRcGrJ1DYq5gyLv6+KEf3VGgw=="
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.7.tgz",
+      "integrity": "sha512-KGllzpbamZDvOIxnmJ0jI840g7Oikx58lBPWV0hUh7dtAyZpFqqrBZdKka5GlTwMTZ1Tjc/bKKW4VSFAt6BqMA=="
     },
     "import-local": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "fast-deep-equal": "3.1.3",
     "file-loader": "^6.2.0",
     "imagesloaded": "^4.1.4",
-    "immer": "5.2.0",
+    "immer": "^9.0.7",
     "jquery-bridget": "2.0.1",
     "jquery-modal": "0.5.9",
     "jquery-stickytabs": "1.2.4",


### PR DESCRIPTION
Update the immer package and use the setAutoFreeze method to continue to use the older behavior of
not autofreezing objects.