### PR TITLE
ZFIN-8162: Replace 'psql' with 'psql -v ON_ERROR_STOP=1'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ task loadDatabase() {
         println "Loading $unloadPath into $dbname"
         exec {
             ignoreExitValue = true
-            commandLine "bash", "-c", "echo 'select pg_terminate_backend(pg_stat_activity.pid) from pg_stat_activity where pid <> pg_backend_pid();' | psql $dbname"
+            commandLine "bash", "-c", "echo 'select pg_terminate_backend(pg_stat_activity.pid) from pg_stat_activity where pid <> pg_backend_pid();' | psql -v ON_ERROR_STOP=1 $dbname"
         }
         exec {
             ignoreExitValue = true
@@ -92,7 +92,7 @@ task loadDatabase() {
         }
         exec {
             ignoreExitValue = true
-            commandLine "bash", "-c", "echo 'vacuum (analyze)' | psql $dbname"
+            commandLine "bash", "-c", "echo 'vacuum (analyze)' | psql -v ON_ERROR_STOP=1 $dbname"
         }
 
     }

--- a/lib/DB_functions/build.gradle
+++ b/lib/DB_functions/build.gradle
@@ -46,6 +46,6 @@ int runSqlFiles(String directory) {
 task dropFunctions() {
     doLast {
         description = "drop all functions from the database"
-        exec { commandLine "bash", "-c", "psql $dbname < ./dropFunctions" }
+        exec { commandLine "bash", "-c", "psql -v ON_ERROR_STOP=1 $dbname < ./dropFunctions" }
     }
 }

--- a/lib/DB_triggers/build.gradle
+++ b/lib/DB_triggers/build.gradle
@@ -39,6 +39,6 @@ int runSqlFiles(String directory){
 task dropTriggers() {
      doLast {
      	    description = "drop all triggers from the database"
-   	    exec { commandLine "bash", "-c", "echo 'select strip_all_triggers()' | psql $dbname" }
+   	    exec { commandLine "bash", "-c", "echo 'select strip_all_triggers()' | psql -v ON_ERROR_STOP=1 $dbname" }
      }
 }

--- a/server_apps/DB_maintenance/loadExternalNotes.pl
+++ b/server_apps/DB_maintenance/loadExternalNotes.pl
@@ -51,7 +51,7 @@ close INPUT;
 
 close OUTPUT;
 
-system("psql -d <!--|DB_NAME|--> -a -f loadExternalNotes.sql");
+system("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f loadExternalNotes.sql");
 
 exit;
 

--- a/server_apps/DB_maintenance/postgres/doClobWork.sh
+++ b/server_apps/DB_maintenance/postgres/doClobWork.sh
@@ -11,33 +11,33 @@ rm -rf ${SOURCEROOT}/server_apps/DB_maintenance/postgres/clobLoad.sql
 ${INFORMIXDIR}/bin/dbaccess ${DBNAME} ${SOURCEROOT}/server_apps/DB_maintenance/postgres/unloadAbstract.sql
 
 # update the schema definition in postgres to use 'bytea' as per the postgres doc suggestions
-${PGBINDIR}/psql ${DBNAME} < ${SOURCEROOT}/server_apps/DB_maintenance/postgres/changeSmartLargeObjects.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME} < ${SOURCEROOT}/server_apps/DB_maintenance/postgres/changeSmartLargeObjects.sql
 
 # create the update statements that we need to load up the clobs.
 ${SOURCEROOT}/server_apps/DB_maintenance/postgres/createClobLoadStatements.sh
 
-${PGBINDIR}/psql ${DBNAME} < ${SOURCEROOT}/lib/DB_functions/bytea_import.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME} < ${SOURCEROOT}/lib/DB_functions/bytea_import.sql
 
 # load up the clobs into postgres
-${PGBINDIR}/psql ${DBNAME} < ${SOURCEROOT}/server_apps/DB_maintenance/postgres/clobLoad.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME} < ${SOURCEROOT}/server_apps/DB_maintenance/postgres/clobLoad.sql
 
-echo "alter table publication add abstract_text text" | ${PGBINDIR}/psql ${DBNAME}
-echo "alter table person add nonzf_pubs_text text" | ${PGBINDIR}/psql ${DBNAME}
+echo "alter table publication add abstract_text text" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
+echo "alter table person add nonzf_pubs_text text" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
 
-echo "update publication set abstract_text = convert_from(pub_abstract, 'UTF-8')" | ${PGBINDIR}/psql ${DBNAME}
-echo "update person set nonzf_pubs_text = convert_from(nonzf_pubs, 'UTF-8')" | ${PGBINDIR}/psql ${DBNAME}
+echo "update publication set abstract_text = convert_from(pub_abstract, 'UTF-8')" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
+echo "update person set nonzf_pubs_text = convert_from(nonzf_pubs, 'UTF-8')" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
 
-echo "update publication set pub_abstract = null" | ${PGBINDIR}/psql ${DBNAME}
-echo "update person set nonzf_pubs = null" | ${PGBINDIR}/psql ${DBNAME}
+echo "update publication set pub_abstract = null" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
+echo "update person set nonzf_pubs = null" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
 
-echo "alter table publication alter column pub_abstract type text using pub_abstract::text" | ${PGBINDIR}/psql ${DBNAME};
-echo "alter table person alter column nonzf_pubs type text using nonzf_pubs::text" | ${PGBINDIR}/psql ${DBNAME};
+echo "alter table publication alter column pub_abstract type text using pub_abstract::text" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME};
+echo "alter table person alter column nonzf_pubs type text using nonzf_pubs::text" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME};
 
-echo "update publication set pub_abstract = abstract_text" | ${PGBINDIR}/psql ${DBNAME}
-echo "update person set nonzf_pubs = nonzf_pubs_text" | ${PGBINDIR}/psql ${DBNAME}
+echo "update publication set pub_abstract = abstract_text" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
+echo "update person set nonzf_pubs = nonzf_pubs_text" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
 
-echo "alter table publication drop abstract_text" | ${PGBINDIR}/psql ${DBNAME}
-echo "alter table person drop nonzf_pubs_text" | ${PGBINDIR}/psql ${DBNAME}
+echo "alter table publication drop abstract_text" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
+echo "alter table person drop nonzf_pubs_text" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
 
 endTime=$(date)
 echo $startTime

--- a/server_apps/DB_maintenance/postgres/fixIndexes.sh
+++ b/server_apps/DB_maintenance/postgres/fixIndexes.sh
@@ -4,16 +4,16 @@ startTime=$(date)
 echo $startTime
 
 # add view for helping with missing indexes
-${PGBINDIR}/psql ${DBNAME} < ${SOURCEROOT}/server_apps/DB_maintenance/postgres/tablesWithoutIndexes.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME} < ${SOURCEROOT}/server_apps/DB_maintenance/postgres/tablesWithoutIndexes.sql
 
 # add zactvd_zdb_id_unique_constraint -- to solve ODC problem.
-echo 'create unique index zactvd_zdb_id_pk_index on zdb_active_data(zactvd_zdb_id)' | ${PGBINDIR}/psql ${DBNAME}
+echo 'create unique index zactvd_zdb_id_pk_index on zdb_active_data(zactvd_zdb_id)' | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
 
 # analyze db (aka:update statistics high)
-echo 'vacuum (analyze);' | ${PGBINDIR}/psql ${DBNAME}
+echo 'vacuum (analyze);' | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
 
 # set up slow query capture
-echo 'CREATE EXTENSION pg_stat_statements;' | ${PGBINDIR}/psql ${DBNAME}
+echo 'CREATE EXTENSION pg_stat_statements;' | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
 
 endTime=$(date)
 echo $endTime

--- a/server_apps/DB_maintenance/postgres/runPostgresBuild.sh
+++ b/server_apps/DB_maintenance/postgres/runPostgresBuild.sh
@@ -15,7 +15,7 @@ sed 's/|/;/g' ${SOURCEROOT}/server_apps/DB_maintenance/postgres/nonKeyIndexes.sq
 
 echo "drop and recreate database in $DBNAME value" 
 
-if ${PGBINDIR}/psql -lqt | cut -d \| -f 1 | grep -qw ${DBNAME}; then
+if ${PGBINDIR}/psql -v ON_ERROR_STOP=1 -lqt | cut -d \| -f 1 | grep -qw ${DBNAME}; then
     ${PGBINDIR}/dropdb ${DBNAME}
 fi
 
@@ -67,7 +67,7 @@ cat /tmp/tables.xml ${SOURCEROOT}/server_apps/DB_maintenance/postgres/xmlFooter.
 cd ${SOURCEROOT}
 ant buildPostgresDatabase
 
