### PR TITLE
ZFIN-7925 (revision 2): Preserve existing records

### DIFF
--- a/server_apps/ZFINPerlModules.pm
+++ b/server_apps/ZFINPerlModules.pm
@@ -177,7 +177,7 @@ sub month3LettersToNumber() {
 #
 sub whirley {
   $WHIRLEY_COUNT = ($WHIRLEY_COUNT + 1) % @WHIRLEY;
-  return @WHIRLEY[$WHIRLEY_COUNT];
+  return $WHIRLEY[$WHIRLEY_COUNT];
 }
 
 sub printWhirleyToStderr {

--- a/server_apps/data_transfer/NCBIGENE/loadNCBIgeneAccs.sql
+++ b/server_apps/data_transfer/NCBIGENE/loadNCBIgeneAccs.sql
@@ -17,6 +17,12 @@ create index t_id_index on ncbi_gene_delete (delete_dblink_zdb_id);
 
 \copy ncbi_gene_delete from '<!--|ROOT_PATH|-->/server_apps/data_transfer/NCBIGENE/toDelete.unl';
 
+create temporary table ncbi_dblink_to_preserve (
+  prsv_dblink_zdb_id    text not null
+);
+create index prsv_id_index on ncbi_dblink_to_preserve (prsv_dblink_zdb_id);
+\copy ncbi_dblink_to_preserve from '<!--|ROOT_PATH|-->/server_apps/data_transfer/NCBIGENE/toPreserve.unl';
+
 create temporary table ncbi_gene_load (
   mapped_zdb_gene_id    text not null,
   ncbi_accession        varchar(50),
@@ -60,7 +66,8 @@ delete from record_attribution
                 where recattrib_data_zdb_id = dblink_zdb_id 
                   and (dblink_linked_recid like 'ZDB-GENE%' or dblink_linked_recid like '%RNAG%')
                   and dblink_fdbcont_zdb_id in ('ZDB-FDBCONT-040412-37','ZDB-FDBCONT-040412-42','ZDB-FDBCONT-040412-36')
-              );
+              )
+   and not exists (select 'x' from ncbi_dblink_to_preserve where prsv_dblink_zdb_id = recattrib_data_zdb_id);
 
 --!echo 'Insert into zdb_active_data the new zdb ids of db_link records'
 

--- a/server_apps/jenkins/jobs/NCBI-Gene-Load_w/config.xml
+++ b/server_apps/jenkins/jobs/NCBI-Gene-Load_w/config.xml
@@ -23,10 +23,19 @@
   </builders>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>server_apps/data_transfer/NCBIGENE/report*,server_apps/data_transfer/NCBIGENE/log*,server_apps/data_transfer/NCBIGENE/*.unl,server_apps/data_transfer/NCBIGENE/loadLog*</artifacts>
+      <artifacts>server_apps/data_transfer/NCBIGENE/report*,server_apps/data_transfer/NCBIGENE/log*,server_apps/data_transfer/NCBIGENE/*.unl,server_apps/data_transfer/NCBIGENE/*Log*,server_apps/data_transfer/NCBIGENE/debug*</artifacts>
       <latestOnly>false</latestOnly>
       <allowEmptyArchive>true</allowEmptyArchive>
     </hudson.tasks.ArtifactArchiver>
+    <hudson.tasks.BuildTrigger>
+      <childProjects>Load-Reference-Proteome</childProjects>
+      <threshold>
+        <name>FAILURE</name>
+        <ordinal>2</ordinal>
+        <color>RED</color>
+        <completeBuild>true</completeBuild>
+      </threshold>
+    </hudson.tasks.BuildTrigger>
     <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@2.35.1">
       <recipientList>$DEFAULT_RECIPIENTS</recipientList>
       <configuredTriggers>


### PR DESCRIPTION
- Added a preservation step for record_attributions that refer to a db_link that is preserved.  Previously, the db_link would be preserved, but the record_attribution was not preserved.
- Include debug files and prepareLog in the artifacts.
- More logging, including the new genes associated with multiple accession numbers. 
- Kick off the reference protein job after running NCBI Gene Load job. 
- Allow running in the old mode with flag (useful for comparing different results).