### PR TITLE
ZFIN-8154: Fix UniProt links

### DIFF
--- a/source/org/zfin/db/postGmakePostloaddb/1134/ZFIN-8154.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1134/ZFIN-8154.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+--changeset rtaylor:ZFIN-8154
+
+-- Revert 8115
+
+update foreign_db set fdb_db_query = 'http://www.uniprot.org/uniprot/'
+where fdb_db_query = 'https://rest.uniprot.org/uniprotkb/'
+  and fdb_db_pk_id = 40;

--- a/source/org/zfin/db/postGmakePostloaddb/1134/db.changelog.master.xml
+++ b/source/org/zfin/db/postGmakePostloaddb/1134/db.changelog.master.xml
@@ -6,6 +6,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <include file="source/org/zfin/db/postGmakePostloaddb/1134/ZFIN-8115.sql" />
+    <include file="source/org/zfin/db/postGmakePostloaddb/1134/ZFIN-8154.sql" />
 
 
 </databaseChangeLog>

--- a/source/org/zfin/sequence/service/UniprotService.java
+++ b/source/org/zfin/sequence/service/UniprotService.java
@@ -17,7 +17,7 @@ import java.io.IOException;
  */
 //@Service
 public class UniprotService {
-
+    private static final String UNIPROT_BASE_URL = "https://rest.uniprot.org/uniprotkb/";
     private Logger logger = LogManager.getLogger(UniprotService.class) ;
 
     //    @Autowired
@@ -35,20 +35,11 @@ public class UniprotService {
 
     }
 
-    public String getUniprotBaseUrl() {
-        if(uniprotUrl==null){
-            HibernateUtil.currentSession().refresh(uniprotReferenceDatabase);
-            uniprotUrl = uniprotReferenceDatabase.getBaseURL();
-        }
-        return uniprotUrl;
-    }
-
     public Boolean validateAgainstUniprotWebsite(String accession) {
-
 
         DefaultHttpClient client = new DefaultHttpClient();
         try {
-            HttpResponse response = client.execute(new HttpGet(getUniprotBaseUrl() + accession));
+            HttpResponse response = client.execute(new HttpGet(UNIPROT_BASE_URL + accession));
             int statusCode = response.getStatusLine().getStatusCode();
             boolean isOk = (statusCode == HttpStatus.SC_OK);
             if (!isOk) {


### PR DESCRIPTION
Fix UniProt links out and retain fixes to the UniProt tests for UniProt accession validation.