### PR TITLE
ZFIN-7608 Fix bug with re-clicking ribbon cell to close it

### DIFF
--- a/home/javascript/react/components/ribbon/Ribbon.js
+++ b/home/javascript/react/components/ribbon/Ribbon.js
@@ -36,7 +36,7 @@ const Ribbon = ({subjects, categories, itemClick, selected}) => {
                 //in case event.detail.subjects[0] chaining fails.
             }
         });
-    },[]);
+    },[subjects, itemClick]);
 
     return (
         <div className='ontology-ribbon-container horizontal-scroll-container' ref={ribbonRef}>


### PR DESCRIPTION
Fix issue reported by Leyla about not being able to collapse a subject by re-clicking the current subject in the ribbon.