### PR TITLE
ZFIN-7953-Refactor: refactor to make less confusing

### DIFF
--- a/source/org/zfin/gwt/curation/server/CurationDiseaseRPCImpl.java
+++ b/source/org/zfin/gwt/curation/server/CurationDiseaseRPCImpl.java
@@ -376,7 +376,7 @@ public class CurationDiseaseRPCImpl extends ZfinRemoteServiceServlet implements 
     protected Fish createFish(Publication publication, FishDTO newFish, GenotypeCreationReportDTO report) throws TermNotFoundException {
         Fish fish = DTOConversionService.convertToFishFromFishDTO(newFish);
 
-        if (getMutantRepository().createFish(fish, publication)) {
+        if (getMutantRepository().createFishIfNotExists(fish, publication)) {
             report.addMessage("created new fish " + fish.getHandle());
         } else {
             report.addMessage("imported fish " + fish.getHandle());

--- a/source/org/zfin/mutant/repository/HibernateMutantRepository.java
+++ b/source/org/zfin/mutant/repository/HibernateMutantRepository.java
@@ -1796,12 +1796,10 @@ public class HibernateMutantRepository implements MutantRepository {
     }
 
     @Override
-    public boolean createFish(Fish fish, Publication publication) {
+    public boolean createFishIfNotExists(Fish fish, Publication publication) {
         Fish existingFish = getFishByGenoStr(fish);
         boolean newFishCreated = false;
-        if (existingFish != null) {
-            fish = existingFish;
-        } else {
+        if (existingFish == null) {
             HibernateUtil.currentSession().save(fish);
             getInfrastructureRepository().insertUpdatesTable(fish, "fish_zdb_id", "create new record", publication.getZdbID(), null);
             newFishCreated = true;

--- a/source/org/zfin/mutant/repository/MutantRepository.java
+++ b/source/org/zfin/mutant/repository/MutantRepository.java
@@ -359,7 +359,13 @@ public interface MutantRepository {
      */
     List<SequenceTargetingReagent> getStrList(String publicationID);
 
-    boolean createFish(Fish fish, Publication publication);
+    /**
+     * Create and persist new instance of fish if it doesn't already exist
+     * @param fish
+     * @param publication
+     * @return return true if new fish is created, false if already exists
+     */
+    boolean createFishIfNotExists(Fish fish, Publication publication);
 
     /**
      * Retrieve all fish attributed to a given pub

--- a/test/org/zfin/nomenclature/repair/GenotypeNameChangeTest.java
+++ b/test/org/zfin/nomenclature/repair/GenotypeNameChangeTest.java
@@ -1,7 +1,5 @@
 package org.zfin.nomenclature.repair;
 
-import org.apache.commons.collections.ListUtils;
-import org.apache.commons.lang.StringUtils;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -13,33 +11,24 @@ import org.zfin.AbstractDatabaseTest;
 import org.zfin.AppConfig;
 import org.zfin.TestConfiguration;
 import org.zfin.feature.Feature;
-import org.zfin.feature.FeatureAlias;
 import org.zfin.feature.FeatureMarkerRelationship;
 import org.zfin.framework.HibernateUtil;
 import org.zfin.gwt.curation.dto.FeatureMarkerRelationshipTypeEnum;
 import org.zfin.gwt.root.dto.*;
 import org.zfin.gwt.root.server.DTOConversionService;
 import org.zfin.gwt.root.ui.ValidationException;
-import org.zfin.infrastructure.DataAliasGroup;
-import org.zfin.infrastructure.PublicationAttribution;
-import org.zfin.infrastructure.RecordAttribution;
 import org.zfin.marker.Marker;
 import org.zfin.marker.repository.MarkerRepository;
 import org.zfin.mutant.Fish;
 import org.zfin.mutant.Genotype;
-import org.zfin.mutant.GenotypeFeature;
 import org.zfin.mutant.GenotypeService;
 import org.zfin.publication.Publication;
 import org.zfin.publication.repository.PublicationRepository;
 import org.zfin.repository.RepositoryFactory;
-import org.zfin.search.Category;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
-import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.*;
 import static org.zfin.repository.RepositoryFactory.*;
 import static org.zfin.repository.RepositoryFactory.getMutantRepository;
@@ -135,7 +124,7 @@ public class GenotypeNameChangeTest extends AbstractDatabaseTest {
         fishDTO.setGenotypeDTO(genoDTO);
 
         Fish fish = DTOConversionService.convertToFishFromFishDTO(fishDTO);
-        getMutantRepository().createFish(fish, publication);
+        getMutantRepository().createFishIfNotExists(fish, publication);
 
         //confirm fish name is correct
         assertEquals("zf5555/+", fish.getName());


### PR DESCRIPTION
Refactor the createFish method to rename it as createFishIfNotExists. And remove confusing assignment that is actually a no-op.