### PR TITLE
ZFIN-8011: Fix hibernate issue from test suite

### DIFF
--- a/source/org/zfin/infrastructure/delete/DeleteFeatureRule.java
+++ b/source/org/zfin/infrastructure/delete/DeleteFeatureRule.java
@@ -23,6 +23,8 @@ public class DeleteFeatureRule extends AbstractDeleteEntityRule implements Delet
     @Override
     public List<DeleteValidationReport> validate() {
         Feature feature = RepositoryFactory.getFeatureRepository().getFeatureByID(zdbID);
+        SortedSet<Publication> featurePublications = RepositoryFactory.getPublicationRepository().getAllPublicationsForFeature(feature);
+
         addToValidationReport(feature.getAbbreviation() + " is used in the following list of genotypes: ", getMutantRepository().getGenotypesByFeature(feature));
 
         // Can't delete the feature if it has a source
@@ -40,7 +42,6 @@ public class DeleteFeatureRule extends AbstractDeleteEntityRule implements Delet
         }
 
         // Can't delete the feature if it has more than 1 publications
-        SortedSet<Publication> featurePublications = RepositoryFactory.getPublicationRepository().getAllPublicationsForFeature(feature);
         if (CollectionUtils.isNotEmpty(featurePublications) && featurePublications.size() > 1) {
             addToValidationReport(feature.getAbbreviation() + " associated with more than one publication: ", featurePublications);
         }


### PR DESCRIPTION
Call getAllPublicationsForFeature at top of method to avoid throwing an exception 
(HibernateException: identifier of an instance of org.zfin.profile.FeatureSupplier 
was altered from org.zfin.profile.ObjectSupplier$HibernateBasicProxy$eAKO0ILG@369902662 
to org.zfin.profile.FeatureSupplier@5cc6fc3)

More details in the ticket: https://zfin.atlassian.net/browse/ZFIN-8011