### PR TITLE
ZFIN 7932: Fix issues validating against alliance API

### DIFF
--- a/server_apps/data_transfer/Downloads/GFF3/generateGff3.groovy
+++ b/server_apps/data_transfer/Downloads/GFF3/generateGff3.groovy
@@ -313,6 +313,8 @@ def generateGenesAndTranscripts() {
     zfinGenesWriter.flush()
     zfinGenesWriter.close()
 
+    println("Wrote file: $gff3Dir/zfin_genes.gff3")
+
     genesWithoutTranscriptsWriter.flush()
     genesWithoutTranscriptsWriter.close()
 

--- a/server_apps/jenkins/jobs/Generate-Alliance-Files_m/config.xml
+++ b/server_apps/jenkins/jobs/Generate-Alliance-Files_m/config.xml
@@ -46,6 +46,7 @@
     <hudson.tasks.Shell>
       <command>
         cd $SOURCEROOT/server_apps/DB_maintenance/Alliance  &amp;&amp; rm -f ZFIN*.json*   &amp;&amp; cp $SOURCEROOT/ZFIN*.json .  &amp;&amp; gzip ZFIN*.json
+        cp $TARGETROOT/home/data_transfer/Downloads/zfin_genes.gff3 .
         cd $SOURCEROOT/server_apps/DB_maintenance/Alliance  &amp;&amp; ./validateAllianceFiles.sh $submit $ALLIANCE_RELEASE_VERSION
       </command>
     </hudson.tasks.Shell>


### PR DESCRIPTION
Validation was failing due to non-existence of zfin_genes.gff3 in the directory that contains all the other files we upload to the alliance.  I added a line that copies zfin_genes.gff3 from the downloads directory where it is generated to the alliance uploads directory.  I also added an explicit check for the existence of each file so a missing file error will be easier to understand.