### PR TITLE
ZFIN 8009: Fix GBrowseImageSpec Failure, other gbrowse regressions

### DIFF
--- a/source/org/zfin/feature/repository/FeatureService.java
+++ b/source/org/zfin/feature/repository/FeatureService.java
@@ -341,15 +341,15 @@ public class FeatureService {
             Marker related = featureMarkerRelationships.iterator().next().getMarker();
             List<MarkerGenomeLocation> markerLocations = RepositoryFactory.getLinkageRepository().getGenomeLocation(related, source);
             if (CollectionUtils.isNotEmpty(markerLocations)) {
-                imageBuilder.landmark(markerLocations.get(0)).withPadding(0.1);
+                imageBuilder.setLandmarkByGenomeLocation(markerLocations.get(0)).withPadding(0.1);
             } else {
-                imageBuilder.landmark(featureLocation).withPadding(10000);
+                imageBuilder.setLandmarkByGenomeLocation(featureLocation).withPadding(10000);
             }
         } else {
-            imageBuilder.landmark(featureLocation).withPadding(10000);
+            imageBuilder.setLandmarkByGenomeLocation(featureLocation).withPadding(10000);
         }
         //currently only ZMP features on previous builds need anything other than the ZFIN_FEATURES track
-        GenomeBrowserTrack featureTrack = featureLocation.getGbrowseTrack() == null ? GenomeBrowserTrack.ZFIN_FEATURES : featureLocation.getGbrowseTrack();
+        GenomeBrowserTrack featureTrack = featureLocation.getGenomeBrowserTrack() == null ? GenomeBrowserTrack.ZFIN_FEATURES : featureLocation.getGenomeBrowserTrack();
 
         imageBuilder.tracks(new GenomeBrowserTrack[]{GenomeBrowserTrack.GENES, featureTrack, GenomeBrowserTrack.TRANSCRIPTS});
 

--- a/source/org/zfin/gbrowse/GBrowseTrack.java
+++ b/source/org/zfin/gbrowse/GBrowseTrack.java
@@ -36,27 +36,24 @@ public enum GBrowseTrack {
         return trackName;
     }
 
-    public static Collection<GBrowseTrack> fromGenomeBrowserTracks(Collection<GenomeBrowserTrack> tracks) {
-        if (tracks == null) {
-            return new ArrayList<>();
-        }
-        return tracks.stream().map(genomeBrowserTrack -> switch (genomeBrowserTrack) {
-            case GENES -> GBrowseTrack.GENES;
-            case TRANSCRIPTS -> GBrowseTrack.TRANSCRIPTS;
-            case CLONE -> GBrowseTrack.CLONE;
-            case GENES_VEGA -> GBrowseTrack.GENES_VEGA;
-            case ENSEMBL_MRNA -> GBrowseTrack.ENSEMBL_MRNA;
-            case PHENOTYPE -> GBrowseTrack.PHENOTYPE;
-            case EXPRESSIONS -> GBrowseTrack.EXPRESSIONS;
-            case ANTIBODY -> GBrowseTrack.ANTIBODY;
-            case KNOCKDOWN_REAGENT -> GBrowseTrack.KNOCKDOWN_REAGENT;
-            case INSERTION -> GBrowseTrack.INSERTION;
-            case CNE -> GBrowseTrack.CNE;
-            case COMPLETE_CLONES -> GBrowseTrack.COMPLETE_CLONES;
-            case ALLZMP -> GBrowseTrack.ALLZMP;
-            case ZFIN_FEATURES -> GBrowseTrack.ZFIN_FEATURES;
-            case ZMP -> GBrowseTrack.ZMP;
-        }).collect(Collectors.toList());
-    }
-
+    public static GenomeBrowserTrack convertGBrowseTrackToGenomeBrowserTrack(GBrowseTrack genomeBrowserTrack) {
+        return switch (genomeBrowserTrack) {
+            case GENES -> GenomeBrowserTrack.GENES;
+            case TRANSCRIPTS -> GenomeBrowserTrack.TRANSCRIPTS;
+            case CLONE -> GenomeBrowserTrack.CLONE;
+            case GENES_VEGA -> GenomeBrowserTrack.GENES_VEGA;
+            case ENSEMBL_MRNA -> GenomeBrowserTrack.ENSEMBL_MRNA;
+            case PHENOTYPE -> GenomeBrowserTrack.PHENOTYPE;
+            case EXPRESSIONS -> GenomeBrowserTrack.EXPRESSIONS;
+            case ANTIBODY -> GenomeBrowserTrack.ANTIBODY;
+            case KNOCKDOWN_REAGENT -> GenomeBrowserTrack.KNOCKDOWN_REAGENT;
+            case INSERTION -> GenomeBrowserTrack.INSERTION;
+            case CNE -> GenomeBrowserTrack.CNE;
+            case COMPLETE_CLONES -> GenomeBrowserTrack.COMPLETE_CLONES;
+            case ALLZMP -> GenomeBrowserTrack.ALLZMP;
+            case ZFIN_FEATURES -> GenomeBrowserTrack.ZFIN_FEATURES;
+            case ZMP -> GenomeBrowserTrack.ZMP;
+        };
+    }    
+    
 }

