### PR TITLE
ZFIN-8009: GBrowse Range Hotfix

### DIFF
--- a/source/org/zfin/feature/repository/FeatureService.java
+++ b/source/org/zfin/feature/repository/FeatureService.java
@@ -331,7 +331,7 @@ public class FeatureService {
             source = GenomeLocation.Source.ZFIN_Zv9;
         } else if (featureLocation.getAssembly().equals("GRCz10")) {
             imageBuilder.genomeBuild(GenomeBrowserBuild.GRCZ10);
-            source = GenomeLocation.Source.ZFIN_Zv9;
+            source = GenomeLocation.Source.ZFIN_Zv9; //TODO: Should this be Zv10?
         } else {
             imageBuilder.genomeBuild(GenomeBrowserBuild.CURRENT);
             source = GenomeLocation.Source.ZFIN;
@@ -341,7 +341,7 @@ public class FeatureService {
             Marker related = featureMarkerRelationships.iterator().next().getMarker();
             List<MarkerGenomeLocation> markerLocations = RepositoryFactory.getLinkageRepository().getGenomeLocation(related, source);
             if (CollectionUtils.isNotEmpty(markerLocations)) {
-                imageBuilder.setLandmarkByGenomeLocation(markerLocations.get(0)).withPadding(0.1);
+                imageBuilder.setLandmarkByGenomeLocation(markerLocations.get(0)).withRelativePadding(0.1);
             } else {
                 imageBuilder.setLandmarkByGenomeLocation(featureLocation).withPadding(10000);
             }

--- a/source/org/zfin/gbrowse/presentation/GBrowseImageBuilder.java
+++ b/source/org/zfin/gbrowse/presentation/GBrowseImageBuilder.java
@@ -32,6 +32,7 @@ public class GBrowseImageBuilder implements GenomeBrowserImageBuilder {
     private Feature highlightFeature;
     private String highlightString;
 
+    @Override
     public GenomeBrowserImage build() {
 
         if (highlightMarker != null) {
@@ -70,100 +71,121 @@ public class GBrowseImageBuilder implements GenomeBrowserImageBuilder {
         return new GBrowseImage(this);
     }
 
+    @Override
     public GenomeBrowserImageBuilder genomeBuild(GenomeBrowserBuild genomeBuild) {
         this.genomeBuild = genomeBuild;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder landmark(String landmark) {
         this.landmark = landmark;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder setLandmarkByGenomeLocation(GenomeLocation landmark) {
         this.landmarkLocation = landmark;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder withCenteredRange(int range) {
         this.centeredRange = range;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder withPadding(int startPadding, int endPadding) {
         this.startPadding = startPadding;
         this.endPadding = endPadding;
         return this;
     }
 
-    public GenomeBrowserImageBuilder withPadding(double padding) {
+    @Override
+    public GenomeBrowserImageBuilder withRelativePadding(double padding) {
         relativePadding = padding;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder withPadding(int padding) {
         return withPadding(padding, padding);
     }
 
+    @Override
     public GenomeBrowserImageBuilder tracks(GenomeBrowserTrack... tracks) {
         return tracks(Arrays.asList(tracks));
     }
 
-    public GenomeBrowserImageBuilder tracks(Collection<GenomeBrowserTrack> tracks) {
+    private GenomeBrowserImageBuilder tracks(Collection<GenomeBrowserTrack> tracks) {
         this.tracks = tracks;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder highlight(String highlight) {
         highlightString = highlight;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder highlight(Marker highlight) {
         highlightMarker = highlight;
         return this;
     }
 
-    public GenomeBrowserBuild getGenomeBuild() {
-        return genomeBuild;
-    }
-
-    public Collection<GenomeBrowserTrack> getTracks() {
-        return tracks;
-    }
-
-    public String getHighlightLandmark() {
-        return highlightLandmark;
-    }
-
-    public String getHighlightColor() {
-        return highlightColor;
-    }
-
-    public boolean isGrid() {
-        return grid;
-    }
-
-    public Feature getHighlightFeature() {
-        return highlightFeature;
-    }
-
+    @Override
     public GenomeBrowserImageBuilder highlight(Feature highlight) {
         highlightFeature = highlight;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder highlightColor(String highlightColor) {
         this.highlightColor = highlightColor;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder grid(boolean grid) {
         this.grid = grid;
         return this;
     }
 
+    @Override
     public String getLandmark() {
         return landmark;
     }
+
+    @Override
+    public GenomeBrowserBuild getGenomeBuild() {
+        return genomeBuild;
+    }
+
+    @Override
+    public Collection<GenomeBrowserTrack> getTracks() {
+        return tracks;
+    }
+
+    @Override
+    public String getHighlightLandmark() {
+        return highlightLandmark;
+    }
+
+    @Override
+    public String getHighlightColor() {
+        return highlightColor;
+    }
+
+    @Override
+    public boolean isGrid() {
+        return grid;
+    }
+
+    @Override
+    public Feature getHighlightFeature() {
+        return highlightFeature;
+    }
+
 }

--- a/source/org/zfin/genomebrowser/presentation/GenomeBrowserImageBuilder.java
+++ b/source/org/zfin/genomebrowser/presentation/GenomeBrowserImageBuilder.java
@@ -6,6 +6,8 @@ import org.zfin.genomebrowser.GenomeBrowserTrack;
 import org.zfin.mapping.GenomeLocation;
 import org.zfin.marker.Marker;
 
+import java.util.Collection;
+
 public interface GenomeBrowserImageBuilder {
     GenomeBrowserImage build();
 
@@ -27,6 +29,25 @@ public interface GenomeBrowserImageBuilder {
 
     GenomeBrowserImageBuilder withCenteredRange(int i);
 
-    GenomeBrowserImageBuilder withPadding(double v);
+    GenomeBrowserImageBuilder withPadding(int startPadding, int endPadding);
 
+    GenomeBrowserImageBuilder withRelativePadding(double v);
+
+    GenomeBrowserImageBuilder withPadding(int v);
+
+    GenomeBrowserImageBuilder grid(boolean grid);
+
+    String getLandmark();
+
+    GenomeBrowserBuild getGenomeBuild();
+
+    Collection<GenomeBrowserTrack> getTracks();
+
+    String getHighlightLandmark();
+
+    String getHighlightColor();
+
+    boolean isGrid();
+
+    Feature getHighlightFeature();
 }

--- a/source/org/zfin/jbrowse/presentation/JBrowseImageBuilder.java
+++ b/source/org/zfin/jbrowse/presentation/JBrowseImageBuilder.java
@@ -37,6 +37,7 @@ public class JBrowseImageBuilder implements GenomeBrowserImageBuilder {
     private Feature highlightFeature;
     private String highlightString;
 
+    @Override
     public GenomeBrowserImage build() {
 
         if (highlightMarker != null) {
@@ -105,100 +106,122 @@ public class JBrowseImageBuilder implements GenomeBrowserImageBuilder {
         .orElse(null);
     }
 
+    @Override
     public GenomeBrowserImageBuilder genomeBuild(GenomeBrowserBuild genomeBuild) {
         this.genomeBuild = genomeBuild;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder landmark(String landmark) {
         this.landmark = landmark;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder setLandmarkByGenomeLocation(GenomeLocation landmark) {
         this.landmarkLocation = landmark;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder withCenteredRange(int range) {
         this.centeredRange = range;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder withPadding(int startPadding, int endPadding) {
         this.startPadding = startPadding;
         this.endPadding = endPadding;
         return this;
     }
 
-    public GenomeBrowserImageBuilder withPadding(double padding) {
+    @Override
+    public GenomeBrowserImageBuilder withRelativePadding(double padding) {
         relativePadding = padding;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder withPadding(int padding) {
         return withPadding(padding, padding);
     }
 
+    @Override
     public GenomeBrowserImageBuilder tracks(GenomeBrowserTrack... tracks) {
         return tracks(Arrays.asList(tracks));
     }
 
-    public GenomeBrowserImageBuilder tracks(Collection<GenomeBrowserTrack> tracks) {
+    private GenomeBrowserImageBuilder tracks(Collection<GenomeBrowserTrack> tracks) {
         this.tracks = tracks;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder highlight(String highlight) {
         highlightString = highlight;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder highlight(Marker highlight) {
         highlightMarker = highlight;
         return this;
     }
 
-    public GenomeBrowserBuild getGenomeBuild() {
-        return genomeBuild;
-    }
-
-    public Collection<GenomeBrowserTrack> getTracks() {
-        return tracks;
-    }
-
-    public String getHighlightLandmark() {
-        return highlightLandmark;
-    }
-
-    public String getHighlightColor() {
-        return highlightColor;
-    }
-
-    public boolean isGrid() {
-        return grid;
-    }
-
-    public Feature getHighlightFeature() {
-        return highlightFeature;
-    }
-
+    @Override
     public GenomeBrowserImageBuilder highlight(Feature highlight) {
         highlightFeature = highlight;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder highlightColor(String highlightColor) {
         this.highlightColor = highlightColor;
         return this;
     }
 
+    @Override
     public GenomeBrowserImageBuilder grid(boolean grid) {
         this.grid = grid;
         return this;
     }
 
+    @Override
     public String getLandmark() {
         return landmark;
     }
+
+    @Override
+    public GenomeBrowserBuild getGenomeBuild() {
+        return genomeBuild;
+    }
+
+    @Override
+    public Collection<GenomeBrowserTrack> getTracks() {
+        return tracks;
+    }
+
+    @Override
+    public String getHighlightLandmark() {
+        return highlightLandmark;
+    }
+
+    @Override
+    public String getHighlightColor() {
+        return highlightColor;
+    }
+
+    @Override
+    public boolean isGrid() {
+        return grid;
+    }
+
+    @Override
+    public Feature getHighlightFeature() {
+        return highlightFeature;
+    }
+
+
 }

--- a/source/org/zfin/marker/presentation/SequenceTargetingReagentViewController.java
+++ b/source/org/zfin/marker/presentation/SequenceTargetingReagentViewController.java
@@ -278,7 +278,7 @@ public class SequenceTargetingReagentViewController {
 
             sequenceTargetingReagentBean.addGBrowseImage(genomeBrowserFactory.getImageBuilder()
                     .setLandmarkByGenomeLocation(mergedLocation)
-                    .withPadding(0.1)
+                    .withRelativePadding(0.1)
                     .tracks(GBrowseService.getGBrowseTracks(sequenceTargetingReagent))
                     .highlight(sequenceTargetingReagent)
                     .build()


### PR DESCRIPTION
Fix issue where the range was calculating incorrectly because the function call "withPadding(10000)" was calling the function with signature of "withPadding(double d)" instead of "withPadding(int i)". Turned out to be due to the integer one not being defined on the new interface.

Screenshots showing the regression:

zfin.org:
![Screen Shot 2022-05-16 at 12 47 02 PM](https://user-images.githubusercontent.com/90803397/168670710-8038225e-cb99-4523-aac7-51df85611114.png)

trunk:

![Screen Shot 2022-05-16 at 12 47 11 PM](https://user-images.githubusercontent.com/90803397/168670749-82eb195e-c11e-4a5d-9a50-6f00a251f58f.png)