### PR TITLE
ZFIN-8052

### DIFF
--- a/server_apps/data_transfer/GO/gofile.sql
+++ b/server_apps/data_transfer/GO/gofile.sql
@@ -110,6 +110,6 @@ update tmp_go
 update tmp_go
 set mv_created_by='UniProt' where mv_created_by='UniProtKB';
 
-\copy (select * from tmp_go) to '<!--|ROOT_PATH|-->/server_apps/data_transfer/GO/go.zfin' with delimiter as '	' null as '';
+\copy (select * from tmp_go order by mv_zdb_id) to '<!--|ROOT_PATH|-->/server_apps/data_transfer/GO/go.zfin' with delimiter as '	' null as '';
 
 commit work;

--- a/server_apps/data_transfer/GO/goparser.pl
+++ b/server_apps/data_transfer/GO/goparser.pl
@@ -46,6 +46,7 @@ while ($line = <INDEXFILE>) {
       @fields = split /\t/, $line;
       $mrkrgoev=$fields[0];
 
+      #this logic assumes the input file is sorted by mrkrgoev_zdb_id
       if ($lastmrkrgoev ne '' && $mrkrgoev ne $lastmrkrgoev) {
 
 


### PR DESCRIPTION
Add an explicit sort to the output to go.zfin file since the goparser.pl file depends on all rows with the same mrkrgoev_zdb_id to be grouped together.