### PR TITLE
ZFIN-7936: Pub prototype copyable ID/pubmedID

### DIFF
--- a/home/WEB-INF/jsp/publication/publication-view-prototype.jsp
+++ b/home/WEB-INF/jsp/publication/publication-view-prototype.jsp
@@ -39,6 +39,8 @@
         <div data-toggle="tooltip" data-placement="bottom" title="${publication.citation}">
                 ${publication.shortAuthorList}
         </div>
+    </jsp:attribute>
+    <jsp:attribute name="entityNameAddendum">
         <div style="font-size: 12px">
                 ${publication.zdbID}
             <c:if test="${!empty publication.accessionNumber}"><p/>PMID:${publication.accessionNumber}</c:if>

--- a/home/WEB-INF/jsp/publication/publication-view-prototype.jsp
+++ b/home/WEB-INF/jsp/publication/publication-view-prototype.jsp
@@ -43,7 +43,7 @@
     <jsp:attribute name="entityNameAddendum">
         <div style="font-size: 12px">
                 ${publication.zdbID}
-            <c:if test="${!empty publication.accessionNumber}"><p/>PMID:${publication.accessionNumber}</c:if>
+            <c:if test="${!empty publication.accessionNumber}"><br/>PMID:${publication.accessionNumber}</c:if>
         </div>
     </jsp:attribute>
 

--- a/home/WEB-INF/tags/layout/dataPage.tag
+++ b/home/WEB-INF/tags/layout/dataPage.tag
@@ -2,10 +2,12 @@
 
 <%@ attribute name="sections" required="true" rtexprvalue="true" type="java.util.Collection" %>
 <%@ attribute name="entityName" required="false" fragment="true" %>
+<%@ attribute name="entityNameAddendum" required="false" fragment="true" %>
 <%@ attribute name="title" required="false" %>
 <%@ attribute name="pageBar" required="false" %>
 
 <jsp:invoke fragment="entityName" var="entityNameValue"/>
+<jsp:invoke fragment="entityNameAddendum" var="entityNameAddendumValue"/>
 
 <z:page bodyClass="data-page" bootstrap="true" title="${title}">
     <div class="d-flex h-100">
@@ -13,11 +15,14 @@
             <ul class="nav nav-pills flex-column">
                 <c:if test="${!empty entityNameValue}">
                     <li class="nav-item w-100">
-                        <a href="#" class="back-to-top-link" title="Back to top">
-                            <h5 class="p-3 m-0 border-bottom text-truncate">
-                                    ${entityNameValue}
-                            </h5>
-                        </a>
+                        <h5 class="p-3 m-0 border-bottom text-truncate back-to-top-link">
+                            <a href="#" class="back-to-top-link" title="Back to top">
+                                ${entityNameValue}
+                            </a>
+                            <c:if test="${!empty entityNameAddendumValue}">
+                                ${entityNameAddendumValue}
+                            </c:if>
+                        </h5>
                     </li>
                 </c:if>
                 <c:forEach var="section" items="${sections}">


### PR DESCRIPTION
Invert nesting of elements (from 'a > h5' to 'h5 > a').  Allow passing subsection or "addendum" to the entity name. Allows the secondary text to be "copyable".