### PR TITLE
Extract a jsp tag for gbrowse/jbrowse

### DIFF
--- a/home/WEB-INF/jsp-include/tag-import.jsp
+++ b/home/WEB-INF/jsp-include/tag-import.jsp
@@ -10,6 +10,7 @@
 <%@ taglib prefix="zfin-figure" tagdir="/WEB-INF/tags/figure" %>
 <%@ taglib prefix="zfin-dev" tagdir="/WEB-INF/tags/dev" %>
 <%@ taglib prefix="zfin-search" tagdir="/WEB-INF/tags/search" %>
+<%@ taglib prefix="zfin-gbrowse" tagdir="/WEB-INF/tags/gbrowse" %>
 <%@ taglib prefix="z" tagdir="/WEB-INF/tags/layout" %>
 <%@ taglib prefix="zfn" uri="/WEB-INF/tld/zfin-fn.tld" %>
 <%@ taglib prefix='c' uri='http://java.sun.com/jsp/jstl/core' %>

--- a/home/WEB-INF/jsp/feature/feature-view.jsp
+++ b/home/WEB-INF/jsp/feature/feature-view.jsp
@@ -31,22 +31,8 @@
             <jsp:include page="../marker/antibody/antibody-view-notes.jsp"/>
         </z:section>
 
-        <z:section title="${GBROWSE}" infoPopup="/action/feature/note/genomebrowser">>
-            <c:if test="${not empty formBean.GBrowseImage}">
-                <div class="__react-root genome-browser-image"
-                     id="${formBean.GBrowseImage.reactComponentId}"
-                     data-image-url="${formBean.GBrowseImage.imageUrl}"
-                     data-link-url="${formBean.GBrowseImage.linkUrl}"
-                     data-build="${formBean.GBrowseImage.build}"
-                ></div>
-            </c:if>
-            <c:if test="${empty formBean.GBrowseImage}">
-                <div class="__react-root genome-browser-image" id="GbrowseImage"
-                     data-image-url="${formBean.GBrowseImage.imageUrl}"
-                     data-link-url="${formBean.GBrowseImage.linkUrl}"
-                     data-build="${formBean.GBrowseImage.build}"
-                ></div>
-            </c:if>
+        <z:section title="${GBROWSE}" infoPopup="/action/feature/note/genomebrowser">
+            <zfin-gbrowse:genomeBrowserImageComponent image="${formBean.GBrowseImage}" />
         </z:section>
 
         <z:section title="${VARIANTS}" >

--- a/home/WEB-INF/jsp/marker/clone/clone-view.jsp
+++ b/home/WEB-INF/jsp/marker/clone/clone-view.jsp
@@ -40,21 +40,7 @@
         <c:if test="${typeName ne 'EST'}">
            <c:if test="${typeName ne 'CDNA'}">
             <z:section title="${GBROWSE}">
-                <c:if test="${not empty formBean.image}">
-                    <div class="__react-root genome-browser-image"
-                         id="${formBean.image.reactComponentId}"
-                         data-image-url="${formBean.image.imageUrl}"
-                         data-link-url="${formBean.image.linkUrl}"
-                         data-build="${formBean.image.build}"
-                    ></div>
-                </c:if>
-                <c:if test="${empty formBean.image}">
-                    <div class="__react-root genome-browser-image" id="GbrowseImage"
-                         data-image-url="${formBean.image.imageUrl}"
-                         data-link-url="${formBean.image.linkUrl}"
-                         data-build="${formBean.image.build}"
-                    ></div>
-                </c:if>                
+                <zfin-gbrowse:genomeBrowserImageComponent image="${formBean.image}" />
             </z:section>
            </c:if>
         </c:if>

--- a/home/WEB-INF/jsp/marker/gene/gene-view-transcripts.jsp
+++ b/home/WEB-INF/jsp/marker/gene/gene-view-transcripts.jsp
@@ -7,12 +7,7 @@
 </z:attributeList>
 
 <c:if test="${!empty formBean.relatedTranscriptDisplay.gbrowseImage}">
-    <div class="__react-root genome-browser-image"
-         id="${formBean.relatedTranscriptDisplay.gbrowseImage.reactComponentId}"
-         data-image-url="${formBean.relatedTranscriptDisplay.gbrowseImage.imageUrl}"
-         data-link-url="${formBean.relatedTranscriptDisplay.gbrowseImage.linkUrl}"
-         data-build="${formBean.relatedTranscriptDisplay.gbrowseImage.build}">
-    </div>
+    <zfin-gbrowse:genomeBrowserImageComponent image="${formBean.relatedTranscriptDisplay.gbrowseImage}" />
 </c:if>
 
 <z:section>