-${PGBINDIR}/psql ${DBNAME} < ${SOURCEROOT}/server_apps/DB_maintenance/postgres/add_monthly_average_curated_metric.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 -v ON_ERROR_STOP=1 ${DBNAME} < ${SOURCEROOT}/server_apps/DB_maintenance/postgres/add_monthly_average_curated_metric.sql
 
 dumpLocation=/research/zunloads/databases/postgres_dumps/${DBNAME}
 echo "dumpLocation"
@@ -85,9 +85,9 @@ cd ${SOURCEROOT}
 ant addPostgresConstraints
 
 # generate serial id replacement sql file : reset.sql
-${PGBINDIR}/psql ${DBNAME} < ${SOURCEROOT}/server_apps/DB_maintenance/postgres/resetSerialIds.sql > ${SOURCEROOT}/server_apps/DB_maintenance/postgres/reset.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME} < ${SOURCEROOT}/server_apps/DB_maintenance/postgres/resetSerialIds.sql > ${SOURCEROOT}/server_apps/DB_maintenance/postgres/reset.sql
 
-echo " SELECT SETVAL('accnum_sequence', COALESCE(MAX(za_sequence_number), 1) ) FROM zfin_accession_number;" | psql ${DBNAME}
+echo " SELECT SETVAL('accnum_sequence', COALESCE(MAX(za_sequence_number), 1) ) FROM zfin_accession_number;" | psql -v ON_ERROR_STOP=1 ${DBNAME}
 
 #remove header and summary from reset.sql so that we can run it directly and reset the sequences.
 
@@ -98,10 +98,10 @@ sed 's/-//g' ${SOURCEROOT}/server_apps/DB_maintenance/postgres/reset.sql > ${SOU
 head -n -2 ${SOURCEROOT}/server_apps/DB_maintenance/postgres/reset.sql > ${SOURCEROOT}/server_apps/DB_maintenance/postgres/temp.txt ; mv ${SOURCEROOT}/server_apps/DB_maintenance/postgres/temp.txt ${SOURCEROOT}/server_apps/DB_maintenance/postgres/reset.sql
 
 # reset the sequence start values for all serial ids
-${PGBINDIR}/psql ${DBNAME} < ${SOURCEROOT}/server_apps/DB_maintenance/postgres/reset.sql
-${PGBINDIR}/psql ${DBNAME} < ${SOURCEROOT}/server_apps/DB_maintenance/postgres/nonKeyIndexes.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME} < ${SOURCEROOT}/server_apps/DB_maintenance/postgres/reset.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME} < ${SOURCEROOT}/server_apps/DB_maintenance/postgres/nonKeyIndexes.sql
 
-echo 'alter table fish_components alter column fc_fish_name type text' | psql ${DBNAME}
+echo 'alter table fish_components alter column fc_fish_name type text' | psql -v ON_ERROR_STOP=1 ${DBNAME}
 
 
 endTime=$(date)

--- a/server_apps/DB_maintenance/regen.sh
+++ b/server_apps/DB_maintenance/regen.sh
@@ -6,34 +6,34 @@
 # themselves update statistics for the tables they generate. 
 
 echo "Starting regen_genox at `date`"
-echo 'select regen_genox(); ' | ${PGBINDIR}/psql ${DBNAME}
+echo 'select regen_genox(); ' | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
 
 echo "Starting regen_anatomy_counts at `date`"
-echo 'select regen_anatomy_counts();' | ${PGBINDIR}/psql ${DBNAME}
+echo 'select regen_anatomy_counts();' | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
 
 echo "Starting regen_term at `date`"
-echo 'select regen_term();' | ${PGBINDIR}/psql ${DBNAME}
+echo 'select regen_term();' | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
 
 echo "Starting regen_term_indexes at `date`"
-${PGBINDIR}/psql ${DBNAME} < ${SOURCEROOT}/server_apps/DB_maintenance/postgres/make_alltermcontains_indexes.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME} < ${SOURCEROOT}/server_apps/DB_maintenance/postgres/make_alltermcontains_indexes.sql
 
 echo "Starting regen_expression_term_fast_search at `date`"
-echo 'select regen_expression_term_fast_search();' | ${PGBINDIR}/psql ${DBNAME}
+echo 'select regen_expression_term_fast_search();' | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
 
 echo "Starting regen_clean_expression at `date`"
-echo 'select regen_clean_expression();' | ${PGBINDIR}/psql ${DBNAME}
+echo 'select regen_clean_expression();' | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
 
 echo "Starting regen_fish_Components at `date`"
-echo 'select regen_fish_components();' | ${PGBINDIR}/psql ${DBNAME}
+echo 'select regen_fish_components();' | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
 
 echo "Starting regen_pheno_fast_search at `date`"
-${PGBINDIR}/psql ${DBNAME} < ${TARGETROOT}/server_apps/DB_maintenance/pheno/pheno_term_regen.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME} < ${TARGETROOT}/server_apps/DB_maintenance/pheno/pheno_term_regen.sql
 
 echo "starting regenExpressionSearchAnatomy at `date`"
-${PGBINDIR}/psql -d ${DBNAME} -f ${TARGETROOT}/server_apps/DB_maintenance/warehouse/expressionMart/regenExpressionSearchAnatomy.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 -d ${DBNAME} -f ${TARGETROOT}/server_apps/DB_maintenance/warehouse/expressionMart/regenExpressionSearchAnatomy.sql
 
 echo "vacuum daily"
-echo 'vacuum (analyze)' | ${PGBINDIR}/psql ${DBNAME}
+echo 'vacuum (analyze)' | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
 
 
 echo "Finished at `date`"

--- a/server_apps/DB_maintenance/reportLabAddressChanges.sh
+++ b/server_apps/DB_maintenance/reportLabAddressChanges.sh
@@ -8,9 +8,9 @@ if ( -e labAddressCheck.txt ) then
  /bin/touch labAddressCheck.txt;
 endif
 
-echo '\COPY lab_address_update_tracking TO labAddressCheck.txt' | ${PGBINDIR}/psql ${DBNAME};
+echo '\COPY lab_address_update_tracking TO labAddressCheck.txt' | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME};
 
 if ( -s labAddressCheck.txt ) then
-    echo 'DELETE FROM lab_address_update_tracking' | ${PGBINDIR}/psql ${DBNAME};
+    echo 'DELETE FROM lab_address_update_tracking' | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME};
 endif
 

--- a/server_apps/DB_maintenance/set_unload_timestamp.sh
+++ b/server_apps/DB_maintenance/set_unload_timestamp.sh
@@ -4,8 +4,8 @@ set delete_command="delete from database_info where di_database_unloaded='${DBNA
 
 echo $delete_command
 
-echo $delete_command | ${PGBINDIR}/psql ${DBNAME}
+echo $delete_command | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}
 
 set insert_command="insert into database_info (di_date_unloaded, di_database_unloaded) select CURRENT_TIMESTAMP, '${DBNAME}' from single;"
 
-echo $insert_command |  ${PGBINDIR}/psql ${DBNAME}
+echo $insert_command |  ${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME}

--- a/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/runChromosomeMart.sh
+++ b/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/runChromosomeMart.sh
@@ -42,10 +42,10 @@ end
 
 if ("X$1" == "X") then
 echo "ready to start dropTables.sql DBNAME from environment." ;
-${PGBINDIR}/psql $DBNAME < $FULL_SCRIPT_FILE
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DBNAME < $FULL_SCRIPT_FILE
 else
 echo "ready to start dropTables.sql DBNAME provided from script call." ;
-${PGBINDIR}/psql $1 < $FULL_SCRIPT_FILE
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 $1 < $FULL_SCRIPT_FILE
 
 endif 
 

--- a/server_apps/DB_maintenance/warehouse/expressionMart/runExpressionMart.sh
+++ b/server_apps/DB_maintenance/warehouse/expressionMart/runExpressionMart.sh
@@ -39,10 +39,10 @@ end
 
 if ("X$1" == "X") then
 echo "ready to start dropTables.sql DBNAME from environment." ;
-${PGBINDIR}/psql $DBNAME < $FULL_SCRIPT_FILE
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DBNAME < $FULL_SCRIPT_FILE
 else
 echo "ready to start dropTables.sql DBNAME provided from script call." ;
-${PGBINDIR}/psql $1 < $FULL_SCRIPT_FILE
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 $1 < $FULL_SCRIPT_FILE
 
 
 

