### PR TITLE
ZFIN-8057: Fix external links that really on popovers.

### DIFF
--- a/home/WEB-INF/tags/layout/otherPagesDropdown.tag
+++ b/home/WEB-INF/tags/layout/otherPagesDropdown.tag
@@ -6,7 +6,6 @@
         type="button"
         data-toggle="dropdown"
         data-boundary="window"                      <%-- these settings prevent the popup from being cut off --%>
-        data-popper-config="{positionFixed: true}"  <%-- by the table horizontal scrolling container --%>
     >
         <i class="fas fa-link"></i>
     </button>

--- a/source/org/zfin/marker/presentation/ProteinDomainBean.java
+++ b/source/org/zfin/marker/presentation/ProteinDomainBean.java
@@ -6,32 +6,10 @@ import lombok.Setter;
 
 /**
  */
+@Setter
+@Getter
 public class ProteinDomainBean {
     private String ipID;
     private String ipName;
     private String ipType;
-
-    public String getIpID() {
-        return ipID;
-    }
-
-    public void setIpID(String ipID) {
-        this.ipID = ipID;
-    }
-
-    public String getIpName() {
-        return ipName;
-    }
-
-    public void setIpName(String ipName) {
-        this.ipName = ipName;
-    }
-
-    public String getIpType() {
-        return ipType;
-    }
-
-    public void setIpType(String ipType) {
-        this.ipType = ipType;
-    }
 }


### PR DESCRIPTION
Drop the positionFixed:True config option since it seems to no longer be supported.
https://getbootstrap.com/docs/4.1/components/popovers/

Convert class to lombok-style getters and setters.