### PR TITLE
ZFIN-7741: UniProt Load - Handle merged genes gracefully

### DIFF
--- a/server_apps/ZFINPerlModules.pm
+++ b/server_apps/ZFINPerlModules.pm
@@ -192,6 +192,15 @@ sub assert_environment {
     }
 }
 
+sub assert_file_exists {
+    my $filename = shift();
+    my $error_message = shift();
+
+    unless (-e $filename) {
+        die($error_message);
+    }
+}
+
 sub trim {
     my $s = shift();
 

--- a/server_apps/data_transfer/SWISS-PROT/pre_loadsp.pl
+++ b/server_apps/data_transfer/SWISS-PROT/pre_loadsp.pl
@@ -27,7 +27,7 @@ use POSIX;
 
 use lib $ENV{'ROOT_PATH'} . "/server_apps/";
 use ZFINPerlModules qw(assert_environment trim);
-assert_environment('ROOT_PATH', 'PGHOST', 'DB_NAME', 'SWISSPROT_EMAIL_ERR');
+assert_environment('ROOT_PATH', 'PGHOST', 'DB_NAME', 'SWISSPROT_EMAIL_ERR', 'SWISSPROT_EMAIL_REPORT');
 
 #------------------- Flush Output Buffer --------------
 $|=1;
@@ -148,11 +148,17 @@ sub select_zebrafish {
     my $TREMBL_FILE_URL = "https://ftp.expasy.org/databases/uniprot/current_release/knowledgebase/taxonomic_divisions/uniprot_trembl_vertebrates.dat.gz";
     if ($ENV{'TREMBL_FILE_URL'}) {
         $TREMBL_FILE_URL = $ENV{'TREMBL_FILE_URL'};
+    } elsif ($ENV{'SKIP_DOWNLOADS'}) {
+        assert_file_exists('./uniprot_trembl_vertebrates.dat.gz', 'Missing uniprot tremble file and SKIP_DOWNLOADS set to 1');
+        $TREMBL_FILE_URL = 'file://' . `pwd` . '/uniprot_trembl_vertebrates.dat.gz';
     }
 
     my $SPROT_FILE_URL = "https://ftp.expasy.org/databases/uniprot/current_release/knowledgebase/taxonomic_divisions/uniprot_sprot_vertebrates.dat.gz";
     if ($ENV{'SPROT_FILE_URL'}) {
         $SPROT_FILE_URL = $ENV{'SPROT_FILE_URL'};
+    } elsif ($ENV{'SKIP_DOWNLOADS'}) {
+        assert_file_exists('./uniprot_sprot_vertebrates.dat.gz', 'Missing uniprot tremble file and SKIP_DOWNLOADS set to 1');
+        $SPROT_FILE_URL = 'file://' . `pwd` . '/uniprot_sprot_vertebrates.dat.gz';
     }
 
     if ($ENV{'SKIP_PRE_ZFIN_GEN'}) {

--- a/server_apps/data_transfer/SWISS-PROT/pre_loadsp.pl
+++ b/server_apps/data_transfer/SWISS-PROT/pre_loadsp.pl
@@ -189,6 +189,20 @@ sub select_zebrafish {
 }
 
 
+sub getMergedGeneIdIfExists {
+    my $dbh = $_[0];
+    my $geneId = $_[1];
+    my $cur = $dbh->prepare('SELECT zrepld_new_zdb_id, mrkr_abbrev FROM zdb_replaced_data LEFT JOIN marker on zrepld_new_zdb_id = mrkr_zdb_id WHERE zrepld_old_zdb_id = ?;');
+    $cur->execute($geneId);
+    my $mergedGeneId;
+    my $mergedGeneAbbrev;
+    $cur->bind_columns(\$mergedGeneId, \$mergedGeneAbbrev);
+    $cur->fetch();
+    $cur->finish();
+    return ($mergedGeneId, $mergedGeneAbbrev);
+}
+
+
 #=======================================================
 #
 #   Main
@@ -414,8 +428,29 @@ foreach $block (@blocks) {
            }
            $cur->finish();
 
+           if (!defined($ZFINgeneAbbrev)) {
+               my ($mergedGeneId, $mergedGeneAbbrev) = getMergedGeneIdIfExists($dbh, $ZFINgeneId);
+               if ($mergedGeneId) {
+                   print DBG "Merged '$ZFINgeneId' ($geneAbbrev) to '$mergedGeneId' ($mergedGeneAbbrev) \n";
+                   print DBG "   Old Line: $line\n";
+                   $line =~ s/$geneAbbrev/$mergedGeneAbbrev/g;
+                   $line =~ s/$ZFINgeneId/$mergedGeneId/g;
+                   print DBG "   New Line: $line\n";
+                   $ZFINgeneAbbrev = $geneAbbrev;
+
+                   if (exists($ZDBgeneIDgeneAbbrevs{$mergedGeneId})) {
+                       $deletes{$lineKey} = 1;
+                       next;
+                   }
+               } else {
+                   print DBG "ERROR: Search for gene abbreviation failed for zdb id '$ZFINgeneId'";
+                   die("ERROR: Search for gene abbreviation failed for zdb id '$ZFINgeneId'");
+               }
+           }
+
            if ($geneAbbrev ne $ZFINgeneAbbrev) {
-               print DBG "Gene Abbreviation is not the same as ZFIN Gene Abbreviation! Updating. \n";
+               my $ZFINgeneAbbrevDebug = defined($ZFINgeneAbbrev) ? $ZFINgeneAbbrev : "UNDEFINED";
+               print DBG "Gene Abbreviation '$geneAbbrev' is not the same as ZFIN Gene Abbreviation ($ZFINgeneAbbrevDebug)! Updating. \n";
                $line =~ s/$geneAbbrev/$ZFINgeneAbbrev/g;
            }
            $toNewInput{$lineKey} = $line;

--- a/server_apps/data_transfer/SWISS-PROT/sp_match.pl
+++ b/server_apps/data_transfer/SWISS-PROT/sp_match.pl
@@ -6,9 +6,10 @@
 # in loadsp.pl process. 
 #
 
-use lib "<!--|ROOT_PATH|-->/server_apps/";
-use ZFINPerlModules;
 use POSIX;
+use lib $ENV{'ROOT_PATH'} . "/server_apps/";
+use ZFINPerlModules qw(assert_environment);
+assert_environment('ROOT_PATH', 'DB_NAME', 'SWISSPROT_EMAIL_REPORT');
 
 if (@ARGV < 1) {
     die "Please enter the accession file name. \n";
@@ -30,22 +31,22 @@ while (<FILE>) {
 close FILE;
 close OK;
 
-  $dbname = "<!--|DB_NAME|-->";
+  $dbname = $ENV{'DB_NAME'};
 
   $subject = "Auto from $dbname: SWISS-PROT check report";
-  ZFINPerlModules->sendMailWithAttachedReport('<!--|SWISSPROT_EMAIL_REPORT|-->',"$subject","checkreport.txt");
+  ZFINPerlModules->sendMailWithAttachedReport($ENV{'SWISSPROT_EMAIL_REPORT'},"$subject","checkreport.txt");
   		
   #----- Another mail send out problem files ----
   $subject = "Auto from $dbname: SWISS-PROT problem file";
-  ZFINPerlModules->sendMailWithAttachedReport('<!--|SWISSPROT_EMAIL_REPORT|-->',"$subject","allproblems.txt");
+  ZFINPerlModules->sendMailWithAttachedReport($ENV{'SWISSPROT_EMAIL_REPORT'},"$subject","allproblems.txt");
 
   #----- Another mail send out problem files ----
   $subject = "Auto from $dbname: PubMed not in ZFIN";
-  ZFINPerlModules->sendMailWithAttachedReport('<!--|SWISSPROT_EMAIL_REPORT|-->',"$subject","pubmed_not_in_zfin");  
+  ZFINPerlModules->sendMailWithAttachedReport($ENV{'SWISSPROT_EMAIL_REPORT'},"$subject","pubmed_not_in_zfin");
 
   #----- Another mail send out problem files ----
   $subject = "Auto from $dbname: report of processing pre_zfin.org";
-  ZFINPerlModules->sendMailWithAttachedReport('<!--|SWISSPROT_EMAIL_REPORT|-->',"$subject","redGeneReport.txt");
+  ZFINPerlModules->sendMailWithAttachedReport($ENV{'SWISSPROT_EMAIL_REPORT'},"$subject","redGeneReport.txt");
 
 
 print("Checksums and file info of important files:\n");


### PR DESCRIPTION
If the uniprot load comes across a record with 2 zfin genes associated with it 
and one of the genes has been merged into the other gene, then omit the old
gene information from that record.