--- a/home/WEB-INF/jsp/marker/pseudogene/pseudogene-view-transcripts.jsp
+++ b/home/WEB-INF/jsp/marker/pseudogene/pseudogene-view-transcripts.jsp
@@ -7,12 +7,7 @@
 </z:attributeList>
 
 <c:if test="${!empty formBean.relatedTranscriptDisplay.gbrowseImage}">
-    <div class="__react-root genome-browser-image"
-         id="${formBean.relatedTranscriptDisplay.gbrowseImage.reactComponentId}"
-         data-image-url="${formBean.relatedTranscriptDisplay.gbrowseImage.imageUrl}"
-         data-link-url="${formBean.relatedTranscriptDisplay.gbrowseImage.linkUrl}"
-         data-build="${formBean.relatedTranscriptDisplay.gbrowseImage.build}">
-    </div>
+    <zfin-gbrowse:genomeBrowserImageComponent image="${formBean.relatedTranscriptDisplay.gbrowseImage}" />
 </c:if>
 
 <z:section>

--- a/home/WEB-INF/jsp/marker/sequenceTargetingReagent/sequence-targeting-reagent-view-target-location.jsp
+++ b/home/WEB-INF/jsp/marker/sequenceTargetingReagent/sequence-targeting-reagent-view-target-location.jsp
@@ -5,12 +5,7 @@
 <c:if test="${!empty formBean.gbrowseImages}">
 
     <c:forEach items="${formBean.gbrowseImages}" var="image" end="1" varStatus="loop">
-        <div class="__react-root genome-browser-image"
-             id="${image.reactComponentId}__${loop.index}"
-             data-image-url="${image.imageUrl}"
-             data-link-url="${image.linkUrl}"
-             data-build="${image.build}">
-        </div>
+        <zfin-gbrowse:genomeBrowserImageComponent image="${image}" loopIndex="${loop.index}" />
     </c:forEach>
 
     <c:if test="${fn:length(formBean.gbrowseImages) > 2}">

--- a/home/WEB-INF/jsp/marker/transcript/transcript-view-related-transcripts.jsp
+++ b/home/WEB-INF/jsp/marker/transcript/transcript-view-related-transcripts.jsp
@@ -3,21 +3,7 @@
 
 <c:forEach var="relatedTranscriptDisplay" items="${formBean.relatedTranscriptDisplayList}" varStatus="loop">
 
-    <c:if test="${not empty relatedTranscriptDisplay.gbrowseImage}">
-        <div class="__react-root genome-browser-image"
-             id="${relatedTranscriptDisplay.gbrowseImage.reactComponentId}"
-             data-image-url="${relatedTranscriptDisplay.gbrowseImage.imageUrl}"
-             data-link-url="${relatedTranscriptDisplay.gbrowseImage.linkUrl}"
-             data-build="${relatedTranscriptDisplay.gbrowseImage.build}"
-        ></div>
-    </c:if>
-    <c:if test="${empty relatedTranscriptDisplay.gbrowseImage}">
-        <div class="__react-root genome-browser-image" id="GbrowseImage"
-             data-image-url="${relatedTranscriptDisplay.gbrowseImage.imageUrl}"
-             data-link-url="${relatedTranscriptDisplay.gbrowseImage.linkUrl}"
-             data-build="${relatedTranscriptDisplay.gbrowseImage.build}"
-        ></div>
-    </c:if>
+    <zfin-gbrowse:genomeBrowserImageComponent image="${relatedTranscriptDisplay.gbrowseImage}" loopIndex="${loop.index}" />
 
     <z:section>
         <jsp:attribute name="title">

--- a/home/WEB-INF/tags/gbrowse/genomeBrowserImageComponent.tag
+++ b/home/WEB-INF/tags/gbrowse/genomeBrowserImageComponent.tag
@@ -1,0 +1,24 @@
+<%@ include file="/WEB-INF/jsp-include/tag-import.jsp" %>
+
+<%@ tag pageEncoding="UTF-8" %>
+
+<%@ attribute name="image" type="org.zfin.genomebrowser.presentation.GenomeBrowserImage" required="true"
+              description="GenomeBrowserImage object" %>
+<%@ attribute name="loopIndex" required="false" %>
+
+<c:set var="loopIndex" value="${(empty loopIndex) ? 0 : loopIndex}" />
+
+<c:if test="${not empty image}">
+    <div class="__react-root genome-browser-image" id="${image.reactComponentId}__${loopIndex}"
+         data-image-url="${image.imageUrl}"
+         data-link-url="${image.linkUrl}"
+         data-build="${image.build}"
+    ></div>
+</c:if>
+<c:if test="${empty image}">
+    <div class="__react-root genome-browser-image" id="GbrowseImage"
+         data-image-url="${image.imageUrl}"
+         data-link-url="${image.linkUrl}"
+         data-build="${image.build}"
+    ></div>
+</c:if>


### PR DESCRIPTION
This is a cleaner way of rendering the standard gbrowse/jbrowse image without duplicating boilerplate code in JSPs.