### PR TITLE
ZFIN-7817: Create new LabAttribution class as subclass of RecordAttribution

### DIFF
--- a/conf/hibernate.cfg.xml
+++ b/conf/hibernate.cfg.xml
@@ -101,6 +101,7 @@
         <mapping class="org.zfin.infrastructure.PersonAttribution"/>
         <mapping class="org.zfin.database.PostgresSession"/>
         <mapping class="org.zfin.infrastructure.PublicationAttribution"/>
+        <mapping class="org.zfin.infrastructure.LabAttribution"/>
         <mapping class="org.zfin.infrastructure.RecordAttribution"/>
         <mapping class="org.zfin.infrastructure.ReplacementZdbID"/>
         <mapping class="org.zfin.infrastructure.SourceAlias"/>

--- a/source/org/zfin/infrastructure/LabAttribution.java
+++ b/source/org/zfin/infrastructure/LabAttribution.java
@@ -1,0 +1,40 @@
+package org.zfin.infrastructure;
+
+import org.zfin.profile.Lab;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import java.io.Serializable;
+
+@Entity
+@DiscriminatorValue("Lab    ")
+public class LabAttribution extends RecordAttribution implements Serializable, Comparable<LabAttribution> {
+
+    @ManyToOne
+    @JoinColumn(name = "recattrib_source_zdb_id", insertable = false, updatable = false)
+    private Lab lab;
+
+    public Lab getLab() {
+        return lab;
+    }
+
+    public void setLab(Lab lab) {
+        this.lab = lab;
+        setSourceZdbID(lab.getZdbID());
+    }
+
+    /**
+     * Compare by lab object.
+     *
+     * @param labAttribution LabAttribution
+     * @return comparison integer
+     */
+    @Override
+    public int compareTo(LabAttribution labAttribution) {
+        if (labAttribution == null)
+            return -1;
+        return lab.compareTo(labAttribution.getLab());
+    }
+}

--- a/source/org/zfin/infrastructure/RecordAttribution.java
+++ b/source/org/zfin/infrastructure/RecordAttribution.java
@@ -18,6 +18,7 @@ import java.io.Serializable;
                 "                                    WHEN 'PERS' THEN      'Person '\n" +
                 "                                    WHEN 'COMPANY' THEN   'Company'\n" +
                 "                                    WHEN 'JRNL' THEN      'Journal'\n" +
+                "                                    WHEN 'LAB'  THEN      'Lab    '\n" +
                 "                                    ELSE                  'other  '\n" +
                 "                                 END")
 @Table(name = "record_attribution")

--- a/source/org/zfin/sequence.hbm.xml
+++ b/source/org/zfin/sequence.hbm.xml
@@ -268,6 +268,7 @@
                                     WHEN 'PERS' THEN      'Person '
                                     WHEN 'COMPANY' THEN   'Company'
                                     WHEN 'JRNL' THEN      'Journal'
+                                    WHEN 'LAB'  THEN      'Lab    '
                                     ELSE                  'other  '
                                  END)"/>
         <property name="dataZdbID" column="recattrib_data_zdb_id" type="string"/>
@@ -279,6 +280,10 @@
 
         <subclass name="org.zfin.infrastructure.PersonAttribution" discriminator-value="Person ">
             <many-to-one name="person" column="recattrib_source_zdb_id" insert="false" update="false"/>
+        </subclass>
+
+        <subclass name="org.zfin.infrastructure.LabAttribution" discriminator-value="Lab    ">
+            <many-to-one name="lab" column="recattrib_source_zdb_id" insert="false" update="false"/>
         </subclass>
 
         <subclass name="org.zfin.infrastructure.TermAttribution" discriminator-value="Term   ">

--- a/test/org/zfin/DbUnitTests.java
+++ b/test/org/zfin/DbUnitTests.java
@@ -31,6 +31,7 @@ import org.zfin.gwt.curation.CurationRPCTest;
 import org.zfin.gwt.marker.GoEvidenceTest;
 import org.zfin.gwt.root.server.DTOConversionServiceTest;
 import org.zfin.infrastructure.InfrastructureRepositoryTest;
+import org.zfin.infrastructure.RecordAttributionTest;
 import org.zfin.infrastructure.delete.DeleteRuleTest;
 import org.zfin.mapping.repository.LinkageRepositoryTest;
 import org.zfin.marker.MarkerAttributionServiceTest;
@@ -138,6 +139,7 @@ import org.zfin.wiki.service.AntibodyWikiWebServiceTest;
         PublicationRepositoryTest.class,
         PublicationServiceSpec.class,
         PublicationValidatorSpec.class,
+        RecordAttributionTest.class,
         RenoMultiRunTest.class,
         RenoRedundancyCandidateControllerTest.class,
         RenoRepositoryTest.class,

--- a/test/org/zfin/infrastructure/RecordAttributionTest.java
+++ b/test/org/zfin/infrastructure/RecordAttributionTest.java
@@ -1,0 +1,64 @@
+package org.zfin.infrastructure;
+
+import org.junit.Test;
+import org.zfin.AbstractDatabaseTest;
+import org.zfin.profile.Person;
+import org.zfin.publication.Publication;
+import org.zfin.repository.RepositoryFactory;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ *     TEST fetching RecordAttributions of the 3 types that exist in the DB (LAB,PERS,PUB--not counting null)
+ *         select *, get_obj_type ( recattrib_source_zdb_id ) as rectype
+ *         FROM
+ *                 record_attribution
+ *         WHERE
+ *         recattrib_data_zdb_id IN ( 'ZDB-EST-040130-186', 'ZDB-EST-010914-5', 'ZDB-EST-000426-244' )
+ */
+
+public class RecordAttributionTest extends AbstractDatabaseTest {
+
+    @Test
+    public void getRecordAttributionsOfLabType() {
+        ActiveData activeData = new ActiveData();
+        activeData.setZdbID("ZDB-EST-040130-186");
+        try {
+            List<RecordAttribution> recordAttributions = RepositoryFactory.getInfrastructureRepository().getRecordAttributions(activeData);
+        } catch (Exception e) {
+            fail("should not catch exception fetching RecordAttribution records");
+        }
+    }
+
+    @Test
+    public void getRecordAttributionsOfPubType() {
+        ActiveData activeData = new ActiveData();
+        activeData.setZdbID("ZDB-EST-010914-5");
+        List<RecordAttribution> recordAttributions = null;
+        try {
+            recordAttributions = RepositoryFactory.getInfrastructureRepository().getRecordAttributions(activeData);
+        } catch (Exception e) {
+            fail("should not catch exception fetching RecordAttribution records");
+        }
+        assertNotNull(recordAttributions);
+        RecordAttribution first = recordAttributions.get(0);
+        assertEquals("ZDB-EST-010914-5 ZDB-PUB-010810-1 standard", first.toString());
+    }
+
+    @Test
+    public void getRecordAttributionsOfPersonType() {
+        ActiveData activeData = new ActiveData();
+        activeData.setZdbID("ZDB-EST-000426-244");
+        try {
+            List<RecordAttribution> recordAttributions = RepositoryFactory.getInfrastructureRepository().getRecordAttributions(activeData);
+        } catch (Exception e) {
+            fail("should not catch exception fetching RecordAttribution records");
+        }
+    }
+
+}


### PR DESCRIPTION
Fix issue when editing certain ESTs (eg. https://zfin.org/action/marker/marker-edit?zdbID=ZDB-EST-040130-186)

Added new subclass of RecordAttribution called LabAttribution for resolving the many to one relationship to a lab.