--- a/server_apps/DB_maintenance/warehouse/phenotypeMart/runPhenotypeMart.sh
+++ b/server_apps/DB_maintenance/warehouse/phenotypeMart/runPhenotypeMart.sh
@@ -44,10 +44,10 @@ end
 
 if ("X$1" == "X") then
 echo "ready to start dropTables.sql DBNAME from environment." ;
-${PGBINDIR}/psql $DBNAME < $FULL_SCRIPT_FILE
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DBNAME < $FULL_SCRIPT_FILE
 else
 echo "ready to start dropTables.sql DBNAME provided from script call." ;
-${PGBINDIR}/psql $1 < $FULL_SCRIPT_FILE
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 $1 < $FULL_SCRIPT_FILE
 
 
 

--- a/server_apps/DB_maintenance/warehouse/regenChromosomeMart.sh
+++ b/server_apps/DB_maintenance/warehouse/regenChromosomeMart.sh
@@ -50,7 +50,7 @@ endif
 
 # move the current table data to backup, move the new data to current.
 
-${PGBINDIR}/psql <!--|DB_NAME|--> < <!--|ROOT_PATH|-->/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/chromosomeMartRegen.sql 
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 <!--|DB_NAME|--> < <!--|ROOT_PATH|-->/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/chromosomeMartRegen.sql 
 
 if ($? != 0) then
    echo "refresh chromosome mart (the public tables) failed and was rolled back";

--- a/server_apps/DB_maintenance/warehouse/regenExpressionMart.sh
+++ b/server_apps/DB_maintenance/warehouse/regenExpressionMart.sh
@@ -50,16 +50,16 @@ endif
 
 # move the current table data to backup, move the new data to current.
 
-${PGBINDIR}/psql <!--|DB_NAME|--> < <!--|ROOT_PATH|-->/server_apps/DB_maintenance/warehouse/expressionMart/expressionMartRegen.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 <!--|DB_NAME|--> < <!--|ROOT_PATH|-->/server_apps/DB_maintenance/warehouse/expressionMart/expressionMartRegen.sql
 
 if ($? != 0) then
    echo "refresh expression mart (the public tables) failed and was rolled back";
 exit 1;
 endif
 
-echo "select regen_expression_term_fast_search()" | ${PGBINDIR}/psql $DBNAME;
+echo "select regen_expression_term_fast_search()" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DBNAME;
 
-echo "select regen_feature_term_fast_search()" | ${PGBINDIR}/psql $DBNAME;
+echo "select regen_feature_term_fast_search()" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DBNAME;
 
 echo "success" ;
 

--- a/server_apps/DB_maintenance/warehouse/regenPhenotypeMart.sh
+++ b/server_apps/DB_maintenance/warehouse/regenPhenotypeMart.sh
@@ -52,7 +52,7 @@ echo "done with phenotype mart building public" ;
 
 # move the current table data to backup, move the new data to current.
 
-${PGBINDIR}/psql <!--|DB_NAME|--> < <!--|ROOT_PATH|-->/server_apps/DB_maintenance/warehouse/phenotypeMart/phenotypeMartRegen.sql >&! <!--|ROOT_PATH|-->/server_apps/DB_maintenance/warehouse/phenotypeMart/regenPhenotypeMartReportPostgres.txt
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 <!--|DB_NAME|--> < <!--|ROOT_PATH|-->/server_apps/DB_maintenance/warehouse/phenotypeMart/phenotypeMartRegen.sql >&! <!--|ROOT_PATH|-->/server_apps/DB_maintenance/warehouse/phenotypeMart/regenPhenotypeMartReportPostgres.txt
 
 if ($? != 0) then
    echo "refresh phenotype mart (the public tables) failed and was rolled back";
@@ -63,7 +63,7 @@ echo "done regen public phenotype tables" ;
 date;
 
 echo "start regen_genox()";
-echo "select regen_genox();" | ${PGBINDIR}/psql $DBNAME;
+echo "select regen_genox();" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DBNAME;
 if ($? != 0) then
    echo "regen phenotype mart failed";
 exit 1;
@@ -74,7 +74,7 @@ echo "done with regen_genox()";
 
 
 echo "start regen_anatomy_counts()";
-echo "select regen_anatomy_counts()" | ${PGBINDIR}/psql $DBNAME
+echo "select regen_anatomy_counts()" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DBNAME
 if ($? != 0) then
    echo "regen phenotype mart failed";
 exit 1;
@@ -86,7 +86,7 @@ echo "done with regen_anatomy_counts()";
 
 
 echo "start regen_pheno_term_regen()";
-${PGBINDIR}/psql $DBNAME < $TARGETROOT/server_apps/DB_maintenance/pheno/pheno_term_regen.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DBNAME < $TARGETROOT/server_apps/DB_maintenance/pheno/pheno_term_regen.sql
 if ($? != 0) then
    echo "regen phenotype mart failed";
 exit 1;

--- a/server_apps/Reports/AnnualStats/runStats.sh
+++ b/server_apps/Reports/AnnualStats/runStats.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
-psql -d <!--|DB_NAME|--> -a -f stats.sql
+psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f stats.sql
 

--- a/server_apps/Reports/Count-phenotype.pl
+++ b/server_apps/Reports/Count-phenotype.pl
@@ -19,7 +19,7 @@ chdir "<!--|ROOT_PATH|-->/server_apps/Reports/PATO";
 
 system("/bin/rm -f PhenotypeStatistics.txt");
 
-system("psql -d <!--|DB_NAME|--> -f count_phenotype.sql > PhenotypeStatistics.txt 2> err.txt");
+system("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -f count_phenotype.sql > PhenotypeStatistics.txt 2> err.txt");
 
 ###-------- New section for case 10249, STR additions to Monthly phenotype statistics --------------------------------
 