--- a/source/org/zfin/gbrowse/presentation/GBrowseImage.java
+++ b/source/org/zfin/gbrowse/presentation/GBrowseImage.java
@@ -4,6 +4,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.zfin.gbrowse.GBrowseTrack;
 import org.zfin.genomebrowser.GenomeBrowserBuild;
+import org.zfin.genomebrowser.GenomeBrowserTrack;
 import org.zfin.genomebrowser.GenomeBrowserType;
 import org.zfin.genomebrowser.presentation.GenomeBrowserImage;
 import org.zfin.util.URLCreator;
@@ -29,7 +30,7 @@ public class GBrowseImage implements GenomeBrowserImage {
     public GBrowseImage(GBrowseImageBuilder builder) {
         this.landmark = builder.getLandmark();
 
-        this.tracks = GBrowseTrack.fromGenomeBrowserTracks(builder.getTracks());
+        this.tracks = GenomeBrowserTrack.convertGenomeBrowserTracksToGBrowse(builder.getTracks());
 
         this.highlightFeature = builder.getHighlightLandmark();
         this.highlightColor = builder.getHighlightColor();

--- a/source/org/zfin/gbrowse/presentation/GBrowseImageBuilder.java
+++ b/source/org/zfin/gbrowse/presentation/GBrowseImageBuilder.java
@@ -80,7 +80,7 @@ public class GBrowseImageBuilder implements GenomeBrowserImageBuilder {
         return this;
     }
 
-    public GenomeBrowserImageBuilder landmark(GenomeLocation landmark) {
+    public GenomeBrowserImageBuilder setLandmarkByGenomeLocation(GenomeLocation landmark) {
         this.landmarkLocation = landmark;
         return this;
     }

--- a/source/org/zfin/genomebrowser/GenomeBrowserTrack.java
+++ b/source/org/zfin/genomebrowser/GenomeBrowserTrack.java
@@ -1,5 +1,11 @@
 package org.zfin.genomebrowser;
 
+import org.zfin.gbrowse.GBrowseTrack;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 /**
  * Names of the gBrowse tracks.
  */
@@ -39,4 +45,33 @@ public enum GenomeBrowserTrack {
         return null;
     }
 
+    public static Collection<GBrowseTrack> convertGenomeBrowserTracksToGBrowse(Collection<GenomeBrowserTrack> tracks) {
+        if (tracks == null) {
+            return new ArrayList<>();
+        }
+        return tracks
+                .stream()
+                .map(GenomeBrowserTrack::convertGenomeBrowserTrackToGBrowse)
+                .collect(Collectors.toList());
+    }
+
+    public static GBrowseTrack convertGenomeBrowserTrackToGBrowse(GenomeBrowserTrack genomeBrowserTrack) {
+        return switch (genomeBrowserTrack) {
+            case GENES -> GBrowseTrack.GENES;
+            case TRANSCRIPTS -> GBrowseTrack.TRANSCRIPTS;
+            case CLONE -> GBrowseTrack.CLONE;
+            case GENES_VEGA -> GBrowseTrack.GENES_VEGA;
+            case ENSEMBL_MRNA -> GBrowseTrack.ENSEMBL_MRNA;
+            case PHENOTYPE -> GBrowseTrack.PHENOTYPE;
+            case EXPRESSIONS -> GBrowseTrack.EXPRESSIONS;
+            case ANTIBODY -> GBrowseTrack.ANTIBODY;
+            case KNOCKDOWN_REAGENT -> GBrowseTrack.KNOCKDOWN_REAGENT;
+            case INSERTION -> GBrowseTrack.INSERTION;
+            case CNE -> GBrowseTrack.CNE;
+            case COMPLETE_CLONES -> GBrowseTrack.COMPLETE_CLONES;
+            case ALLZMP -> GBrowseTrack.ALLZMP;
+            case ZFIN_FEATURES -> GBrowseTrack.ZFIN_FEATURES;
+            case ZMP -> GBrowseTrack.ZMP;
+        };
+    }
 }

--- a/source/org/zfin/genomebrowser/presentation/GenomeBrowserImageBuilder.java
+++ b/source/org/zfin/genomebrowser/presentation/GenomeBrowserImageBuilder.java
@@ -19,7 +19,7 @@ public interface GenomeBrowserImageBuilder {
 
     GenomeBrowserImageBuilder highlightColor(String pink);
 
-    GenomeBrowserImageBuilder landmark(GenomeLocation landmark);
+    GenomeBrowserImageBuilder setLandmarkByGenomeLocation(GenomeLocation landmark);
 
     GenomeBrowserImageBuilder landmark(String s);
 

--- a/source/org/zfin/jbrowse/presentation/JBrowseImageBuilder.java
+++ b/source/org/zfin/jbrowse/presentation/JBrowseImageBuilder.java
@@ -115,7 +115,7 @@ public class JBrowseImageBuilder implements GenomeBrowserImageBuilder {
         return this;
     }
 
-    public GenomeBrowserImageBuilder landmark(GenomeLocation landmark) {
+    public GenomeBrowserImageBuilder setLandmarkByGenomeLocation(GenomeLocation landmark) {
         this.landmarkLocation = landmark;
         return this;
     }

--- a/source/org/zfin/mapping.hbm.xml
+++ b/source/org/zfin/mapping.hbm.xml
@@ -11,7 +11,7 @@
     </typedef>
 
     <typedef class="org.zfin.framework.StringEnumValueUserType" name="gbrowseTrackType">
-        <param name="enumClassname">org.zfin.genomebrowser.GenomeBrowserTrack</param>
+        <param name="enumClassname">org.zfin.gbrowse.GBrowseTrack</param>
     </typedef>
 
     <class name="Linkage" table="linkage">

--- a/source/org/zfin/mapping/GenomeLocation.java
+++ b/source/org/zfin/mapping/GenomeLocation.java
@@ -1,5 +1,6 @@
 package org.zfin.mapping;
 
+import org.zfin.gbrowse.GBrowseTrack;
 import org.zfin.genomebrowser.GenomeBrowserTrack;
 import org.zfin.gwt.root.util.StringUtils;
 import org.zfin.ontology.GenericTerm;
@@ -30,7 +31,7 @@ public class GenomeLocation implements Serializable, Comparable<GenomeLocation> 
 
 
     protected Publication attribution;
-    protected GenomeBrowserTrack gbrowseTrack;
+    protected GBrowseTrack gbrowseTrack;
     protected String assembly;
     private GenericTerm evidence;
 
@@ -132,12 +133,19 @@ public class GenomeLocation implements Serializable, Comparable<GenomeLocation> 
         this.attribution = attribution;
     }
 
-    public GenomeBrowserTrack getGbrowseTrack() {
+    public GBrowseTrack getGbrowseTrack() {
         return gbrowseTrack;
     }
 
-    public void setGbrowseTrack(GenomeBrowserTrack gbrowseTrack) {
+    public void setGbrowseTrack(GBrowseTrack gbrowseTrack) {
         this.gbrowseTrack = gbrowseTrack;
+    }
+
+    public GenomeBrowserTrack getGenomeBrowserTrack() {
+        if (gbrowseTrack == null) {
+            return null;
+        }
+        return GBrowseTrack.convertGBrowseTrackToGenomeBrowserTrack(gbrowseTrack);
     }
 
     public String getAssembly() {

--- a/source/org/zfin/mapping/presentation/MappingDetailController.java
+++ b/source/org/zfin/mapping/presentation/MappingDetailController.java
@@ -251,7 +251,7 @@ public class MappingDetailController {
         for (MarkerGenomeLocation genomeLocation : genomeLocations) {
             if (genomeLocation.getSource() == GenomeLocation.Source.ZFIN) {
                 model.addAttribute("gbrowseImage", genomeBrowserFactory.getImageBuilder()
-                                .landmark(genomeLocation)
+                                .setLandmarkByGenomeLocation(genomeLocation)
                                 .withCenteredRange(500000)
                                 .highlight(trackingGene)
                                 .highlightColor("pink")

--- a/source/org/zfin/mapping/repository/HibernateLinkageRepository.java
+++ b/source/org/zfin/mapping/repository/HibernateLinkageRepository.java
@@ -285,7 +285,7 @@ public class HibernateLinkageRepository implements LinkageRepository {
     public List<FeatureGenomeLocation> getGenomeLocation(Feature feature, GenomeLocation.Source... sources) {
         Criteria query = HibernateUtil.currentSession().createCriteria(FeatureGenomeLocation.class);
         query.add(Restrictions.eq("feature", feature));
-        query.add(Restrictions.in("source", (Object) sources));
+        query.add(Restrictions.in("source", (Object[]) sources));
         return query.list();
     }
 

--- a/source/org/zfin/marker/presentation/SequenceTargetingReagentViewController.java
+++ b/source/org/zfin/marker/presentation/SequenceTargetingReagentViewController.java
@@ -277,7 +277,7 @@ public class SequenceTargetingReagentViewController {
             mergedLocation.setEnd(Math.max(mergedLocation.getEnd(), strLocations.get(0).getEnd()));
 
             sequenceTargetingReagentBean.addGBrowseImage(genomeBrowserFactory.getImageBuilder()
-                    .landmark(mergedLocation)
+                    .setLandmarkByGenomeLocation(mergedLocation)
                     .withPadding(0.1)
                     .tracks(GBrowseService.getGBrowseTracks(sequenceTargetingReagent))
                     .highlight(sequenceTargetingReagent)
@@ -287,7 +287,7 @@ public class SequenceTargetingReagentViewController {
             // otherwise: just show each STR location with 10kbp padding
             for (MarkerGenomeLocation location : strLocations) {
                 sequenceTargetingReagentBean.addGBrowseImage(genomeBrowserFactory.getImageBuilder()
-                        .landmark(location)
+                        .setLandmarkByGenomeLocation(location)
                         .withPadding(10000)
                         .tracks(GBrowseService.getGBrowseTracks(sequenceTargetingReagent))
                         .highlight(sequenceTargetingReagent)

--- a/source/org/zfin/sequence/blast/results/view/BlastResultMapper.java
+++ b/source/org/zfin/sequence/blast/results/view/BlastResultMapper.java
@@ -3,7 +3,6 @@ package org.zfin.sequence.blast.results.view;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager; import org.apache.logging.log4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.zfin.genomebrowser.GenomeBrowserTrack;
 import org.zfin.genomebrowser.presentation.GenomeBrowserFactory;
 import org.zfin.mapping.GenomeLocation;
@@ -384,7 +383,7 @@ public class BlastResultMapper {
                                 .getLinkageRepository()
                                 .getGenomeLocation(gene, GenomeLocation.Source.ZFIN);
                         hitViewBean.setGbrowseImage(GenomeBrowserFactory.getStaticImageBuilder()
-                                .landmark(locations.get(0))
+                                .setLandmarkByGenomeLocation(locations.get(0))
                                 .highlight(transcript.getAbbreviation())
                                 .tracks(new GenomeBrowserTrack[]{GenomeBrowserTrack.TRANSCRIPTS})
                                 .build());

--- a/source/org/zfin/sequence/service/TranscriptService.java
+++ b/source/org/zfin/sequence/service/TranscriptService.java
@@ -2,7 +2,6 @@ package org.zfin.sequence.service;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.zfin.Species;
 import org.zfin.framework.HibernateUtil;
 import org.zfin.genomebrowser.GenomeBrowserTrack;
@@ -99,7 +98,7 @@ public class TranscriptService {
                 && getLinkageRepository().hasGenomeLocation(gene, MarkerGenomeLocation.Source.ENSEMBL)
                 && getLinkageRepository().hasGenomeLocation(gene, MarkerGenomeLocation.Source.ZFIN)) {
             GenomeBrowserImageBuilder imageBuilder = GenomeBrowserFactory.getStaticImageBuilder()
-                    .landmark(getLinkageRepository().getGenomeLocation(gene, GenomeLocation.Source.ZFIN).get(0))
+                    .setLandmarkByGenomeLocation(getLinkageRepository().getGenomeLocation(gene, GenomeLocation.Source.ZFIN).get(0))
                     .tracks(new GenomeBrowserTrack[]{GenomeBrowserTrack.TRANSCRIPTS});
             if (highlightedTranscript != null) {
                 imageBuilder.highlight(highlightedTranscript.getAbbreviation());

--- a/test/org/zfin/gbrowse/presentation/GBrowseImageSpec.groovy
+++ b/test/org/zfin/gbrowse/presentation/GBrowseImageSpec.groovy
@@ -42,7 +42,7 @@ class GBrowseImageSpec extends AbstractZfinIntegrationSpec {
         def m = RepositoryFactory.markerRepository.getMarkerByID(zdbId)
         def location = linkageRepository.getGenomeLocation(m, GenomeLocation.Source.ZFIN)?.getAt(0)
         def image = GenomeBrowserFactory.getStaticImageBuilder()
-                .landmark(location)
+                .setLandmarkByGenomeLocation(location)
                 .build()
 
         then:
@@ -58,7 +58,7 @@ class GBrowseImageSpec extends AbstractZfinIntegrationSpec {
         def f = RepositoryFactory.featureRepository.getFeatureByID(zdbId)
         def location = linkageRepository.getGenomeLocation(f, GenomeLocation.Source.ZFIN_Zv9)?.getAt(0)
         def image = GenomeBrowserFactory.getStaticImageBuilder()
-                .landmark(location)
+                .setLandmarkByGenomeLocation(location)
                 .genomeBuild(GenomeBrowserBuild.ZV9)
                 .build()
 
@@ -141,7 +141,7 @@ class GBrowseImageSpec extends AbstractZfinIntegrationSpec {
         def location = linkageRepository.getGenomeLocation(m, GenomeLocation.Source.ZFIN)[0]
         def padding = 1000
         def image = GenomeBrowserFactory.getStaticImageBuilder()
-                .landmark(location)
+                .setLandmarkByGenomeLocation(location)
                 .withPadding(padding)
                 .build()
 
@@ -156,7 +156,7 @@ class GBrowseImageSpec extends AbstractZfinIntegrationSpec {
         def padding = 0.1
         def absolutePadding = (int) (padding * (location.end - location.start))
         def image = GenomeBrowserFactory.getStaticImageBuilder()
-                .landmark(location)
+                .setLandmarkByGenomeLocation(location)
                 .withPadding(padding)
                 .build()
 


### PR DESCRIPTION
Fix hibernate cast from "(Object)sources" to "(Object[])sources".

Fix gbrowse regression: GenomeLocation objects were not properly loading the gbrowseTrack field from the column in the database.