### PR TITLE
Hotfix for Hibernate Upgrade bug

### DIFF
--- a/source/org/zfin/antibody/repository/HibernateAntibodyRepository.java
+++ b/source/org/zfin/antibody/repository/HibernateAntibodyRepository.java
@@ -531,10 +531,18 @@ public class HibernateAntibodyRepository implements AntibodyRepository {
         // loop over all antibodyAOStatistic records until the given number of distinct antibodies from the pagination
         // bean is reached.
         if (includeSubstructures) {
-            hql = "  from AntibodyAOStatistics stat fetch all properties" +
+            hql = "  from AntibodyAOStatistics stat " +
+                    " LEFT JOIN FETCH stat.figure " +
+                    " LEFT JOIN FETCH stat.gene " +
+                    " LEFT JOIN FETCH stat.publication " +
+                    " LEFT JOIN FETCH stat.antibody " +
                     "     where stat.superterm = :aoterm";
         } else {
-            hql = " select distinct stat, stat.antibody.name from AntibodyAOStatistics stat fetch all properties" +
+            hql = " select distinct stat, stat.antibody.name from AntibodyAOStatistics stat " +
+                    " LEFT JOIN FETCH stat.figure " +
+                    " LEFT JOIN FETCH stat.gene " +
+                    " LEFT JOIN FETCH stat.publication " +
+                    " LEFT JOIN FETCH stat.antibody " +
                     "     where stat.superterm = :aoterm and " +
                     "           stat.subterm = :aoterm " +
                     "           order by stat.antibody.name";

--- a/source/org/zfin/expression/repository/HibernateExpressionRepository.java
+++ b/source/org/zfin/expression/repository/HibernateExpressionRepository.java
@@ -1803,7 +1803,7 @@ public class HibernateExpressionRepository implements ExpressionRepository {
                 "        and fishox = xpExp.fishExperiment " +
                 "        and xpRslt.expressionExperiment = xpExp " +
                 "        and xpExp.gene != null" +
-                "        and xpExp.gene.zdbID not like :markerId)";
+                "        and xpExp.gene.zdbID not like :markerId";
         Query query = session.createQuery(hql);
         query.setParameter("fish", fish);
         query.setParameter("markerId", "%" + "ZDB-EFG" + "%");
@@ -1819,7 +1819,7 @@ public class HibernateExpressionRepository implements ExpressionRepository {
                 "        and fishox = xpExp.fishExperiment " +
                 "        and xpRslt.expressionExperiment = xpExp " +
                 "        and xpExp.gene != null" +
-                "        and xpExp.gene.zdbID like :markerId)";
+                "        and xpExp.gene.zdbID like :markerId";
         Query query = session.createQuery(hql);
         query.setParameter("fish", fish);
         query.setParameter("markerId", "%" + "ZDB-EFG" + "%");


### PR DESCRIPTION
Seems like "fetch all properties" is not having any effect.
We are getting a hibernate error when ```            newAntibodyStat.addFigure(figure);```
is called because it is resolving a lazy-loaded relationship and this is
happening while in the context of iterating over a ScrollableResults set which doesn't
allow running queries. Must be due to hibernate upgrade.