### PR TITLE
ZFIN-7803 Do not log to catalina.out

### DIFF
--- a/home/WEB-INF/log4j2.xml
+++ b/home/WEB-INF/log4j2.xml
@@ -44,7 +44,9 @@
         <Logger name="org.hibernate.engine.internal.StatefulPersistenceContext" level="error"/>
         <Logger name="org.zfin" level="warn"/>
         <Logger name="org.zfin.ontology.OntologySerializationService" level="info"/>
-        <Logger name="org.zfin.ontology.datatransfer.AbstractScriptWrapper" level="debug"/>
+        <Logger name="org.zfin.ontology.datatransfer.AbstractScriptWrapper" level="debug" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
         <Root level="warn">
             <AppenderRef ref="rollingFileAppender"/>
             <AppenderRef ref="rollingJSONFileAppender"/>

--- a/source/org/zfin/nomenclature/repair/GenotypeNamingIssues.java
+++ b/source/org/zfin/nomenclature/repair/GenotypeNamingIssues.java
@@ -84,6 +84,7 @@ public class GenotypeNamingIssues extends AbstractScriptWrapper {
         Map<String, String> fixes = new HashMap<>();
         String manuallyApprovedFixes = System.getenv("MANUALLY_APPROVED_FIXES");
         String jenkinsWorkspace =  System.getenv("WORKSPACE");
+        String rootPath =  System.getenv("ROOT_PATH");
         if (StringUtils.isEmpty(manuallyApprovedFixes)
                 || StringUtils.isEmpty(jenkinsWorkspace)) {
             LOG.debug("Not in a jenkins task, or no file of manual fixes uploaded. Skipping manually approved fixes.");
@@ -91,8 +92,14 @@ public class GenotypeNamingIssues extends AbstractScriptWrapper {
         }
 
         String sourceFileName = Paths.get(jenkinsWorkspace, "MANUALLY_APPROVED_FIXES").toString();
-        if (!FileUtil.checkFileExists(sourceFileName)) {
-            LOG.debug("Could not open file: " + sourceFileName + ". Skipping manually approved fixes.");
+        String alternateSourceFileName = Paths.get(rootPath, "MANUALLY_APPROVED_FIXES").toString();
+        if (FileUtil.checkFileExists(sourceFileName)) {
+            LOG.debug("Found MANUALLY_APPROVED_FIXES file: " + sourceFileName );
+        } else if (FileUtil.checkFileExists(alternateSourceFileName)) {
+            LOG.debug("Could not open file: " + sourceFileName + ". Using alternate " + alternateSourceFileName);
+            sourceFileName = alternateSourceFileName;
+        } else {
+            LOG.debug("Could not open file: '" + sourceFileName + "' or alternate: '" + alternateSourceFileName + "'");
             return;
         }
 


### PR DESCRIPTION
Log gradle scripts that extent AbstractScriptWrapper to stdout only (not catalina.out).
Check for alternate file location for uploaded file because on trunk, jenkins is setting WORKSPACE env var to the wrong path on trunk, instead using ROOT_PATH.