### PR TITLE
ZFIN-8035: Handle duplicate entries that are imported in GAF-GOA Load

### DIFF
--- a/home/WEB-INF/conf/log4j2.xml
+++ b/home/WEB-INF/conf/log4j2.xml
@@ -17,6 +17,7 @@
         <Logger name="com.mchange.v2.c3p0.impl" level="error"/>
         <Logger name="com.mchange" level="error"/>
         <Logger name="org.zfin" level="info"/>
+        <Logger name="org.zfin.datatransfer" level="debug"/>
         <Root level="warn">
             <AppenderRef ref="STDOUT"/>
         </Root>

--- a/lib/DB_functions/p_goterm_not_obsolete.sql
+++ b/lib/DB_functions/p_goterm_not_obsolete.sql
@@ -13,7 +13,7 @@ declare ok boolean := (select term_is_obsolete
 begin
 if ok then
 
-  raise exception 'FAIL!: GO Term is OBSOLETE!';
+  raise exception 'FAIL!: GO Term is OBSOLETE! (%)', vGoTerm;
 
 elsif not ok then 
 

--- a/server_apps/DB_maintenance/build.xml
+++ b/server_apps/DB_maintenance/build.xml
@@ -73,6 +73,17 @@
     </target>
 
     <target name="load-gaf-goa" description="">
+        <echo message="Running GafLoadJob with arguments:"/>
+        <echo message="  propertyFilePath: ${web-inf.dir}/zfin.properties"/>
+        <echo message="  baseDir: ${validateData}/gafLoad"/>
+        <echo message="  jobName: ${jobName}"/>
+        <echo message="  organization: GOA"/>
+        <echo message="  downloadUrl: ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/ZEBRAFISH/goa_zebrafish.gaf.gz"/>
+        <echo message="  parserClassName: org.zfin.datatransfer.go.GoaGafParser"/>
+        <echo message="  downloadUrl2: ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/ZEBRAFISH/goa_zebrafish_isoform.gaf.gz"/>
+        <echo message="  downloadUrl3: ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/ZEBRAFISH/goa_zebrafish_rna.gaf.gz"/>
+        <echo message="  log4j jvm arg: ${jvm.arg.log4j}"/>
+
         <java classname="org.zfin.datatransfer.go.service.GafLoadJob"
               fork="yes"
               classpathref="extended.classpath"

--- a/source/org/zfin/datatransfer/go/GafEntry.java
+++ b/source/org/zfin/datatransfer/go/GafEntry.java
@@ -1,5 +1,8 @@
 package org.zfin.datatransfer.go;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.util.List;
 
 /**
@@ -7,14 +10,20 @@ import java.util.List;
  * <p/>
  * should have 17 columns
  */
+@Getter
+@Setter
 public class GafEntry {
 
+    ////////////////////////// // 1-based indexes
     private String entryId; // 2
+    private String markerAbbrev; // 3 //Added for ZFIN-8035
     private String qualifier; // 4
     private String goTermId;  // 5
     private String pubmedId;  // 6
     private String evidenceCode;  // 7
     private String inferences; // 8
+    private String dbObjectName; // 10 //Added for ZFIN-8035 debugging
+    private String dbObjectSynonym; // 11 //Added for ZFIN-8035 debugging
     private String taxonId; //13
     private String createdDate; //14
     private String createdBy; //15
@@ -29,165 +38,21 @@ public class GafEntry {
     private int col8both;
 
 
-    public int getCol8pipes() {
-        return col8pipes;
-    }
-
-    public void setCol8pipes(int col8pipes) {
-        this.col8pipes = col8pipes;
-    }
-
-
-    public int getCol8both() {
-        return col8both;
-    }
-
-    public void setCol8both(int col8both) {
-        this.col8both = col8both;
-    }
-
-
-
-    public int getCol8commas() {
-        return col8commas;
-    }
-
-    public void setCol8commas(int col8commas) {
-        this.col8commas = col8commas;
-    }
-
-    public String getEntryId() {
-        return entryId;
-    }
-
-    public void setEntryId(String uniprotId) {
-        this.entryId = uniprotId;
-    }
-
-    public String getQualifier() {
-        return qualifier;
-    }
-
-    public void setQualifier(String qualifier) {
-        this.qualifier = qualifier;
-    }
-
-    public String getGoTermId() {
-        return goTermId;
-    }
-
-    public void setGoTermId(String goTermId) {
-        this.goTermId = goTermId;
-    }
-
-    public String getPubmedId() {
-        return pubmedId;
-    }
-
-    public void setPubmedId(String pubmedId) {
-        this.pubmedId = pubmedId;
-    }
-
-    public String getEvidenceCode() {
-        return evidenceCode;
-    }
-
-    public void setEvidenceCode(String evidenceCode) {
-        this.evidenceCode = evidenceCode;
-    }
-
-    public String getInferences() {
-        return inferences;
-    }
-
-    public void setInferences(String inferences) {
-        this.inferences = inferences;
-    }
-
-    public String getTaxonId() {
-        return taxonId;
-    }
-
-    public void setTaxonId(String taxonId) {
-        this.taxonId = taxonId;
-    }
-
-    public String getCreatedDate() {
-        return createdDate;
-    }
-
-    public void setCreatedDate(String createdDate) {
-        this.createdDate = createdDate;
-    }
-
-    public String getCreatedBy() {
-        return createdBy;
-    }
-
-    public void setCreatedBy(String createdBy) {
-        this.createdBy = createdBy;
-    }
-
-    public String getAnnotExtn() {
-        return annotExtn;
-    }
-
-    public void setAnnotExtn(String annotExtn) {
-        this.annotExtn = annotExtn;
-    }
-
-   public String getGeneProductFormID() {
-        return geneProductFormID;
-    }
-
-    public void setGeneProductFormID(String geneProductFormID) {
-        this.geneProductFormID = geneProductFormID;
-    }
-
-
-
-    public String getModelID() {
-        return modelID;
-    }
-
-    public void setModelID(String modelID) {
-        this.modelID = modelID;
-    }
-
-    public List<GafAnnotationGroup> getAnnotationGroups() {
-        return annotationGroups;
-    }
-
-    public void setAnnotationGroups(List<GafAnnotationGroup> annotationGroups) {
-        this.annotationGroups = annotationGroups;
-    }
-
-    public String getAnnotationProperties() {
-        return annotationProperties;
-    }
-
-    public void setAnnotationProperties(String annotationProperties) {
-        this.annotationProperties = annotationProperties;
-    }
-
-
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("GafEntry");
-        sb.append("{entryId='").append(entryId).append('\'');
-        sb.append(", qualifier='").append(qualifier).append('\'');
-        sb.append(", goid='").append(goTermId).append('\'');
-        sb.append(", pmid='").append(pubmedId).append('\'');
-        sb.append(", evidenceCode='").append(evidenceCode).append('\'');
-        sb.append(", inferences='").append(inferences).append('\'');
-        sb.append(", taxonID='").append(taxonId).append('\'');
-        sb.append(", createdDate='").append(createdDate).append('\'');
-        sb.append(", createdBy='").append(createdBy).append('\'');
-        sb.append(", annotExtn='").append(annotExtn).append('\'');
-        sb.append(", geneProducFormID='").append(geneProductFormID).append('\'');
-        sb.append('}').append("\n");
-        return sb.toString();
+        return "GafEntry" +
+                "{entryId='" + entryId + '\'' +
+                ", qualifier='" + qualifier + '\'' +
+                ", goid='" + goTermId + '\'' +
+                ", pmid='" + pubmedId + '\'' +
+                ", evidenceCode='" + evidenceCode + '\'' +
+                ", inferences='" + inferences + '\'' +
+                ", taxonID='" + taxonId + '\'' +
+                ", createdDate='" + createdDate + '\'' +
+                ", createdBy='" + createdBy + '\'' +
+                ", annotExtn='" + annotExtn + '\'' +
+                ", geneProducFormID='" + geneProductFormID + '\'' +
+                '}' + "\n";
     }
 
     //FB case 8432 prevent GO annotation to GO:0005623 from FP-Inf. GAF load
@@ -195,5 +60,25 @@ public class GafEntry {
         return goTermId.equalsIgnoreCase("GO:0005623");
     }
 
+    /**
+     * Creates a key for a gafEntry for indexing in a hash. We use this to determine if a gaf entry
+     * that we are adding is essentially a duplicate of an existing gaf entry.  We then retain the gaf
+     * entry that has the most information (geneProductFormID).
+     *
+     * @return Key for gafEntry
+     */
+    public String getSimilarityHash() {
+        return (getQualifier() == null ? "NULL" : getQualifier()) +
+                (getMarkerAbbrev() == null ? "NULL" : getMarkerAbbrev()) +
+                (getGoTermId() == null ? "NULL" : getGoTermId()) +
+                (getEvidenceCode() == null ? "NULL" : getEvidenceCode()) +
+                (getPubmedId() == null ? "NULL" : getPubmedId()) +
+                (getInferences() == null ? "NULL" : getInferences()) +
+                (getDbObjectName() == null ? "NULL" : getDbObjectName()) +
+                (getDbObjectSynonym() == null ? "NULL" : getDbObjectSynonym()) +
+                (getTaxonId() == null ? "NULL" : getTaxonId()) +
+                (getCreatedBy() == null ? "NULL" : getCreatedBy()) +
+                (getCreatedDate() == null ? "NULL" : getCreatedDate());
+    }    
 
 }

--- a/source/org/zfin/datatransfer/go/service/GafService.java
+++ b/source/org/zfin/datatransfer/go/service/GafService.java
@@ -92,7 +92,6 @@ public class GafService {
     }
 
     public void processEntries(List<GafEntry> gafEntries, GafJobData gafJobData) {
-
         GafOrganization gafOrganization =
                 markerGoTermEvidenceRepository.getGafOrganization(organizationEnum);
 

--- a/source/org/zfin/db/postGmakePostloaddb/1133/ZFIN-7977-2.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1133/ZFIN-7977-2.sql
@@ -1,0 +1,94 @@
+--liquibase formatted sql
+--changeset rtaylor:ZFIN-7977-2
+
+-- Set the new protein_accession column to the correct value based on table joins
+WITH mgte_joined_to_db_link AS (
+    SELECT m.mrkrgoev_zdb_id,
+           fdb_db_name || ':' ||	dbl.dblink_acc_num as accession
+    FROM
+        marker_go_term_evidence m,
+        db_link dbl,
+        foreign_db_contains fdbc,
+        foreign_db fdb,
+        term
+    WHERE dblink_zdb_id IS NOT NULL AND mrkrgoev_protein_accession IS NULL
+      AND mrkrgoev_protein_dblink_zdb_id = dbl.dblink_zdb_id
+      AND dbl.dblink_fdbcont_zdb_id = fdbc.fdbcont_zdb_id
+      AND fdbc.fdbcont_fdb_db_id = fdb.fdb_db_pk_id
+      AND mrkrgoev_term_zdb_id = term.term_zdb_id
+      AND NOT term_is_obsolete
+)
+UPDATE marker_go_term_evidence mgte
+    SET mrkrgoev_protein_accession = mgte_joined_to_db_link.accession
+    FROM mgte_joined_to_db_link
+    WHERE mgte.mrkrgoev_zdb_id = mgte_joined_to_db_link.mrkrgoev_zdb_id;
+
+DROP TABLE IF EXISTS tmp_to_delete_marker_go_term_evidence;
+
+-- DELETE duplicates from marker_go_term_evidence (matches rows with same fields listed in partition clause)
+-- this will match exact duplicates in the mrkrgoev_protein_accession field (among other fields)
+SELECT * INTO tmp_to_delete_marker_go_term_evidence FROM marker_go_term_evidence WHERE mrkrgoev_zdb_id IN (
+    SELECT mrkrgoev_zdb_id
+    FROM (
+        SELECT
+            mrkrgoev_zdb_id,
+            row_number() OVER (PARTITION BY
+                mrkrgoev_mrkr_zdb_id,
+                mrkrgoev_source_zdb_id,
+                mrkrgoev_evidence_code,
+                mrkrgoev_notes,
+                mrkrgoev_contributed_by,
+                mrkrgoev_modified_by,
+                mrkrgoev_gflag_name,
+                mrkrgoev_term_zdb_id,
+                mrkrgoev_annotation_organization,
+                mrkrgoev_annotation_organization_created_by,
+                mrkrgoev_relation_term_zdb_id,
+                mrkrgoev_relation_qualifier,
+                mrkrgoev_tag_submit_format,
+                mrkrgoev_protein_accession
+                ORDER BY mrkrgoev_zdb_id) AS row_num
+        FROM "public"."marker_go_term_evidence") AS subquery
+    WHERE row_num > 1);
+
+
+-- Similar to above, but need to handle case of nulls for accession
+-- so this will delete any duplicates where each field matches, but one row contains null protein_accession
+INSERT INTO tmp_to_delete_marker_go_term_evidence
+SELECT * FROM marker_go_term_evidence
+WHERE
+        mrkrgoev_zdb_id NOT IN ( select mrkrgoev_zdb_id from tmp_to_delete_marker_go_term_evidence )
+  AND
+        mrkrgoev_zdb_id IN (
+        SELECT mrkrgoev_zdb_id
+        FROM (
+                 SELECT
+                     mrkrgoev_zdb_id,
+                     mrkrgoev_protein_accession,
+                     row_number() OVER (PARTITION BY
+                    mrkrgoev_mrkr_zdb_id,
+                    mrkrgoev_source_zdb_id,
+                    mrkrgoev_evidence_code,
+                    mrkrgoev_notes,
+                    mrkrgoev_contributed_by,
+                    mrkrgoev_modified_by,
+                    mrkrgoev_gflag_name,
+                    mrkrgoev_term_zdb_id,
+                    mrkrgoev_annotation_organization,
+                    mrkrgoev_annotation_organization_created_by,
+                    mrkrgoev_relation_term_zdb_id,
+                    mrkrgoev_relation_qualifier,
+                    mrkrgoev_tag_submit_format
+                    ORDER BY mrkrgoev_protein_accession, mrkrgoev_zdb_id) AS row_num
+                 FROM "public"."marker_go_term_evidence") AS subquery
+        WHERE row_num > 1
+          AND mrkrgoev_protein_accession IS NULL );
+
+-- ==== find out if other DB tables depend on the rows to delete =====
+select * from inference_group_member where infgrmem_mrkrgoev_zdb_id in (select mrkrgoev_zdb_id from tmp_to_delete_marker_go_term_evidence);
+select * from noctua_model_annotation where nma_mrkrgoev_zdb_id in (select mrkrgoev_zdb_id from tmp_to_delete_marker_go_term_evidence);
+select * from marker_go_term_annotation_extension_group where mgtaeg_mrkrgoev_zdb_id in (select mrkrgoev_zdb_id from tmp_to_delete_marker_go_term_evidence);
+
+-- ===== do the delete =======
+DELETE FROM marker_go_term_evidence where mrkrgoev_zdb_id in
+      (select mrkrgoev_zdb_id from tmp_to_delete_marker_go_term_evidence);

--- a/source/org/zfin/db/postGmakePostloaddb/1133/ZFIN-7977.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1133/ZFIN-7977.sql
@@ -7,4 +7,3 @@ ALTER TABLE marker_go_term_evidence ADD COLUMN mrkrgoev_protein_accession text;
 CREATE INDEX "mrkrgoev_protein_accession_index" ON "public"."marker_go_term_evidence" USING btree (
     "mrkrgoev_protein_accession" COLLATE "pg_catalog"."default" "pg_catalog"."text_ops" ASC NULLS LAST
     );
-

--- a/source/org/zfin/db/postGmakePostloaddb/1133/db.changelog.master.xml
+++ b/source/org/zfin/db/postGmakePostloaddb/1133/db.changelog.master.xml
@@ -6,6 +6,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <include file="source/org/zfin/db/postGmakePostloaddb/1133/ZFIN-7977.sql" />
+    <include file="source/org/zfin/db/postGmakePostloaddb/1133/ZFIN-7977-2.sql" />
     <include file="source/org/zfin/db/postGmakePostloaddb/1133/ZFIN-7979.sql" />
     <include file="source/org/zfin/db/postGmakePostloaddb/1133/ZFIN-7922.sql" />
     <include file="source/org/zfin/db/postGmakePostloaddb/1133/ZFIN-7812.xml" />


### PR DESCRIPTION
ZFIN-8035: Handle duplicate entries that are imported in GAF-GOA Load and show up in the gene-association export

When adding new column, populate it with default values.
In liquibase file, add some deduplication logic for rows that are identical except for a null value in protein_accession_number (dropping the null row).
Avoid adding duplicates when building the list of GafEntries in the gaf input parser. Favor the duplicate with the geneProductFormID.