### PR TITLE
ZFIN-7604: Add links to Single Cell Expression Atlas

### DIFF
--- a/home/WEB-INF/tags/expressionHighThroughputAttributeListItem.tag
+++ b/home/WEB-INF/tags/expressionHighThroughputAttributeListItem.tag
@@ -4,6 +4,7 @@
 
 <c:set var="hasGeo" value="${!empty markerExpression.geoLink}"/>
 <c:set var="hasAtlas" value="${!empty markerExpression.expressionAtlasLink.link}"/>
+<c:set var="hasSingleCellAtlas" value="${!empty markerExpression.singleCellExpressionAtlasLink}"/>
 <c:set var="hasData" value="${hasGeo or hasAtlas}"/>
 
 <z:attributeListItem label="High Throughput Data">
@@ -23,6 +24,11 @@
                             href="https://cells.ucsc.edu/?ds=zebrafish-dev&gene=${ensdarg}">UCSC scRNA-seq</zfin2:externalLink>
                     (<a href="/ZDB-PUB-210917-2">1</a>)
                 </c:forEach>
+            </c:if>
+            <c:if test="${hasSingleCellAtlas}">
+                <zfin2:externalLink
+                        href="${markerExpression.singleCellExpressionAtlasLink}">Single Cell Expression Atlas</zfin2:externalLink>
+                (<a href="/ZDB-PUB-220103-3">1</a>)
             </c:if>
         </ul>
     </z:ifHasData>

--- a/source/org/zfin/expression/presentation/MarkerExpression.java
+++ b/source/org/zfin/expression/presentation/MarkerExpression.java
@@ -19,6 +19,7 @@ public class MarkerExpression {
     private WildTypeExpression wildTypeStageExpression;
     private String geoLink;
     private LinkDisplay expressionAtlasLink;
+    private String singleCellExpressionAtlasLink;
     private List<String> ensdargGenes;
     private int inSituFigCount;
     private String geoGeneSymbol ;

--- a/source/org/zfin/expression/service/ExpressionService.java
+++ b/source/org/zfin/expression/service/ExpressionService.java
@@ -270,6 +270,10 @@ public class ExpressionService {
         return gxaLinkDisplay;
     }
 
+    public String getSingleCellExpressionAtlasForMarker(Marker marker) {
+        return "https://www.ebi.ac.uk/gxa/sc/search?q=" + marker.getAbbreviation() + "&species=Danio%20rerio";
+    }
+
     public String getGeoLinkForMarkerIfExists(Marker marker) {
         if (marker.isInTypeGroup(Marker.TypeGroup.GENEDOM)) {
             if (!infrastructureRepository.hasStandardPublicationAttributionForRelatedMarkers(marker.getZdbID(), MicroarrayWebserviceJob.MICROARRAY_PUB)) {
@@ -305,6 +309,7 @@ public class ExpressionService {
 
         markerExpression.setAllMarkerExpressionInstance(allMarkerExpressionInstance);
         markerExpression.setExpressionAtlasLink(getExpressionAtlasForMarker(marker.zdbID, ForeignDB.AvailableName.EXPRESSIONATLAS));
+        markerExpression.setSingleCellExpressionAtlasLink(getSingleCellExpressionAtlasForMarker(marker));
         markerExpression.setGeoLink(getGeoLinkForMarkerIfExists(marker));
 
         // directly submitted


### PR DESCRIPTION
Add an outgoing link from gene page to Single Cell Expression Atlas.
Use curation publication (ZDB-PUB-220103-3) as reference link.