### PR TITLE
ZFIN-8178: Require auth for prototype edit

### DIFF
--- a/home/WEB-INF/spring/security.xml
+++ b/home/WEB-INF/spring/security.xml
@@ -115,6 +115,7 @@
         <security:intercept-url pattern="/action/marker/clone-add" access="hasRole('root') or ${DISABLE_SECURITY}"/>
         <security:intercept-url pattern="/action/marker/gene-add" access="hasRole('root') or ${DISABLE_SECURITY}"/>
         <security:intercept-url pattern="/action/marker/gene/edit/**" access="hasRole('root') or ${DISABLE_SECURITY}"/>
+        <security:intercept-url pattern="/action/marker/gene/prototype-edit/*" access="hasRole('root') or ${DISABLE_SECURITY}"/>
         <security:intercept-url pattern="/action/marker/gene/prototype-view/*" access="hasRole('root') or ${DISABLE_SECURITY}"/>
         <security:intercept-url pattern="/action/marker/clone/prototype-view/*" access="hasRole('root') or ${DISABLE_SECURITY}"/>
         <security:intercept-url pattern="/action/marker/transcribedRegion-add" access="hasRole('root') or ${DISABLE_SECURITY}"/>


### PR DESCRIPTION
Fix for issue:

I can get to the prototype edit page for en.2ankrd1a even though I am not logged into ZFIN:

https://zfin.org/action/marker/gene/prototype-edit/ZDB-ENHANCER-190916-7#nomenclature

Windows pop up when I click on “Add”. I didn’t actually try to add or edit anything since I didn’t want to mess up production.