### PR TITLE
Fix liquibase issue that was throwing an exception

### DIFF
--- a/source/org/zfin/db/postGmakePostloaddb/1133/ZFIN-7977-2.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1133/ZFIN-7977-2.sql
@@ -17,6 +17,7 @@ WITH mgte_joined_to_db_link AS (
       AND fdbc.fdbcont_fdb_db_id = fdb.fdb_db_pk_id
       AND mrkrgoev_term_zdb_id = term.term_zdb_id
       AND NOT term_is_obsolete
+      AND NOT term_is_secondary
 )
 UPDATE marker_go_term_evidence mgte
     SET mrkrgoev_protein_accession = mgte_joined_to_db_link.accession


### PR DESCRIPTION
Fix liquibase issue that was throwing an exception with message 
"ERROR: FAIL!: GO Term is SECONDARY!"

See:
https://trunk.zfin.org/build/job/1.%20TRUNK%20load%20liquibase/2033/console