### PR TITLE
ZFIN-7813: Use Genome Location Information for jBrowse Highlighting

### DIFF
--- a/source/org/zfin/jbrowse/presentation/JBrowseImage.java
+++ b/source/org/zfin/jbrowse/presentation/JBrowseImage.java
@@ -62,10 +62,10 @@ public class JBrowseImage implements GenomeBrowserImage {
                 url.addNameValuePair("tracks", StringUtils.join(tracks, ","));
             }
 
-            //String highlight = getHighlightString();
-            //if (StringUtils.isNotBlank(highlight)) {
-            //    url.addNameValuePair("highlight", highlight);
-            //}
+            String highlight = getHighlightString();
+            if (StringUtils.isNotBlank(highlight)) {
+                url.addNameValuePair("highlight", highlight);
+            }
 
             //url.addNameValuePair("grid", grid ? "1" : "0");
 

--- a/source/org/zfin/jbrowse/presentation/JBrowseImageBuilder.java
+++ b/source/org/zfin/jbrowse/presentation/JBrowseImageBuilder.java
@@ -5,11 +5,16 @@ import org.zfin.genomebrowser.GenomeBrowserBuild;
 import org.zfin.genomebrowser.GenomeBrowserTrack;
 import org.zfin.genomebrowser.presentation.GenomeBrowserImageBuilder;
 import org.zfin.genomebrowser.presentation.GenomeBrowserImage;
+import org.zfin.infrastructure.ZdbID;
 import org.zfin.mapping.GenomeLocation;
 import org.zfin.marker.Marker;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import static org.zfin.repository.RepositoryFactory.getLinkageRepository;
 
 public class JBrowseImageBuilder implements GenomeBrowserImageBuilder {
 
@@ -35,9 +40,9 @@ public class JBrowseImageBuilder implements GenomeBrowserImageBuilder {
     public GenomeBrowserImage build() {
 
         if (highlightMarker != null) {
-            highlightLandmark = highlightMarker.getAbbreviation();
+            highlightLandmark = getHighlightLandmarkByMarkerOrFeature(highlightMarker);
         } else if (highlightFeature != null) {
-            highlightLandmark = highlightFeature.getAbbreviation();
+            highlightLandmark = getHighlightLandmarkByMarkerOrFeature(highlightFeature);
         } else if (highlightString != null) {
             highlightLandmark = highlightString;
         }
@@ -68,6 +73,39 @@ public class JBrowseImageBuilder implements GenomeBrowserImageBuilder {
         }
 
         return new JBrowseImage(this);
+    }
+
+    private String getHighlightLandmarkByMarkerOrFeature(ZdbID entity) {
+        String defaultValue = "";
+        if (entity instanceof Marker) {
+            defaultValue = ((Marker) entity).getAbbreviation();
+        } else if (entity instanceof Feature) {
+            defaultValue = ((Feature) entity).getAbbreviation();
+        }
+        String landmark = defaultValue;
+
+        GenomeLocation location = getGenomeLocation(entity);
+
+        if (location != null) {
+            landmark = location.getChromosome() + ":" +
+                    location.getStart() + ".." +
+                    location.getEnd();
+        }
+        return landmark;
+    }
+
+    private GenomeLocation getGenomeLocation(ZdbID markerOrFeature) {
+        List<GenomeLocation> genomeLocations = getLinkageRepository().getGenericGenomeLocation(markerOrFeature);
+
+        Optional<GenomeLocation> first = genomeLocations.stream().filter(
+                genomeLocation -> getGenomeBuild().getValue().equals(genomeLocation.getAssembly())
+        ).findFirst();
+
+        GenomeLocation result = null;
+        if (first.isPresent()) {
+            result = first.get();
+        }
+        return result;
     }
 
     public GenomeBrowserImageBuilder genomeBuild(GenomeBrowserBuild genomeBuild) {

--- a/source/org/zfin/jbrowse/presentation/JBrowseImageBuilder.java
+++ b/source/org/zfin/jbrowse/presentation/JBrowseImageBuilder.java
@@ -97,15 +97,11 @@ public class JBrowseImageBuilder implements GenomeBrowserImageBuilder {
     private GenomeLocation getGenomeLocation(ZdbID markerOrFeature) {
         List<GenomeLocation> genomeLocations = getLinkageRepository().getGenericGenomeLocation(markerOrFeature);
 
-        Optional<GenomeLocation> first = genomeLocations.stream().filter(
-                genomeLocation -> getGenomeBuild().getValue().equals(genomeLocation.getAssembly())
-        ).findFirst();
-
-        GenomeLocation result = null;
-        if (first.isPresent()) {
-            result = first.get();
-        }
-        return result;
+        return genomeLocations.stream().filter(
+            genomeLocation -> getGenomeBuild().getValue().equals(genomeLocation.getAssembly())
+        )
+        .findFirst()
+        .orElse(null);
     }
 
     public GenomeBrowserImageBuilder genomeBuild(GenomeBrowserBuild genomeBuild) {

--- a/source/org/zfin/mapping/repository/HibernateLinkageRepository.java
+++ b/source/org/zfin/mapping/repository/HibernateLinkageRepository.java
@@ -230,6 +230,22 @@ public class HibernateLinkageRepository implements LinkageRepository {
         return list1;
     }
 
+    /**
+     * Return the GenomeLocation for the marker if provided, or the feature if that's provided.
+     * @param markerOrFeature (should be an instance of either Marker class or Feature class)
+     * @return
+     */
+    @Override
+    public List<GenomeLocation> getGenericGenomeLocation(ZdbID markerOrFeature) {
+        List<GenomeLocation> results = new ArrayList<>();
+        if (markerOrFeature instanceof Marker) {
+            getGenomeLocation((Marker)markerOrFeature).stream().forEach(location -> results.add(location));
+        } else if (markerOrFeature instanceof Feature) {
+            getGenomeLocation((Feature)markerOrFeature).stream().forEach(location -> results.add(location));
+        }
+        return results;
+    }
+
     @Override
     public List<LinkageMember> getLinkageMemberForMarker(Marker marker) {
         Query query = HibernateUtil.currentSession().createQuery(

--- a/source/org/zfin/mapping/repository/LinkageRepository.java
+++ b/source/org/zfin/mapping/repository/LinkageRepository.java
@@ -112,6 +112,8 @@ public interface LinkageRepository {
     List<LinkageMember> getLinkageMemberForMarker(Marker marker);
     List<FeatureGenomeLocation> getFeatureLocations(Marker marker);
 
+    List<GenomeLocation> getGenericGenomeLocation(ZdbID markerOrFeature);
+
     /**
      * Retrieves genome location information.
      *


### PR DESCRIPTION
Translate highlight string for features and markers by using values from sequence_feature_chromosome_location_generated table via LinkageRepository::getGenomeLocation.