### PR TITLE
ZFIN-8115: Fix failing tests (Release-1133)

### DIFF
--- a/server_apps/data_transfer/SWISS-PROT/pre_loadsp.pl
+++ b/server_apps/data_transfer/SWISS-PROT/pre_loadsp.pl
@@ -317,7 +317,7 @@ print "\nNumber of manually curated UniProt IDs: $ctManuallyEnteredUniProtIDs at
 
 my $uniprotId;
 my $url;
-my $uniProtURL = "https://www.uniprot.org/uniprot/";
+my $uniProtURL = "https://rest.uniprot.org/uniprotkb/";
 
 if ($ENV{"SKIP_MANUAL_CHECK"}) {
     print("Skipping check for invalid manually entered uniprot IDs\n");

--- a/source/org/zfin/db/postGmakePostloaddb/1134/ZFIN-8115.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1134/ZFIN-8115.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--changeset rtaylor:ZFIN-8115
+
+-- Use the rest API url for validating uniprot ids
+UPDATE "public"."foreign_db" SET "fdb_db_query" = 'https://rest.uniprot.org/uniprotkb/'
+WHERE "fdb_db_pk_id" = 40
+AND "fdb_db_query" = 'http://www.uniprot.org/uniprot/';

--- a/source/org/zfin/db/postGmakePostloaddb/1134/db.changelog.master.xml
+++ b/source/org/zfin/db/postGmakePostloaddb/1134/db.changelog.master.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <include file="source/org/zfin/db/postGmakePostloaddb/1134/ZFIN-8115.sql" />
+
+
+</databaseChangeLog>

--- a/source/org/zfin/db/postGmakePostloaddb/db.changelog.master.xml
+++ b/source/org/zfin/db/postGmakePostloaddb/db.changelog.master.xml
@@ -74,5 +74,6 @@
     <include file="source/org/zfin/db/postGmakePostloaddb/1131/db.changelog.master.xml"/>
     <include file="source/org/zfin/db/postGmakePostloaddb/1132/db.changelog.master.xml"/>
     <include file="source/org/zfin/db/postGmakePostloaddb/1133/db.changelog.master.xml"/>
+    <include file="source/org/zfin/db/postGmakePostloaddb/1134/db.changelog.master.xml"/>
 <!-- starting fresh with migration to postgres -->
 </databaseChangeLog>

--- a/source/org/zfin/marker/repository/HibernateMarkerRepository.java
+++ b/source/org/zfin/marker/repository/HibernateMarkerRepository.java
@@ -877,6 +877,7 @@ public class HibernateMarkerRepository implements MarkerRepository {
 
         Criteria criteria = session.createCriteria(MarkerLocation.class);
         criteria.add(Restrictions.eq("marker.zdbID", zdbID));
+        criteria.addOrder(Property.forName("zdbID").asc());
 
         return (List<MarkerLocation>) criteria.list();
     }

--- a/test/org/zfin/gwt/marker/GoEvidenceTest.java
+++ b/test/org/zfin/gwt/marker/GoEvidenceTest.java
@@ -44,7 +44,7 @@ public class GoEvidenceTest extends AbstractDatabaseTest {
         assertNotNull(goEvidenceDTO.getInferredFrom());
         assertEquals(1,goEvidenceDTO.getInferredFrom().size());
 
-        String zdbID1 = "ZDB-MRKRGOEV-210304-3287" ;
+        String zdbID1 = "ZDB-MRKRGOEV-220118-132028" ;
         goEvidenceDTO = markerRPCService.getMarkerGoTermEvidenceDTO(zdbID1) ;
         assertNotNull(goEvidenceDTO);
         assertEquals(zdbID1,goEvidenceDTO.getZdbID());

--- a/test/org/zfin/mapping/MappingServiceTest.java
+++ b/test/org/zfin/mapping/MappingServiceTest.java
@@ -90,10 +90,11 @@ public class MappingServiceTest extends AbstractDatabaseTest {
         assertEquals(retrievedMarkerLocations.size(), initialSize + 1);
 
         MarkerLocation retrievedMarkerLocation = retrievedMarkerLocations.get(initialSize);
-
+        
+        assertEquals(retrievedMarkerLocation.getZdbID(), markerLocation.getZdbID());
         assertEquals(retrievedMarkerLocation.getAssembly(), clb.getAssembly());
-        assertEquals(retrievedMarkerLocation.getStartLocation(), clb.getStartLocation());
-        assertEquals(retrievedMarkerLocation.getEndLocation(), clb.getEndLocation());
+        assertEquals(retrievedMarkerLocation.getStartLocation().longValue(), clb.getStartLocation().longValue());
+        assertEquals(retrievedMarkerLocation.getEndLocation().longValue(), clb.getEndLocation().longValue());
 
     }
 

--- a/test/org/zfin/mutant/repository/MarkerGoTermEvidenceRepositoryTest.java
+++ b/test/org/zfin/mutant/repository/MarkerGoTermEvidenceRepositoryTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.*;
 
 /**
@@ -69,7 +70,7 @@ public class MarkerGoTermEvidenceRepositoryTest extends AbstractDatabaseTest {
         String pubId = "ZDB-PUB-160828-8";
         List<MarkerGoTermEvidence> evidences = markerGoTermEvidenceRepository.getMarkerGoTermEvidencesForPubZdbID(pubId);
         assertNotNull(evidences);
-        assertThat(evidences.size(), greaterThan(2));
+        assertThat(evidences.size(), greaterThanOrEqualTo(2));
     }
 
     @Test


### PR DESCRIPTION
ZFIN-8115: Fix failing test.

This commit fixes an issue with NCBI fetch that was needed due to external web server changes.  It shows up in the NCBI load and causes ZFIN-7925 to fail.

- Use the rest API url for validating uniprot ids (https://www.uniprot.org/help/api_retrieve_entries).
- Use InputStreams to eager fetch with HttpClient before closing connection.
- Update tests to match changes in ZFIN-8052.
- Add explicit ordering to getMarkerLocation (by zdbID).
- Update uniprot API URL for perl.