### PR TITLE
ZFIN-8167: record_attribution timestamps

### DIFF
--- a/lib/DB_functions/record_attribution_sync_modified_at.sql
+++ b/lib/DB_functions/record_attribution_sync_modified_at.sql
@@ -1,0 +1,17 @@
+-- last modified trigger function
+CREATE OR REPLACE FUNCTION record_attribution_sync_modified_at()
+  RETURNS trigger AS $BODY$
+BEGIN
+  NEW.recattrib_modified_at := NOW();
+  NEW.recattrib_modified_count := COALESCE(NEW.recattrib_modified_count, 0) + 1;
+RETURN NEW;
+END;
+$BODY$ LANGUAGE plpgsql;
+
+-- last modified trigger
+CREATE TRIGGER
+    record_attribution_sync_modified_at_trigger
+    BEFORE UPDATE ON
+    record_attribution
+    FOR EACH ROW EXECUTE PROCEDURE
+    record_attribution_sync_modified_at();

--- a/source/org/zfin/db/postGmakePostloaddb/1135/ZFIN-8167-add-timestamp-columns-to-record-attribution.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1135/ZFIN-8167-add-timestamp-columns-to-record-attribution.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+--changeset rtaylor:ZFIN-8167
+
+ALTER TABLE record_attribution ADD COLUMN recattrib_created_at TIMESTAMP;
+ALTER TABLE record_attribution ALTER COLUMN recattrib_created_at SET DEFAULT now();
+
+ALTER TABLE record_attribution ADD COLUMN recattrib_modified_at TIMESTAMP;
+ALTER TABLE record_attribution ALTER COLUMN recattrib_modified_at SET DEFAULT now();
+
+ALTER TABLE record_attribution ADD COLUMN recattrib_modified_count integer;
+ALTER TABLE record_attribution ALTER COLUMN recattrib_modified_count SET DEFAULT 0;
+

--- a/source/org/zfin/db/postGmakePostloaddb/1135/db.changelog.master.xml
+++ b/source/org/zfin/db/postGmakePostloaddb/1135/db.changelog.master.xml
@@ -8,6 +8,7 @@
     <include file="source/org/zfin/db/postGmakePostloaddb/1135/ZFIN-8137.sql" />
     <include file="source/org/zfin/db/postGmakePostloaddb/1135/ZFIN-8138.sql" />
     <include file="source/org/zfin/db/postGmakePostloaddb/1135/ZFIN-8152.sql" />
+    <include file="source/org/zfin/db/postGmakePostloaddb/1135/ZFIN-8167-add-timestamp-columns-to-record-attribution.sql" />
 
 
 </databaseChangeLog>


### PR DESCRIPTION
Add columns:
 - recattrib_modified_at
 - recattrib_created_at
 - recattrib_modified_count

I think it's up for discussion whether or not we want a "modified count" or a "created at".  I thought the count could be useful for tracking if any rows get changed multiple times.  The "created at" column could potentially be useful for diagnostics too.