### PR TITLE
ZFIN 7922 (Revert): Revert to old behavior for genotype names when involving features with multiple markers

### DIFF
--- a/lib/DB_functions/get_feature_and_marker_abbrev_display.sql
+++ b/lib/DB_functions/get_feature_and_marker_abbrev_display.sql
@@ -36,7 +36,13 @@ for featAbbrev, featMrkrAbbrev, featName, featType in
     	 	 and fmrel_type = 'is allele of'
     	 	 left outer join marker on fmrel_mrkr_zdb_id = mrkr_zdb_id
         where feature_zdb_id = featZdbId
-        and (fmrel_mrkr_zdb_id = markerZdbId or fmrel_mrkr_zdb_id is null)
+
+--
+--        TODO: Uncomment this "and" clause to handle features with multiple markers once approved.
+--              See ticket ZFIN-7922
+--        and (fmrel_mrkr_zdb_id = markerZdbId or fmrel_mrkr_zdb_id is null)
+--
+
  loop 
 
   if (featName is null) then


### PR DESCRIPTION
Revert latest change on ZFIN-7922.  I thought we had approval for this change, but it turned out to affect more genotypes and Amy has requested that we hold off on this specific change.  I'm reverting to the old behavior for the case of features with multiple markers.