--- a/server_apps/Reports/Nomenclature/get_uninformative.sh
+++ b/server_apps/Reports/Nomenclature/get_uninformative.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-(${PGBINDIR}/psql ${DBNAME} -q << END
+(${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME} -q << END
 
 CREATE TEMP TABLE tmp_counts (
     tmp_label     text,

--- a/server_apps/Reports/PATO/FinCount.pl
+++ b/server_apps/Reports/PATO/FinCount.pl
@@ -151,6 +151,6 @@ print SQLFILE "\nselect count (distinct id) from tmp_contains;\n\n\n";
 
 close(SQLFILE);
 
-system("psql -d <!--|DB_NAME|--> -f FinPhenoCount.sql > FinPhenotypeStatistics.txt 2> errFin.txt");
+system("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -f FinPhenoCount.sql > FinPhenotypeStatistics.txt 2> errFin.txt");
 
 exit;

--- a/server_apps/Reports/PubTracking/runMonthlyBinLengthReport.sh
+++ b/server_apps/Reports/PubTracking/runMonthlyBinLengthReport.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-${PGBINDIR}/psql ${DBNAME} < <!--|ROOT_PATH|-->/server_apps/Reports/PubTracking/monthlyBinLengthReport.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 ${DBNAME} < <!--|ROOT_PATH|-->/server_apps/Reports/PubTracking/monthlyBinLengthReport.sql

--- a/server_apps/Reports/PubTracking/runPaperlessPubTrackingDailyIndexedMetrics.sh
+++ b/server_apps/Reports/PubTracking/runPaperlessPubTrackingDailyIndexedMetrics.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-${PGBINDIR}/psql <!--|DB_NAME|--> < <!--|ROOT_PATH|-->/server_apps/Reports/PubTracking/paperlessPubTrackingDailyIndexedStats.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 <!--|DB_NAME|--> < <!--|ROOT_PATH|-->/server_apps/Reports/PubTracking/paperlessPubTrackingDailyIndexedStats.sql

--- a/server_apps/Reports/ZGC/Count-ZGC.sh
+++ b/server_apps/Reports/ZGC/Count-ZGC.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-${PGBINDIR}/psql -d ${DBNAME} -f zgcCount.sql > zgcStatistics.txt 2> err.txt;
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 -d ${DBNAME} -f zgcCount.sql > zgcStatistics.txt 2> err.txt;

--- a/server_apps/data_transfer/Addgene/LoadAddgene.groovy
+++ b/server_apps/data_transfer/Addgene/LoadAddgene.groovy
@@ -51,7 +51,7 @@ static Process dbaccess(String dbname, String sql) {
     println sql
 
     def proc
-    proc = "psql -d $dbname -a".execute()
+    proc = "psql -v ON_ERROR_STOP=1 -d $dbname -a".execute()
     proc.getOutputStream().with {
         write(sql.bytes)
         close()

--- a/server_apps/data_transfer/AllianceGeneDesc/LoadAllianceGeneDesc.groovy
+++ b/server_apps/data_transfer/AllianceGeneDesc/LoadAllianceGeneDesc.groovy
@@ -112,7 +112,7 @@ static Process dbaccess(String dbname, String sql) {
     println sql
 
     def proc
-    proc = "psql -d $dbname -a".execute()
+    proc = "psql -v ON_ERROR_STOP=1 -d $dbname -a".execute()
     proc.getOutputStream().with {
         write(sql.bytes)
         close()

--- a/server_apps/data_transfer/BLAST/runZfinEnsemblTscripts.sh
+++ b/server_apps/data_transfer/BLAST/runZfinEnsemblTscripts.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-${PGBINDIR}/psql $DBNAME < getEnsemblTscripts.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DBNAME < getEnsemblTscripts.sql

--- a/server_apps/data_transfer/Downloads/DownloadFiles.pl
+++ b/server_apps/data_transfer/Downloads/DownloadFiles.pl
@@ -43,6 +43,8 @@
 
 use DBI;
 use Try::Tiny;
+use lib "<!--|ROOT_PATH|-->/server_apps/";
+use ZFINPerlModules;
 
 # define GLOBALS
 
@@ -65,7 +67,7 @@ else {
 }
 
 try {
-  system("psql -d <!--|DB_NAME|--> -a -f DownloadFiles.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f DownloadFiles.sql");
 } catch {
   warn "Failed at DownloadFiles.sql - $_";
   exit -1;

--- a/server_apps/data_transfer/Downloads/GFF3/generateGff3.sh
+++ b/server_apps/data_transfer/Downloads/GFF3/generateGff3.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-psql -d $DBNAME -f E_zfin_ensembl_gene.sql -f E_expression_gff3.sql -f E_phenotype_gff3.sql -f E_antibody_gff3.sql -f unload_mutants.sql
+psql -v ON_ERROR_STOP=1 -d $DBNAME -f E_zfin_ensembl_gene.sql -f E_expression_gff3.sql -f E_phenotype_gff3.sql -f E_antibody_gff3.sql -f unload_mutants.sql
 
 ./generateGff3.groovy

--- a/server_apps/data_transfer/Downloads/GFF3/knockdown_reagents/load_knockdown_reagents.sh
+++ b/server_apps/data_transfer/Downloads/GFF3/knockdown_reagents/load_knockdown_reagents.sh
@@ -13,7 +13,7 @@ rm -f mo_seq.fa_line mo_seq.fa E_mo_seq.sam E_zfin_morpholino.gff3 mo_seq_E_miss
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # BOWTIE v1 ALIGNMENT FOR MOs AND CRISPRs
 
-${PGBINDIR}/psql $DBNAME < get_mo_and_crispr_seq.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DBNAME < get_mo_and_crispr_seq.sql
 tr \~ '\n' < mo_seq.fa_line > mo_seq.fa
 /opt/misc/bowtie/bowtie --all --best --strata --sam -f $BOWTIE_IDX mo_seq.fa > E_mo_seq.sam
 ./sam2gff3.groovy < E_mo_seq.sam > E_zfin_morpholino.gff3 2> mo_seq_E_miss.fa
@@ -22,7 +22,7 @@ tr \~ '\n' < mo_seq.fa_line > mo_seq.fa
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # BOWTIE2 TALEN ALIGNMENT
 
-${PGBINDIR}/psql -d $DBNAME -f get_talen_seq_1.sql -f get_talen_seq_2.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 -d $DBNAME -f get_talen_seq_1.sql -f get_talen_seq_2.sql
 tr \~ '\n' < talen_seq_1.fa_line > talen_seq_1.fa
 tr \~ '\n' < talen_seq_2.fa_line > talen_seq_2.fa
 /opt/misc/bowtie2/bowtie2 -x $BOWTIE_IDX  --no-discordant --no-mixed -X 750 -f -1 talen_seq_1.fa -2 talen_seq_2.fa -S E_talen_seq.sam
@@ -34,10 +34,10 @@ tr \~ '\n' < talen_seq_2.fa_line > talen_seq_2.fa
 
 ./merge_gff3.groovy E_zfin_knockdown_reagents.gff3 E_zfin_morpholino.gff3 E_zfin_talen.gff3
 ./gff32unl.groovy E_zfin_knockdown_reagents.gff3 > E_zfin_knockdown_reagents.unl
-${PGBINDIR}/psql -d $DBNAME -f load_knockdown_reagents.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 -d $DBNAME -f load_knockdown_reagents.sql
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # update sequence_feature_chromosome_location_generated table
-psql -d $DB_NAME -a -f ../../../Ensembl/updateSequenceFeatureChromosomeLocation.sql
+psql -v ON_ERROR_STOP=1 -d $DB_NAME -a -f ../../../Ensembl/updateSequenceFeatureChromosomeLocation.sql
 
 

--- a/server_apps/data_transfer/Downloads/patoNumbers.pl
+++ b/server_apps/data_transfer/Downloads/patoNumbers.pl
@@ -12,7 +12,7 @@ use DBI;
 # set environment variables
 
 # call patoNumbers.sql to prepare some download files and some pre-processed files
-system("psql -d <!--|DB_NAME|--> -a -f patoNumbers.sql");
+system("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f patoNumbers.sql");
 
 $dbname = "<!--|DB_NAME|-->";
 $username = "";

--- a/server_apps/data_transfer/Ensembl/Makefile
+++ b/server_apps/data_transfer/Ensembl/Makefile
@@ -21,10 +21,10 @@ fetch_ensdarg:
 	cd $(TARGETDIR) && fetch_ensdarg.sh
 
 load_ensdarG_rollback: fetch_ensdarg
-	cd $(TARGETDIR) && cat load_ensdarG.sql rollback.sql | ${PGBINDIR}/psql -e ${DBNAME}
+	cd $(TARGETDIR) && cat load_ensdarG.sql rollback.sql | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 -e ${DBNAME}
 
 load_ensdarG: fetch_ensdarg
-	cd $(TARGETDIR)/ && cat load_ensdarG.sql commit.sql | ${PGBINDIR}/psql -e ${DBNAME}
+	cd $(TARGETDIR)/ && cat load_ensdarG.sql commit.sql | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 -e ${DBNAME}
 
 # 		fetch  Ensembl GTF and convert to gff3
 run_gff: 

--- a/server_apps/data_transfer/Ensembl/fetch_ensembl_agp.sh
+++ b/server_apps/data_transfer/Ensembl/fetch_ensembl_agp.sh
@@ -22,7 +22,7 @@ echo `pwd`
 echo ""
 echo "get DNA clones that are in ZFIN into: zfin_DNA_clone.txt"
 
-${PGBINDIR}/psql $DBNAME < unload_zfin_DNA_clone.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DBNAME < unload_zfin_DNA_clone.sql
 
 echo "convert agp to gff3 and augment with zfin clone data as: "
 echo "${dest}/E_full_zfin_clone.gff3"

--- a/server_apps/data_transfer/ExpressionAtlas/addExpressionAtlasLinks.groovy
+++ b/server_apps/data_transfer/ExpressionAtlas/addExpressionAtlasLinks.groovy
@@ -98,7 +98,7 @@ static Process dbaccess(String dbname, String sql) {
     println sql
 
     def proc
-    proc = "psql -d $dbname -a".execute()
+    proc = "psql -v ON_ERROR_STOP=1 -d $dbname -a".execute()
     proc.getOutputStream().with {
         write(sql.bytes)
         close()

--- a/server_apps/data_transfer/GO/go.pl
+++ b/server_apps/data_transfer/GO/go.pl
@@ -51,14 +51,14 @@ foreach $id (keys %identifiers) {
 close IDS;
 
 try {
-  ZFINPerlModules->doSystemCommand("psql -d <!--|DB_NAME|--> -a -f gofile.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f gofile.sql");
 } catch {
   warn "Failed at gofile.sql - $_";
   exit -1;
 };
 
 try {
-  ZFINPerlModules->doSystemCommand("psql -d <!--|DB_NAME|--> -a -f gpad2.0.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f gpad2.0.sql");
 } catch {
   warn "Failed at gpad2.0.sql - $_";
   exit -1;
@@ -91,14 +91,14 @@ try {
   exit -1;
 };
 try {
-  ZFINPerlModules->doSystemCommand("psql -d <!--|DB_NAME|--> -a -f gofile2.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f gofile2.sql");
 } catch {
   warn "Failed at gofile2.sql - $_";
   exit -1;
 };
 
 try {
-  ZFINPerlModules->doSystemCommand("psql -d <!--|DB_NAME|--> -a -f gofile2_all.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f gofile2_all.sql");
 } catch {
   warn "Failed at gofile2_all.sql - $_";
   exit -1;

--- a/server_apps/data_transfer/GO/gpad.pl
+++ b/server_apps/data_transfer/GO/gpad.pl
@@ -19,7 +19,7 @@ chdir "<!--|ROOT_PATH|-->/server_apps/data_transfer/GO";
 system("/local/bin/gunzip gpad2.0.zfin.gz");
 
 try {
-  ZFINPerlModules->doSystemCommand("psql -d <!--|DB_NAME|--> -a -f gpad2.0.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f gpad2.0.sql");
 } catch {
   warn "Failed at gpad2.0.sql - $_";
   exit -1;

--- a/server_apps/data_transfer/Genbank/gbaccession.pl
+++ b/server_apps/data_transfer/Genbank/gbaccession.pl
@@ -8,6 +8,8 @@
 #
 use strict;
 use Try::Tiny;
+use lib "<!--|ROOT_PATH|-->/server_apps/";
+use ZFINPerlModules;
 
 my ($mailprog, $md_date, $prefix, $unzipfile, $newfile, $dir_on_development_machine, $accfile, $report);
 
@@ -98,7 +100,7 @@ if (! system ("/bin/mv $accfile nc_zf_acc.unl")) {
     
     # load the updates into accesson_bank and db_link
     try {
-      system("$ENV{'PGBINDIR'}/psql <!--|DB_NAME|--> < GenBank-Accession-Update_d.sql >> $report 2>&1");
+      ZFINPerlModules->doSystemCommand("$ENV{'PGBINDIR'}/psql -v ON_ERROR_STOP=1 <!--|DB_NAME|--> < GenBank-Accession-Update_d.sql >> $report 2>&1");
     } catch {
       warn "Failed at GenBank-Accession-Update_d.sql - $_";
       exit -1;

--- a/server_apps/data_transfer/MEOW/meow.pl
+++ b/server_apps/data_transfer/MEOW/meow.pl
@@ -4,6 +4,8 @@
 ##$ENV{"DBDATE"}="Y4MD-";
 
 use Try::Tiny;
+use lib "<!--|ROOT_PATH|-->/server_apps/";
+use ZFINPerlModules;
 
 if (! -e "<!--|FTP_ROOT|-->/pub/transfer/MEOW") {
     system("/bin/mkdir -m 755 -p <!--|FTP_ROOT|-->/pub/transfer/MEOW");
@@ -13,7 +15,7 @@ print "beginning in ". `pwd` ."\n";
 system("rm -f ./*.txt");
 print "running MEOW_dump.sql on <!--|DB_NAME|-->\n";
 try {
-  system("$ENV{'PGBINDIR'}/psql <!--|DB_NAME|--> < MEOW_dump.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 <!--|DB_NAME|--> < MEOW_dump.sql");
 } catch {
   warn "Failed at MEOW_dump.sql - $_";
   exit -1;

--- a/server_apps/data_transfer/NCBIStartEnd/NCBIStartEnd.pl
+++ b/server_apps/data_transfer/NCBIStartEnd/NCBIStartEnd.pl
@@ -151,7 +151,7 @@ foreach $zdbID (keys %zdbIDsMissingCor) {
 close ADDLIST;
 
 try {
-  &doSystemCommand("psql -d <!--|DB_NAME|--> -a -f NCBIStartEnd.sql");
+  &doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f NCBIStartEnd.sql");
 } catch {
   warn "Failed to execute NCBIStartEnd.sql - $_";
   exit -1;

--- a/server_apps/data_transfer/NCBIStartEnd/ncbistartend.sh
+++ b/server_apps/data_transfer/NCBIStartEnd/ncbistartend.sh
@@ -14,4 +14,4 @@
 /bin/sed '/^7955|Un/d' process_seq_gene.md > processing.tmp && mv -f processing.tmp process_seq_gene.md
 /bin/sed 's/GeneID://g' process_seq_gene.md > processing.tmp && mv -f processing.tmp process_seq_gene.md
 
-${PGBINDIR}/psql $DBNAME < loadNCBIStartEnd.sql
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DBNAME < loadNCBIStartEnd.sql

--- a/server_apps/data_transfer/OMIM/OMIM.pl
+++ b/server_apps/data_transfer/OMIM/OMIM.pl
@@ -81,8 +81,8 @@ open (LOG, ">log1.log") || die "Cannot open log1.log : $!\n";
 print LOG "\nDownloading OMIM files ... \n\n";
 
 try {
-  system("/local/bin/wget http://omim.org/static/omim/data/mim2gene.txt");
-  system("/local/bin/wget https://data.omim.org/downloads/TsbrMAQ1T76RqganEcUayA/genemap2.txt");
+  ZFINPerlModules->doSystemCommand("/local/bin/wget http://omim.org/static/omim/data/mim2gene.txt");
+  ZFINPerlModules->doSystemCommand("/local/bin/wget https://data.omim.org/downloads/TsbrMAQ1T76RqganEcUayA/genemap2.txt");
 } catch {
   warn "Downloading from OMIM failed - $_";
   exit -1;
@@ -512,14 +512,14 @@ print LOG "For all $ctFoundMIMwithSymbolOnGenemap records that found with symbol
 ##################################################################################################################################################################
 
 try {
-  ZFINPerlModules->doSystemCommand("psql -d <!--|DB_NAME|--> -a -f loadOMIM.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f loadOMIM.sql");
 } catch {
   warn "Failed to execute loadOMIM.sql - $_";
   exit -1;
 };
 
 try {
-  ZFINPerlModules->doSystemCommand("psql -d <!--|DB_NAME|--> -a -f update_omimp_termxref_mapping.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f update_omimp_termxref_mapping.sql");
 } catch {
   warn "Failed to execute update_omimp_termxref_mapping.sql - $_";
   exit -1;

--- a/server_apps/data_transfer/ORTHO/runOrthology.pl
+++ b/server_apps/data_transfer/ORTHO/runOrthology.pl
@@ -21,14 +21,14 @@ require ("<!--|ROOT_PATH|-->/server_apps/data_transfer/ORTHO/parseHumanData.pl")
 
 print "finished parsing and reporting, do updates.\n";
 try {
-  ZFINPerlModules->doSystemCommand("psql -d <!--|DB_NAME|--> -a -f loadAndUpdateNCBIOrthologs.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f loadAndUpdateNCBIOrthologs.sql");
 } catch {
   warn "Failed to execute loadAndUpdateNCBIOrthologs.sql - $_";
   exit -1;
 };
 
 
-$cmd = "psql -d <!--|DB_NAME|--> -a -f loadHumanSynonyms.sql";
+$cmd = "psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f loadHumanSynonyms.sql";
 ;
  
 &doSystemCommand($cmd);

--- a/server_apps/data_transfer/ORTHO/updateZebrafishGeneNames.pl
+++ b/server_apps/data_transfer/ORTHO/updateZebrafishGeneNames.pl
@@ -171,7 +171,7 @@ close(UPDATELIST);
 
 if ($ctProblem == 0) {
     try {
-      ZFINPerlModules->doSystemCommand("psql -d <!--|DB_NAME|--> -a -f updateZebrafishGeneNames.sql >updateZebrafishGeneNameSQLlog1");
+      ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f updateZebrafishGeneNames.sql >updateZebrafishGeneNameSQLlog1");
     } catch {
       warn "Failed to execute updateZebrafishGeneNames.sql - $_";
       exit -1;

--- a/server_apps/data_transfer/PUBMED/Journal/checkAndUpdateJournals.pl
+++ b/server_apps/data_transfer/PUBMED/Journal/checkAndUpdateJournals.pl
@@ -5,6 +5,8 @@
 
 use DBI;
 use Try::Tiny;
+use lib "<!--|ROOT_PATH|-->/server_apps/";
+use ZFINPerlModules;
 
 #set environment variables
 
@@ -71,7 +73,7 @@ close ALLJOURNALS;
 close NCBIJOURNALS;
 
 try {
-  system("psql -d <!--|DB_NAME|--> -a -f  checkAndUpdateJournals.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f  checkAndUpdateJournals.sql");
 } catch {
   warn "Failed to execute checkAndUpdateJournals.sql - $_";
   exit -1;

--- a/server_apps/data_transfer/PUBMED/Journal/mergeJournals.pl
+++ b/server_apps/data_transfer/PUBMED/Journal/mergeJournals.pl
@@ -136,7 +136,7 @@ print "\nct = $ct\n\n";
 system("/bin/rm -f <!--|ROOT_PATH|-->/server_apps/data_transfer/PUBMED/Journal/mergeJournalInput");
 
 try {
-  system("psql -d $dbname -a -f insertJournalAlias.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d $dbname -a -f insertJournalAlias.sql");
 } catch {
   warn "Failed to execute insertJournalAlias.sql - $_";
   exit -1;

--- a/server_apps/data_transfer/PUBMED/complete_auther_names.pl
+++ b/server_apps/data_transfer/PUBMED/complete_auther_names.pl
@@ -6,6 +6,8 @@ use DBI;
 use XML::Twig;
 use utf8;
 use Try::Tiny;
+use lib "<!--|ROOT_PATH|-->/server_apps/";
+use ZFINPerlModules;
 
 $dbname = "<!--|DB_NAME|-->";
 $username = "";
@@ -92,7 +94,7 @@ $dbh->disconnect();
 close $AUTHOR;
 
 try {
-  system("psql -d <!--|DB_NAME|--> -a -f load_complete_author_names.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f load_complete_author_names.sql");
 } catch {
   warn "Failed to execute load_complete_author_names.sql - $_";
   exit -1;

--- a/server_apps/data_transfer/PUBMED/fetchPubsFromPubMed.groovy
+++ b/server_apps/data_transfer/PUBMED/fetchPubsFromPubMed.groovy
@@ -141,7 +141,7 @@ PARSE_PUBS.withWriter { pubLog ->
     articles.eachWithIndex{ GPathResult article, int i -> processArticle(printer, article, i) }
 }
 
-dbaccessProc = ['/bin/bash', '-c', "${ZfinPropertiesEnum.PGBINDIR}/psql " +
+dbaccessProc = ['/bin/bash', '-c', "${ZfinPropertiesEnum.PGBINDIR}/psql -v ON_ERROR_STOP=1 " +
         "${ZfinPropertiesEnum.DB_NAME} -f ${WORKING_DIR.absolutePath}/loadNewPubs.sql " +
         ">${WORKING_DIR.absolutePath}/loadSQLOutput.log 2> ${WORKING_DIR.absolutePath}/loadSQLError.log"].execute()
 dbaccessProc.waitFor()

--- a/server_apps/data_transfer/PUBMED/getPDFandImages.groovy
+++ b/server_apps/data_transfer/PUBMED/getPDFandImages.groovy
@@ -293,22 +293,22 @@ new File(PUB_IDS_TO_CHECK).withReader { reader ->
 
 fetchBundlesForExistingPubs(idsToGrab, PUBS_WITH_PDFS_TO_UPDATE)
 
-givePubsPermissions = ['/bin/bash', '-c', "${ZfinPropertiesEnum.PGBINDIR}/psql " +
+givePubsPermissions = ['/bin/bash', '-c', "${ZfinPropertiesEnum.PGBINDIR}/psql -v ON_ERROR_STOP=1  " +
         "${ZfinPropertiesEnum.DB_NAME} -f ${WORKING_DIR.absolutePath}/give_pubs_permissions.sql " +
         ">${WORKING_DIR.absolutePath}/loadSQLOutput.log 2> ${WORKING_DIR.absolutePath}/loadSQLError.log"].execute()
 givePubsPermissions.waitFor()
 
-loadBasicPDFFiles = ['/bin/bash', '-c', "${ZfinPropertiesEnum.PGBINDIR}/psql " +
+loadBasicPDFFiles = ['/bin/bash', '-c', "${ZfinPropertiesEnum.PGBINDIR}/psql -v ON_ERROR_STOP=1 " +
         "${ZfinPropertiesEnum.DB_NAME} -f ${WORKING_DIR.absolutePath}/add_basic_pdfs.sql " +
         ">${WORKING_DIR.absolutePath}/loadSQLOutput.log 2> ${WORKING_DIR.absolutePath}/loadSQLError.log"].execute()
 loadBasicPDFFiles.waitFor()
 
-loadFigsAndImages = ['/bin/bash', '-c', "${ZfinPropertiesEnum.PGBINDIR}/psql " +
+loadFigsAndImages = ['/bin/bash', '-c', "${ZfinPropertiesEnum.PGBINDIR}/psql -v ON_ERROR_STOP=1 " +
         "${ZfinPropertiesEnum.DB_NAME} -f ${WORKING_DIR.absolutePath}/load_figs_and_images.sql " +
         ">${WORKING_DIR.absolutePath}/loadSQLOutput.log 2> ${WORKING_DIR.absolutePath}/loadSQLError.log"].execute()
 loadFigsAndImages.waitFor()
 
-loadPubFiles = ['/bin/bash', '-c', "${ZfinPropertiesEnum.PGBINDIR}/psql " +
+loadPubFiles = ['/bin/bash', '-c', "${ZfinPropertiesEnum.PGBINDIR}/psql -v ON_ERROR_STOP=1 " +
         "${ZfinPropertiesEnum.DB_NAME} -f ${WORKING_DIR.absolutePath}/load_pub_files.sql " +
         ">${WORKING_DIR.absolutePath}/loadSQLOutput.log 2> ${WORKING_DIR.absolutePath}/loadSQLError.log"].execute()
 loadPubFiles.waitFor()

--- a/server_apps/data_transfer/PUBMED/loadMeshTerms.groovy
+++ b/server_apps/data_transfer/PUBMED/loadMeshTerms.groovy
@@ -37,7 +37,7 @@ def parse (InputStream inputStream) {
 }
 
 def psql (String dbname, String sql) {
-  proc = "psql $dbname ".execute()
+  proc = "psql -v ON_ERROR_STOP=1 $dbname ".execute()
   proc.getOutputStream().with {
     write(sql.bytes)
     close()

--- a/server_apps/data_transfer/Panther/LoadAGR.groovy
+++ b/server_apps/data_transfer/Panther/LoadAGR.groovy
@@ -11,7 +11,7 @@ ZfinProperties.init("${System.getenv()['TARGETROOT']}/home/WEB-INF/zfin.properti
 
 
 def psql (String dbname, String sql) {
-    proc = "psql $dbname ".execute()
+    proc = "psql -v ON_ERROR_STOP=1 $dbname ".execute()
     proc.getOutputStream().with {
         write(sql.bytes)
         close()

--- a/server_apps/data_transfer/Panther/LoadPanther.groovy
+++ b/server_apps/data_transfer/Panther/LoadPanther.groovy
@@ -18,7 +18,7 @@ static Process dbaccess(String dbname, String sql) {
     println sql
 
     def proc
-    proc = "psql -d $dbname -a".execute()
+    proc = "psql -v ON_ERROR_STOP=1 -d $dbname -a".execute()
     proc.getOutputStream().with {
         write(sql.bytes)
         close()

--- a/server_apps/data_transfer/RNACentral/LoadRNACentralIDs.groovy
+++ b/server_apps/data_transfer/RNACentral/LoadRNACentralIDs.groovy
@@ -18,7 +18,7 @@ static Process dbaccess(String dbname, String sql) {
     println sql
 
     def proc
-    proc = "psql -d $dbname -a".execute()
+    proc = "psql -v ON_ERROR_STOP=1 -d $dbname -a".execute()
     proc.getOutputStream().with {
         write(sql.bytes)
         close()

--- a/server_apps/data_transfer/RNACentral/runTscriptSequenceLoad.pl
+++ b/server_apps/data_transfer/RNACentral/runTscriptSequenceLoad.pl
@@ -12,7 +12,7 @@ $dbname = "<!--|DB_NAME|-->";
 
 print "load transcripts that need sequences.\n";
 try {
-  ZFINPerlModules->doSystemCommand("psql -d <!--|DB_NAME|--> -a -f preLoadTranscriptSequence.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f preLoadTranscriptSequence.sql");
 } catch {
   warn "Failed to execute preLoadTranscriptSequence.sql - $_";
   exit -1;
@@ -24,7 +24,7 @@ try {
   exit -1;
 };
 try {
-  ZFINPerlModules->doSystemCommand("psql -d <!--|DB_NAME|--> -a -f loadTranscriptSequences.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f loadTranscriptSequences.sql");
 } catch {
   warn "Failed at loadTranscriptSequences - $_";
   exit -1;

--- a/server_apps/data_transfer/ResourceCenters/LoadZircPdfs.groovy
+++ b/server_apps/data_transfer/ResourceCenters/LoadZircPdfs.groovy
@@ -18,7 +18,7 @@ static Process dbaccess(String dbname, String sql) {
     println sql
 
     def proc
-    proc = "psql -d $dbname -a".execute()
+    proc = "psql -v ON_ERROR_STOP=1 -d $dbname -a".execute()
     proc.getOutputStream().with {
         write(sql.bytes)
         close()

--- a/server_apps/data_transfer/ResourceCenters/pullFromCZRC.pl
+++ b/server_apps/data_transfer/ResourceCenters/pullFromCZRC.pl
@@ -182,7 +182,7 @@ $dbh->commit();
 $dbh->disconnect();
 
 try {
-  ZFINPerlModules->doSystemCommand("psql -d <!--|DB_NAME|--> -a -f syncFishOrderThisLinks.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f syncFishOrderThisLinks.sql");
   #&sendLoadReport("Data transfer report","<!--|VALIDATION_EMAIL_DBA|-->", "<!--|ROOT_PATH|-->/server_apps/data_transfer/ResourceCenters/loadReport.txt") ;
 } catch {
   warn "Failed to execute syncFishOrderThisLinks.sh - $_";

--- a/server_apps/data_transfer/ResourceCenters/pullFromEZRC.pl
+++ b/server_apps/data_transfer/ResourceCenters/pullFromEZRC.pl
@@ -182,7 +182,7 @@ $dbh->commit();
 $dbh->disconnect();
 
 try {
-  ZFINPerlModules->doSystemCommand("psql -d <!--|DB_NAME|--> -a -f syncFishOrderThisLinks.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f syncFishOrderThisLinks.sql");
   #&sendLoadReport("Data transfer report","<!--|VALIDATION_EMAIL_DBA|-->", "<!--|ROOT_PATH|-->/server_apps/data_transfer/ResourceCenters/loadReport.txt") ;
 } catch {
   warn "Failed to execute syncFishOrderThisLinks.sh - $_";

--- a/server_apps/data_transfer/ResourceCenters/pullFromResourceCenter.pl
+++ b/server_apps/data_transfer/ResourceCenters/pullFromResourceCenter.pl
@@ -201,7 +201,7 @@ $dbh->commit();
 $dbh->disconnect();
 
 try {
-  ZFINPerlModules->doSystemCommand("psql -d <!--|DB_NAME|--> -a -f syncFishOrderThisLinks.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f syncFishOrderThisLinks.sql");
   #&sendLoadReport("Data transfer report","<!--|VALIDATION_EMAIL_DBA|-->", "<!--|ROOT_PATH|-->/server_apps/data_transfer/ResourceCenters/loadReport.txt") ;
 } catch {
   warn "Failed to execute syncFishOrderThisLinks.sh - $_";

--- a/server_apps/data_transfer/ResourceCenters/pullFromZIRC.pl
+++ b/server_apps/data_transfer/ResourceCenters/pullFromZIRC.pl
@@ -180,7 +180,7 @@ $dbh->commit();
 $dbh->disconnect();
 
 try {
-  ZFINPerlModules->doSystemCommand("psql -d <!--|DB_NAME|--> -a -f syncFishOrderThisLinks.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f syncFishOrderThisLinks.sql");
 } catch {
   warn "Failed to execute syncFishOrderThisLinks.sql - $_";
   exit -1;

--- a/server_apps/data_transfer/ResourceCenters/pushToZirc.pl
+++ b/server_apps/data_transfer/ResourceCenters/pushToZirc.pl
@@ -3,12 +3,14 @@
 #  output files are written to <!--|ROOT_PATH|-->/home/data_transfer/ZIRC/
 
 use Try::Tiny;
+use lib "<!--|ROOT_PATH|-->/server_apps/";
+use ZFINPerlModules;
 
 chdir "<!--|ROOT_PATH|-->/server_apps/data_transfer/ResourceCenters";
 umask(022);
 
 try {
-  system("${PGBINDIR}/psql <!--|DB_NAME|--> pushToZirc.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -f pushToZirc.sql");
 } catch {
   warn "Failed to execute pushToZirc.sql - $_";
   exit -1;

--- a/server_apps/data_transfer/SNP/addNewClonesJSmith.pl
+++ b/server_apps/data_transfer/SNP/addNewClonesJSmith.pl
@@ -5,6 +5,8 @@
 # add new clones associated with Jeff Smith SNPs
 # 
 use Try::Tiny;
+use lib "<!--|ROOT_PATH|-->/server_apps/";
+use ZFINPerlModules;
 
 ### set environment variables
 $ENV{"INFORMIXSQLHOSTS"}="<!--|INFORMIX_DIR|-->/etc/<!--|SQLHOSTS_FILE|-->";
@@ -112,7 +114,7 @@ print "ct1: $ct1\tct2: $ct2\tctNew: $ctNew\n";
 
 if ($ctNew > 0) {
   try {
-    system( "$ENV{'INFORMIXDIR'}/bin/dbaccess -a $ENV{'DATABASE'} loadClonesJSmith.sql" );
+    ZFINPerlModules->doSystemCommand( "$ENV{'INFORMIXDIR'}/bin/dbaccess -a $ENV{'DATABASE'} loadClonesJSmith.sql" );
   } catch {
     warn "Failed to execute loadClonesJSmith.sql - $_";
     exit -1;

--- a/server_apps/data_transfer/SNP/dbSNP.pl
+++ b/server_apps/data_transfer/SNP/dbSNP.pl
@@ -8,7 +8,8 @@
 
 use MIME::Lite;
 use DBI;
-
+use lib "<!--|ROOT_PATH|-->/server_apps/";
+use ZFINPerlModules;
 
 ### set environment variables
 $ENV{"INFORMIXSQLHOSTS"}="<!--|INFORMIX_DIR|-->/etc/<!--|SQLHOSTS_FILE|-->";
@@ -332,7 +333,7 @@ print "\n ctOutSmith: $ctOutSmith \t ctOutJohson: $ctOutJohson\t ctOutTalbot: $c
 
 if ($ctNew > 0) {
   try {
-    system( "psql -d <!--|DB_NAME|--> -a -f loadNewSNPs.sql > newSNPs.report.txt 2> loadDbSNPlog.txt" );
+    ZFINPerlModules->doSystemCommand( "psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f loadNewSNPs.sql > newSNPs.report.txt 2> loadDbSNPlog.txt" );
   } catch {
     &emailError("failed to load snp_download table");
     warn "Failed to execute loadNewSNPs.sql - $_";
@@ -458,7 +459,7 @@ print "\n ctJohson = $ctJohson \t ctSmith = $ctSmith \t ctTalbot: $ctTalbot \n\n
 
 if ($ctNew2 > 0) {
   try {
-    system( "psql -d <!--|DB_NAME|--> -a -f loadNewSNPAttrs.sql > newSNPattribution.report.txt 2> loadDbSNPlog2.txt" );
+    ZFINPerlModules->doSystemCommand( "psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f loadNewSNPAttrs.sql > newSNPattribution.report.txt 2> loadDbSNPlog2.txt" );
   } catch {
     &emailError("failed to load snp_download_attribution table");
     warn "Failed to execute loadNewSNPAttrs.sql - $_";
@@ -469,7 +470,7 @@ if ($ctNew2 > 0) {
 
 if ($ctNew3 > 0) {
   try {
-    system( "psql -d <!--|DB_NAME|--> -a -f addTalbotSNPAttr.sql > talbotAttribution.report.txt 2> loadDbSNPlog3.txt" );
+    ZFINPerlModules->doSystemCommand( "psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> -a -f addTalbotSNPAttr.sql > talbotAttribution.report.txt 2> loadDbSNPlog3.txt" );
   } catch {
     &emailError("failed to insert record_attribution table");
     warn "Failed to execute addTalbotSNPAttr.sql - $_";

--- a/server_apps/data_transfer/SWISS-PROT/backupTables.sh
+++ b/server_apps/data_transfer/SWISS-PROT/backupTables.sh
@@ -24,19 +24,19 @@ echo "Making csv backups "  $(date "+%Y-%m-%d %H:%M:%S")
 for t in $TABLES
 do
   echo " $t to $DIRECTORY/csv/$t.csv"
-  echo "copy (select * from $t order by 1,2,3) to stdout with csv header" | psql $DBNAME > $DIRECTORY/csv/$t.csv
+  echo "copy (select * from $t order by 1,2,3) to stdout with csv header" | psql -v ON_ERROR_STOP=1 $DBNAME > $DIRECTORY/csv/$t.csv
 done
 
 for t in $TABLES_WITH_1_COLUMN
 do
   echo " $t to $DIRECTORY/csv/$t.csv"
-  echo "copy (select * from $t order by 1) to stdout with csv header" | psql $DBNAME > $DIRECTORY/csv/$t.csv
+  echo "copy (select * from $t order by 1) to stdout with csv header" | psql -v ON_ERROR_STOP=1 $DBNAME > $DIRECTORY/csv/$t.csv
 done
 
 for t in $TABLES_WITH_2_COLUMN
 do
   echo " $t to $DIRECTORY/csv/$t.csv"
-  echo "copy (select * from $t order by 1,2) to stdout with csv header" | psql $DBNAME > $DIRECTORY/csv/$t.csv
+  echo "copy (select * from $t order by 1,2) to stdout with csv header" | psql -v ON_ERROR_STOP=1 $DBNAME > $DIRECTORY/csv/$t.csv
 done
 
 echo "Making sql backups "  $(date "+%Y-%m-%d %H:%M:%S")

--- a/server_apps/data_transfer/SWISS-PROT/loadsp_ec2go_part.pl
+++ b/server_apps/data_transfer/SWISS-PROT/loadsp_ec2go_part.pl
@@ -46,7 +46,7 @@ sub sendErrorReport ($) {
 
 sub downloadGOtermFiles () {
    try {
-      system("wget -q http://www.geneontology.org/external2go/ec2go -O ec2go");
+      ZFINPerlModules->doSystemCommand("wget -q http://www.geneontology.org/external2go/ec2go -O ec2go");
    } catch {
       chomp $_;
       &sendErrorReport("Failed to download http://www.geneontology.org/external2go/ec2go - $_");
@@ -71,7 +71,7 @@ system("rm -f *2go");
 print "\n delete records source from last ec2go loading.\n";
 ###system ("$ENV{'INFORMIXDIR'}/bin/dbaccess $ENV{'DB_NAME'} sp_delete_ec2gopart.sql >out 2>report.txt");
 try {
-  system("psql -v ON_ERROR_STOP=1 -d $ENV{'DB_NAME'} -a -f sp_delete_ec2gopart.sql > report.txt");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d $ENV{'DB_NAME'} -a -f sp_delete_ec2gopart.sql > report.txt");
 } catch {
   chomp $_;
   &sendErrorReport("Failed to execute sp_delete_ec2gopart.sql - $_");
@@ -82,7 +82,7 @@ try {
 
 print "\nectogo.pl ec2go\n";
 try {
-  system ("ectogo.pl ec2go");
+  ZFINPerlModules->doSystemCommand("ectogo.pl ec2go");
 } catch {
   chomp $_;
   &sendErrorReport("Failed at ectogo.pl ec2go - $_");
@@ -102,7 +102,7 @@ while( !( -e "ec_mrkrgoterm.unl")) {
       $retry = 0;
       print "retry ectogo.pl\n";
       try {
-        system("ectogo.pl ec2go");
+        ZFINPerlModules->doSystemCommand("ectogo.pl ec2go");
       } catch 
       {
         chomp $_;
@@ -121,7 +121,7 @@ while( !( -e "ec_mrkrgoterm.unl")) {
 # ------------ Loading ---------------------
 print "\nloading...\n";
 try {
-  system("psql -v ON_ERROR_STOP=1 -d $ENV{'DB_NAME'} -a -f sp_load_ec2gopart.sql >out 2> report2.txt");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d $ENV{'DB_NAME'} -a -f sp_load_ec2gopart.sql >out 2> report2.txt");
 } catch {
   chomp $_;
   &sendErrorReport("Failed to execute sp_load_ec2gopart.sql - $_");
@@ -141,7 +141,7 @@ close F;
 #----------- Match the obsolete/secondary go terms in the translation file -----
 print "\n deal with obsolete / secondary go terms \n";
 try {
-  system ("sp_badgo_report_ec2gopart.pl");
+  ZFINPerlModules->doSystemCommand ("sp_badgo_report_ec2gopart.pl");
 } catch {
   chomp $_;
   &sendErrorReport("Failed at sp_badgo_report_ec2gopart.pl ec2go - $_");

--- a/server_apps/data_transfer/SWISS-PROT/protein_domain_info_load.pl
+++ b/server_apps/data_transfer/SWISS-PROT/protein_domain_info_load.pl
@@ -418,7 +418,7 @@ $dbh->disconnect();
 
 # execute the sql file to do the loading
 try {
-  system("psql -v ON_ERROR_STOP=1 -d $ENV{'DB_NAME'} -a -f load_protein_domain_info.sql");
+  ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d $ENV{'DB_NAME'} -a -f load_protein_domain_info.sql");
 } catch {
   warn "Failed to execute load_protein_domain.sql - $_";
   exit -1;

--- a/server_apps/data_transfer/eco_go_mapping/getECOGOMapping.groovy
+++ b/server_apps/data_transfer/eco_go_mapping/getECOGOMapping.groovy
@@ -32,7 +32,7 @@ new File(OUTFILE).withWriter { outFile ->
     }
 }
 
-givePubsPermissions = ['/bin/bash', '-c', "${ZfinPropertiesEnum.PGBINDIR}/psql " +
+givePubsPermissions = ['/bin/bash', '-c', "${ZfinPropertiesEnum.PGBINDIR}/psql -v ON_ERROR_STOP=1 " +
         "${ZfinPropertiesEnum.DB_NAME} -f ${WORKING_DIR.absolutePath}/insert_eco_go_map.sql " +
         ">${WORKING_DIR.absolutePath}/loadSQLOutput.log 2> ${WORKING_DIR.absolutePath}/loadSQLError.log"].execute()
 givePubsPermissions.waitFor()

--- a/server_apps/data_transfer/zfishbook/zfishbook.pl
+++ b/server_apps/data_transfer/zfishbook/zfishbook.pl
@@ -8,6 +8,8 @@
 
 use MIME::Lite;
 use Try::Tiny;
+use lib "<!--|ROOT_PATH|-->/server_apps/";
+use ZFINPerlModules;
 
 #------------------ Send load output ----------------
 # 
@@ -154,7 +156,7 @@ print "\n\nStarting to load ...\n\n\n" if $doTheLoad > 0;
 
 if ($doTheLoad > 0)[
   try {
-    system("$ENV{'PGBINDIR'}/psql <!--|DB_NAME|--> < loadZfishbookData.sql >log1 2> log2") ;
+    ZFINPerlModules->doSystemCommand("psql -v ON_ERROR_STOP=1 -d <!--|DB_NAME|--> < loadZfishbookData.sql >log1 2> log2") ;
   } catch {
     warn "Failed to execute loadZfishbookData.sql - $_";
     exit -1;

--- a/server_apps/jenkins/jobs/Regen-Construct_d/config.xml
+++ b/server_apps/jenkins/jobs/Regen-Construct_d/config.xml
@@ -22,7 +22,7 @@
       <buildFile>$TARGETROOT/server_apps/DB_maintenance/build.xml</buildFile>
     </hudson.tasks.Ant>
     <hudson.tasks.Shell>
-      <command>echo &apos;select regen_construct()&apos; | psql $DBNAME </command>
+      <command>echo &apos;select regen_construct()&apos; | psql -v ON_ERROR_STOP=1 $DBNAME </command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>


### PR DESCRIPTION
Replace 'psql' with 'psql -v ON_ERROR_STOP=1' on all files that are referenced by jenkins jobs.

The affected jenkins jobs are:

Regen-Construct_d
CZRC-Resource-Center-Pull_d
Check-And-Update-Journals_w
CheckPaperBinStatus_d
Download-Files_d
EZRC-Resource-Center-Pull_d
Expression-Atlas_m
Fetch-Pubs-From-Pubmed-By-Accession
Fetch-Pubs-From-Pubmed_d
GenBank-Accession-Update_d
Gene-Association-File-Export_w
Generate-Annual-Statistics_m
Get-PDFsAndImages_d
Index-Faceted-Search_d
Lab-Address-Change_w
Load-Addgene_w
Load-AllianceGeneDesc_m
Load-AllianceLinks_m
Load-Complete-Author-Names_d
Load-External-Notes
Load-MeSH-Terms_m
Load-NCBIStartEndPositions
Load-Panther_m
Load-RNACentralLinks_m
Load-ZircPdfs_m
Merge-Journals
OMIM-Update_w
Phenotype-Statistics-Report_m
Refresh-GBrowse-Tracks_d
Regenerate-Chromosome-Mart_d
Regenerate-Expression-Mart_d
Regenerate-Phenotype-Mart_d
Run-Meow_w
Run-Regen-Functions_d
Run-ZFIN-Ensembl-Transcripts-Blast-Data-Dump_d
Uninformative-Gene-Nomenclature_m
Update-Gene-Name-According-To-Orthologue-Name
Update-Orthology_w
Update-Transcript_Sequences_w
ZGC-Report_m
ZIRC-Resource-Center-Pull_d