### PR TITLE
UniProt: Fail gracefully, other tweaks

### DIFF
--- a/server_apps/ZFINPerlModules.pm
+++ b/server_apps/ZFINPerlModules.pm
@@ -5,7 +5,7 @@ use strict;
 use MIME::Lite;
 use DBI;
 use Exporter 'import';
-our @EXPORT_OK = qw(md5_file assert_environment trim assert_file_exists);
+our @EXPORT_OK = qw(md5File assertEnvironment trim assertFileExists getPropertyValue downloadOrUseLocalFile doSystemCommand doSystemCommandOrFailWithEmail);
 
 my %monthDisplays = (
     "Jan" => "01",
@@ -33,7 +33,7 @@ my $WHIRLEY_TIME_LIMIT = 10;
 
 sub doSystemCommand {                  
 
-  my $systemCommand = $_[1];               
+  my $systemCommand = $_[1];
 
   print "Executing [$systemCommand] \n";
 
@@ -42,8 +42,22 @@ sub doSystemCommand {
   if ( $returnCode != 0 ) {
     exit -1;
   }
-} 
+}
 
+sub doSystemCommandOrFailWithEmail {
+    my $systemCommand = shift();
+    my $email = shift();
+    my $subject = shift();
+    my $textFile = shift();
+
+    print "Executing [$systemCommand] \n";
+    my $returnCode = system( $systemCommand );
+
+    if ( $returnCode != 0 ) {
+        ZFINPerlModules->sendMailWithAttachedReport($email, $subject, $textFile);
+        exit -1;
+    }
+}
 
 sub sendMailWithAttachedReport {
     my $MAILTO = $_[1];
@@ -175,24 +189,24 @@ sub printWhirleyToStderr {
 }
 
 
-sub md5_file {
+sub md5File {
     my $file = $_[0];
     my $hash = `md5sum '$file' | cut -d ' ' -f 1`;
     $hash =~ s/\s+$//;
     return $hash;
 }
 
-sub assert_environment {
+sub assertEnvironment {
     my @required_vars = @_;
     foreach my $var (@required_vars) {
-        if (!$var) {
+        if (!$ENV{$var}) {
             print("No $var environment variable defined\n");
             exit(2);
         }
     }
 }
 
-sub assert_file_exists {
+sub assertFileExists {
     my $filename = shift();
     my $error_message = shift();
 
@@ -212,6 +226,42 @@ sub trim {
     $s =~ s/\s*$//u;
 
     return $s;
+}
+
+sub getPropertyValue {
+    my $property_name = shift();
+    my $property_file = $ENV{'TARGETROOT'} . "/home/WEB-INF/zfin.properties";
+
+    open(PROPERTIES, $property_file) or die("Could not open $property_file");
+    while (<PROPERTIES>) {
+        chomp;
+        if ($_ =~ m/^$property_name=(.*)$/) {
+            close(PROPERTIES);
+            return $1;
+        }
+    }
+    close(PROPERTIES);
+}
+
+sub downloadOrUseLocalFile {
+    my ($url, $outfile) = @_;
+    if ($ENV{"SKIP_DOWNLOADS"}) {
+        print("Skipping download '$url' to '$outfile'\n");
+        my $outfileWithoutGz = $outfile  =~ s/\.gz$//r;
+        if (!-e $outfile && !-e $outfileWithoutGz) {
+            print "*************************************************\n";
+            print "* ERROR: The $outfile file does not exist, but we are running with SKIP_DOWNLOADS flag\n";
+            print "*************************************************\n";
+            exit -1;
+        } elsif (!-e $outfile && -e $outfileWithoutGz) {
+            print "$outfile file missing, continuing with $outfileWithoutGz\n";
+        }
+    } else {
+        print("Downloading '$url' to '$outfile'\n");
+
+        #set the number of bytes that a dot represents in wget progress bar to 10M
+        system("/local/bin/wget --progress=dot -e dotbytes=10M '$url' -O '$outfile'");
+    }
 }
 
 1;

--- a/server_apps/data_transfer/SWISS-PROT/pre_loadsp.pl
+++ b/server_apps/data_transfer/SWISS-PROT/pre_loadsp.pl
@@ -144,13 +144,16 @@ sub sendRunningResult {
 # Extracts only zfin data from vertebrates.
 #
 sub select_zebrafish {
+    my $cwd = `pwd`;
+    chomp $cwd;
+
     #where to find the uniprot files (can override with env var, for example with a file:/// URL)
     my $TREMBL_FILE_URL = "https://ftp.expasy.org/databases/uniprot/current_release/knowledgebase/taxonomic_divisions/uniprot_trembl_vertebrates.dat.gz";
     if ($ENV{'TREMBL_FILE_URL'}) {
         $TREMBL_FILE_URL = $ENV{'TREMBL_FILE_URL'};
     } elsif ($ENV{'SKIP_DOWNLOADS'}) {
         assertFileExists('./uniprot_trembl_vertebrates.dat.gz', 'Missing uniprot tremble file and SKIP_DOWNLOADS set to 1');
-        $TREMBL_FILE_URL = 'file://' . `pwd` . '/uniprot_trembl_vertebrates.dat.gz';
+        $TREMBL_FILE_URL = 'file://' . $cwd . '/uniprot_trembl_vertebrates.dat.gz';
     }
 
     my $SPROT_FILE_URL = "https://ftp.expasy.org/databases/uniprot/current_release/knowledgebase/taxonomic_divisions/uniprot_sprot_vertebrates.dat.gz";
@@ -158,7 +161,7 @@ sub select_zebrafish {
         $SPROT_FILE_URL = $ENV{'SPROT_FILE_URL'};
     } elsif ($ENV{'SKIP_DOWNLOADS'}) {
         assertFileExists('./uniprot_sprot_vertebrates.dat.gz', 'Missing uniprot tremble file and SKIP_DOWNLOADS set to 1');
-        $SPROT_FILE_URL = 'file://' . `pwd` . '/uniprot_sprot_vertebrates.dat.gz';
+        $SPROT_FILE_URL = 'file://' . $cwd . '/uniprot_sprot_vertebrates.dat.gz';
     }
 
     if ($ENV{'SKIP_PRE_ZFIN_GEN'}) {

--- a/server_apps/data_transfer/SWISS-PROT/pre_loadsp.pl
+++ b/server_apps/data_transfer/SWISS-PROT/pre_loadsp.pl
@@ -26,8 +26,8 @@ use POSIX;
 
 
 use lib $ENV{'ROOT_PATH'} . "/server_apps/";
-use ZFINPerlModules qw(assert_environment trim);
-assert_environment('ROOT_PATH', 'PGHOST', 'DB_NAME', 'SWISSPROT_EMAIL_ERR', 'SWISSPROT_EMAIL_REPORT');
+use ZFINPerlModules qw(assertEnvironment trim);
+assertEnvironment('ROOT_PATH', 'PGHOST', 'DB_NAME', 'SWISSPROT_EMAIL_ERR', 'SWISSPROT_EMAIL_REPORT');
 
 #------------------- Flush Output Buffer --------------
 $|=1;
@@ -149,7 +149,7 @@ sub select_zebrafish {
     if ($ENV{'TREMBL_FILE_URL'}) {
         $TREMBL_FILE_URL = $ENV{'TREMBL_FILE_URL'};
     } elsif ($ENV{'SKIP_DOWNLOADS'}) {
-        assert_file_exists('./uniprot_trembl_vertebrates.dat.gz', 'Missing uniprot tremble file and SKIP_DOWNLOADS set to 1');
+        assertFileExists('./uniprot_trembl_vertebrates.dat.gz', 'Missing uniprot tremble file and SKIP_DOWNLOADS set to 1');
         $TREMBL_FILE_URL = 'file://' . `pwd` . '/uniprot_trembl_vertebrates.dat.gz';
     }
 
@@ -157,7 +157,7 @@ sub select_zebrafish {
     if ($ENV{'SPROT_FILE_URL'}) {
         $SPROT_FILE_URL = $ENV{'SPROT_FILE_URL'};
     } elsif ($ENV{'SKIP_DOWNLOADS'}) {
-        assert_file_exists('./uniprot_sprot_vertebrates.dat.gz', 'Missing uniprot tremble file and SKIP_DOWNLOADS set to 1');
+        assertFileExists('./uniprot_sprot_vertebrates.dat.gz', 'Missing uniprot tremble file and SKIP_DOWNLOADS set to 1');
         $SPROT_FILE_URL = 'file://' . `pwd` . '/uniprot_sprot_vertebrates.dat.gz';
     }
 

--- a/server_apps/data_transfer/SWISS-PROT/protein_domain_info_load.pl
+++ b/server_apps/data_transfer/SWISS-PROT/protein_domain_info_load.pl
@@ -5,12 +5,15 @@
 # in order to load and update protein domain info stored in ZFIN database tables
 
 use DBI;
-use lib "<!--|ROOT_PATH|-->/server_apps/";
-use ZFINPerlModules;
 use Try::Tiny;
+use FindBin;
+use lib "$FindBin::Bin/../../";
+use ZFINPerlModules qw(assertEnvironment);
+assertEnvironment('ROOT_PATH', 'PGHOST', 'DB_NAME');
 
-$dbname = "<!--|DB_NAME|-->";
-my $dbhost = "<!--|PGHOST|-->";
+
+$dbname = "$ENV{'DB_NAME'}";
+my $dbhost = "$ENV{'PGHOST'}";
 $username = "";
 $password = "";
 
@@ -141,7 +144,7 @@ system("/bin/rm -f entry.list");
 system("/bin/rm -f domain.txt");
 
 ## download the Interpro file for protein domain summary
-system("/local/bin/wget ftp://ftp.ebi.ac.uk/pub/databases/interpro/current/entry.list");
+system("/local/bin/wget ftp://ftp.ebi.ac.uk/pub/databases/interpro/current_release/entry.list");
 
 open (DOMAINS, "entry.list") || die "Cannot open entry.list : $!\n";
 open (DOMAINOUT, ">domain.txt") || die "Cannot open domain.txt : $!\n";
@@ -415,7 +418,7 @@ $dbh->disconnect();
 
 # execute the sql file to do the loading
 try {
-  system("psql -d <!--|DB_NAME|--> -a -f load_protein_domain_info.sql");
+  system("psql -v ON_ERROR_STOP=1 -d $ENV{'DB_NAME'} -a -f load_protein_domain_info.sql");
 } catch {
   warn "Failed to execute load_protein_domain.sql - $_";
   exit -1;
@@ -484,8 +487,8 @@ sub countData {
   my $ctsql = @_[0];
   my $nRecords = 0;
 
-  my $dbname = "<!--|DB_NAME|-->";
-  my $dbhost = "<!--|PGHOST|-->";
+  my $dbname = "$ENV{'DB_NAME'}";
+  my $dbhost = "$ENV{'PGHOST'}";
   my $username = "";
   my $password = "";
 

--- a/server_apps/data_transfer/SWISS-PROT/referenceProteome.pl
+++ b/server_apps/data_transfer/SWISS-PROT/referenceProteome.pl
@@ -12,22 +12,24 @@
 ## genes that have a protein ID of any kind and have xpat or phenotype and not associated with reference proteome
 
 use DBI;
-use lib "<!--|ROOT_PATH|-->/server_apps/";
-use ZFINPerlModules;
 use Try::Tiny;
+use FindBin;
+use lib "$FindBin::Bin/../../";
+use ZFINPerlModules qw(assertEnvironment);
+assertEnvironment('ROOT_PATH', 'PGHOST', 'DB_NAME');
 
 # set environment variables
 $ENV{"DBDATE"}="Y4MD-";
 $ENV{"CLIENT_LOCALE"}="en_US.utf8";
 $ENV{"DB_LOCALE"}="en_US.utf8";
 
-chdir "<!--|ROOT_PATH|-->/server_apps/data_transfer/SWISS-PROT/";
+chdir "$ENV{'ROOT_PATH'}/server_apps/data_transfer/SWISS-PROT/";
 
 system("/bin/rm -f *.tab");
 system("/bin/rm -f UP000000437_7955.fasta");
 
-$dbname = "<!--|DB_NAME|-->";
-my $dbhost = "<!--|PGHOST|-->";
+$dbname = "$ENV{'DB_NAME'}";
+my $dbhost = "$ENV{'PGHOST'}";
 
 $username = "";
 $password = "";
@@ -151,7 +153,7 @@ while(<FASTA>) {
 close(REFPR);
 
 try {
-  ZFINPerlModules->doSystemCommand("psql -d <!--|DB_NAME|--> -a -f referenceProteome.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d $ENV{'DB_NAME'} -a -f referenceProteome.sql");
 } catch {
   warn "Failed to execute referenceProteome.sql - $_";
   exit -1;

--- a/server_apps/data_transfer/SWISS-PROT/runUniprotPreload.sh
+++ b/server_apps/data_transfer/SWISS-PROT/runUniprotPreload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 #
 # Use environment variable "SKIP_DOWNLOADS" to not to download anything and instead assume files exist locally (will exit if no file exists)
 # Use environment variable "SKIP_MANUAL_CHECK" to not to scan uniprot for IDs gone bad
@@ -15,6 +15,8 @@
 #     ( setenv SKIP_MANUAL_CHECK 1 ; setenv SKIP_CLEANUP 1 ; setenv SKIP_SLEEP 1 ; setenv SKIP_PRE_ZFIN_GEN 1 ; setenv SKIP_DOWNLOADS 1 ; setenv ARCHIVE_ARTIFACTS 1; ./runUniprotPreload.sh )
 # or for bash:
 #     SKIP_MANUAL_CHECK=1 SKIP_CLEANUP=1 SKIP_SLEEP=1 SKIP_PRE_ZFIN_GEN=1 SKIP_DOWNLOADS=1 ARCHIVE_ARTIFACTS=1 ./runUniprotPreload.sh
+
+set -eo pipefail
 
 main() {
 echo "#########################################################################"
@@ -36,7 +38,7 @@ echo "run sp_match.pl manuallyCuratedUniProtIDs.txt " $(date "+%Y-%m-%d %H:%M:%S
 
 echo "copying generated preload files to network drive"
 
-/usr/bin/scp <!--|ROOT_PATH|-->/server_apps/data_transfer/SWISS-PROT/{okfile,ok2file,ec2go,interpro2go,spkw2go} /research/zarchive/load_files/UniProt/
+/usr/bin/scp "$ROOT_PATH"/server_apps/data_transfer/SWISS-PROT/{okfile,ok2file,ec2go,interpro2go,spkw2go} /research/zarchive/load_files/UniProt/
 
 echo "#########################################################################"
 echo "## FINISHED runUniprotPreload.sh "      $(date "+%Y-%m-%d %H:%M:%S")

--- a/server_apps/data_transfer/SWISS-PROT/runUniprotProd.sh
+++ b/server_apps/data_transfer/SWISS-PROT/runUniprotProd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 # $1 is the location on dev system where we should copy
 # the *2go and ok* files to do the run on almost and production
@@ -10,23 +10,24 @@
 # Can run with those env vars in tcsh like so: (https://stackoverflow.com/questions/5946736/)
 #     (  setenv SKIP_CLEANUP 1; ./runUniprotProd.sh )
 
-main() {
+set -eo pipefail
 
+main() {
 
 if [ -z "$SKIP_CLEANUP" ]
 then
 	echo "#########################################################################"
 	echo "Remove old files: okfile, *2go " $(date "+%Y-%m-%d %H:%M:%S")
-	/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/okfile
-	/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/ok2file
-	/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/ec2go
-	/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/interpro2go
-	/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/spkw2go
-	/bin/rm -f <!--|TARGETROOT|-->/server_apps/data_transfer/SWISS-PROT/*.txt
+	/bin/rm -f "$TARGETROOT/server_apps/data_transfer/SWISS-PROT/okfile"
+	/bin/rm -f "$TARGETROOT/server_apps/data_transfer/SWISS-PROT/ok2file"
+	/bin/rm -f "$TARGETROOT/server_apps/data_transfer/SWISS-PROT/ec2go"
+	/bin/rm -f "$TARGETROOT/server_apps/data_transfer/SWISS-PROT/interpro2go"
+	/bin/rm -f "$TARGETROOT/server_apps/data_transfer/SWISS-PROT/spkw2go"
+	/bin/rm -f "$TARGETROOT/server_apps/data_transfer/SWISS-PROT/*.txt"
 	echo "#########################################################################"
 
 	echo "Copy new files from /research/zarchive/load_files/UniProt/" 
-	/usr/bin/scp /research/zarchive/load_files/UniProt/* <!--|ROOT_PATH|-->/server_apps/data_transfer/SWISS-PROT/
+	/usr/bin/scp /research/zarchive/load_files/UniProt/* "$ROOT_PATH/server_apps/data_transfer/SWISS-PROT/"
 else
 	echo "Skipping copying files from server " $(date "+%Y-%m-%d %H:%M:%S")
 fi
@@ -48,7 +49,7 @@ echo "running protein_domain_info_load.pl " $(date "+%Y-%m-%d %H:%M:%S")
 ./protein_domain_info_load.pl ;
 
 echo "running go.pl " $(date "+%Y-%m-%d %H:%M:%S")
-cd <!--|TARGETROOT|-->/server_apps/data_transfer/GO;
+cd "$TARGETROOT/server_apps/data_transfer/GO";
 ./go.pl ;
 
 echo "#########################################################################"

--- a/server_apps/data_transfer/SWISS-PROT/sp_badgo_report.pl
+++ b/server_apps/data_transfer/SWISS-PROT/sp_badgo_report.pl
@@ -12,7 +12,10 @@
 # bigger, might better use loop.) 
 #
 use MIME::Lite;
-
+use FindBin;
+use lib "$FindBin::Bin/../../";
+use ZFINPerlModules qw(assertEnvironment);
+assertEnvironment('GO_EMAIL_CURATOR');
 
 #------------------ Send GO Result ----------------
 # No parameter
@@ -20,7 +23,7 @@ use MIME::Lite;
 sub sendGOResult {
 
   my $SUBJECT="Auto: Obsolete/secondary GO term in translation files";
-  my $MAILTO="<!--|GO_EMAIL_CURATOR|-->";     
+  my $MAILTO="$ENV{'GO_EMAIL_CURATOR'}";     
 
   # Create another new multipart message:
   $msg4 = new MIME::Lite 

--- a/server_apps/data_transfer/SWISS-PROT/sp_badgo_report_ec2gopart.pl
+++ b/server_apps/data_transfer/SWISS-PROT/sp_badgo_report_ec2gopart.pl
@@ -9,7 +9,10 @@
 # categories.
 #
 use MIME::Lite;
-
+use FindBin;
+use lib "$FindBin::Bin/../../";
+use ZFINPerlModules qw(assertEnvironment);
+assertEnvironment('GO_EMAIL_CURATOR');
 
 #------------------ Send GO Result ----------------
 # No parameter
@@ -17,7 +20,7 @@ use MIME::Lite;
 sub sendGOResult {
 
   my $SUBJECT="Auto: Obsolete/secondary GO term in ec2to translation file";
-  my $MAILTO="<!--|GO_EMAIL_CURATOR|-->";     
+  my $MAILTO="$ENV{'GO_EMAIL_CURATOR'}";     
 
 print "\n\nemail to : $MAILTO \n\n";
 

--- a/server_apps/data_transfer/SWISS-PROT/sp_check.pl
+++ b/server_apps/data_transfer/SWISS-PROT/sp_check.pl
@@ -19,8 +19,8 @@ use POSIX;
 
 
 use lib $ENV{'ROOT_PATH'} . "/server_apps/";
-use ZFINPerlModules qw(assert_environment md5_file);
-assert_environment('PGHOST','ROOT_PATH', 'DB_NAME');
+use ZFINPerlModules qw(assertEnvironment md5File);
+assertEnvironment('PGHOST','ROOT_PATH', 'DB_NAME');
 
 # Take a SP file as input (content format restricted).
 
@@ -42,7 +42,7 @@ my $dbh = DBI->connect("DBI:Pg:dbname=$dbname;host=$dbhost", $username, $passwor
 # if PubMed number not in zfin, output to a single file
 open PUB, ">pubmed_not_in_zfin" or die "Cannot open the pubmed_not_in_zfin:$!";
 
-my $zfin_dat_hash = md5_file('zfin.dat');
+my $zfin_dat_hash = md5File('zfin.dat');
 print "Processing zfin.dat (md5:$zfin_dat_hash) at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n";
 
 $/ = "//\n";

--- a/server_apps/data_transfer/SWISS-PROT/sp_load.sql
+++ b/server_apps/data_transfer/SWISS-PROT/sp_load.sql
@@ -399,7 +399,7 @@ and exists (Select 'x' from pre_marker_go_term_evidence
 				mrkrgoev_source_zdb_id, mrkrgoev_evidence_code,mrkrgoev_date_entered,mrkrgoev_date_modified,
 				mrkrgoev_annotation_organization,mrkrgoev_external_load_date,mrkrgoev_notes)
 		select DISTINCT p.pre_mrkrgoev_zdb_id, p.mrkr_zdb_id, p.go_zdb_id, p.mrkrgoev_source, 'IEA' as iea,
-		       now() as time1, now() as time2, '5' as org, now() as time3, p.mrkrgoev_note
+		       now() as time1, now() as time2, 5 as org, now() as time3, p.mrkrgoev_note
 		  from pre_marker_go_term_evidence p;
 --!echo '		into marker_go_term_evidence'
 	

--- a/server_apps/data_transfer/SWISS-PROT/sp_load_ec2gopart.sql
+++ b/server_apps/data_transfer/SWISS-PROT/sp_load_ec2gopart.sql
@@ -75,7 +75,7 @@ begin work;
 				mrkrgoev_source_zdb_id, mrkrgoev_evidence_code,
 				mrkrgoev_date_entered,mrkrgoev_date_modified,mrkrgoev_annotation_organization,mrkrgoev_external_load_date)
 		select p.mrkrgoev_zdb_id,p.mrkr_zdb_id, p.go_zdb_id,
-		       p.mrkrgoev_source, 'IEA' as iea, now() as time1, now() as time2, '5' as org, now() as time3
+		       p.mrkrgoev_source, 'IEA' as iea, now() as time1, now() as time2, 5 as org, now() as time3
 		  from pre_marker_go_evidence p
 		  where not exists (Select 'x' from marker a
 		  	    	   	   where a.mrkr_zdb_id = p.mrkr_zdb_id

--- a/server_apps/data_transfer/SWISS-PROT/sp_match.pl
+++ b/server_apps/data_transfer/SWISS-PROT/sp_match.pl
@@ -8,8 +8,8 @@
 
 use POSIX;
 use lib $ENV{'ROOT_PATH'} . "/server_apps/";
-use ZFINPerlModules qw(assert_environment);
-assert_environment('ROOT_PATH', 'DB_NAME', 'SWISSPROT_EMAIL_REPORT');
+use ZFINPerlModules qw(assertEnvironment);
+assertEnvironment('ROOT_PATH', 'DB_NAME', 'SWISSPROT_EMAIL_REPORT');
 
 if (@ARGV < 1) {
     die "Please enter the accession file name. \n";

--- a/server_apps/data_transfer/SWISS-PROT/sp_parser.pl
+++ b/server_apps/data_transfer/SWISS-PROT/sp_parser.pl
@@ -9,7 +9,11 @@
 use DBI;
 use Cwd;
 
-my $cwd = getcwd();
+use FindBin;
+use lib "$FindBin::Bin/../../";
+use ZFINPerlModules qw(assertEnvironment);
+assertEnvironment('DB_NAME', 'PGHOST');
+
 my $first = 1;       #indicate the beginning of DR(the end of CC)
 
 my (@ext_dr, @cc, $cc, @sp_ac, $sp_ac, $sp_ac_list, $embl, $gene, $single_gene, @gene_array, $kw);
@@ -23,8 +27,8 @@ open ACC, ">ac_dalias.unl" or die "Cannot open ac_dalias.unl:$!";
 open COMMT, ">cc_external.unl" or die "Cannot open cc_external.unl:$!";
 open KEYWD, ">kd_spkeywd.unl" or die "Cannot open kd_spkeywd.unl:$!";
 
-my $zfindbname = "<!--|DB_NAME|-->";
-my $dbhost = "<!--|PGHOST|-->";
+my $zfindbname = "$ENV{'DB_NAME'}";
+my $dbhost = "$ENV{'PGHOST'}";
 my $username = "";
 my $password = "";
 


### PR DESCRIPTION
- Make sure command execution failure results in exiting script with error code.
- Use consistent casing
- Replace <!--VARIABLE--> with $ENV{'VARIABLE'}
- Fix this error:

```
psql:sp_load.sql:403: ERROR:  column "mrkrgoev_annotation_organization" is of type bigint but expression is of type text
LINE 5:          now() as time1, now() as time2, '5' as org, now() a...
```