### PR TITLE
ZFIN-8029: Prefix the path to apiToken.txt with TARGETROOT.

### DIFF
--- a/source/org/zfin/alliancegenome/RestAllianceService.java
+++ b/source/org/zfin/alliancegenome/RestAllianceService.java
@@ -1,6 +1,7 @@
 package org.zfin.alliancegenome;
 
 import lombok.extern.log4j.Log4j2;
+import org.zfin.properties.ZfinPropertiesEnum;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -17,14 +18,14 @@ public class RestAllianceService {
 
     static {
         try {
-            token = new String(Objects.requireNonNull(getToken()).getBytes("ISO8859-1"), StandardCharsets.UTF_8);
+            token = new String(Objects.requireNonNull(getToken(), "Please Provide API Token for Alliance").getBytes("ISO8859-1"), StandardCharsets.UTF_8);
         } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
         }
     }
 
     private static String getToken() {
-        Path file = Path.of("server_apps/DB_maintenance/Alliance/apiToken.txt");
+        Path file = Path.of(ZfinPropertiesEnum.TARGETROOT.value() + "/server_apps/DB_maintenance/Alliance/apiToken.txt");
         try {
             return Files.readString(file);
         } catch (IOException e) {


### PR DESCRIPTION
Seems like the path for the apiToken.txt was from the file system root.
I added the target_root to the path and manually created an apiToken.txt.
Is there a better way to handle the api token? Perhaps another entry in
the env file?