### PR TITLE
Add imagemagick as requirement for tomcat container.

### DIFF
--- a/docker/tomcat/Dockerfile
+++ b/docker/tomcat/Dockerfile
@@ -7,3 +7,8 @@ RUN addgroup --gid 1000 zfin && \
 USER zfishweb
 
 COPY ./postgresql-42.2.18.jar  /usr/local/tomcat/lib
+
+#Add imagemagick for generating thumbnails
+RUN apt-get update && apt-get install -y \
+  imagemagick \
+  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Tomcat container needs imagemagick for generating thumbnails.