### PR TITLE
ZFIN-8179: Lab page alignment

### DIFF
--- a/home/WEB-INF/jsp/profile/company-view-summary.jsp
+++ b/home/WEB-INF/jsp/profile/company-view-summary.jsp
@@ -1,10 +1,10 @@
 <%@ include file="/WEB-INF/jsp-include/tag-import.jsp" %>
 
-<table>
+<table class="company-view-summary-table">
     <tr>
         <td>
             <z:attributeList>
-                <z:attributeListItem label="Contact Person">
+                <z:attributeListItem dtColSize="3" label="Contact Person">
                     <c:choose>
                         <c:when test="${empty company.contactPerson}">
                             <div class="error-inline">No Contact Person Assigned</div>
@@ -15,31 +15,31 @@
                     </c:choose>
                 </z:attributeListItem>
 
-                <z:attributeListItem label="Email">
+                <z:attributeListItem dtColSize="3" label="Email">
                     <a href="mailto:${company.email}">${company.email}</a>
                 </z:attributeListItem>
 
-                <z:attributeListItem label="URL">
+                <z:attributeListItem dtColSize="3" label="URL">
                     <zfin2:uriDisplay uri="${company.url}"/>
                 </z:attributeListItem>
 
-                <z:attributeListItem label="Address">
+                <z:attributeListItem dtColSize="3" label="Address">
                     <span class="postal-address">${company.address}</span>
                 </z:attributeListItem>
 
-                <z:attributeListItem label="Country">
+                <z:attributeListItem dtColSize="3" label="Country">
                     ${country}
                 </z:attributeListItem>
 
-                <z:attributeListItem label="Phone">
+                <z:attributeListItem dtColSize="3" label="Phone">
                     ${company.phone}
                 </z:attributeListItem>
 
-                <z:attributeListItem label="Fax">
+                <z:attributeListItem dtColSize="3" label="Fax">
                     ${company.fax}
                 </z:attributeListItem>
 
-                <z:attributeListItem label="Line Designation">
+                <z:attributeListItem dtColSize="3" label="Line Designation">
                     <c:choose>
                         <c:when test="${empty prefixes}">
                             <span class="no-data-tag">None assigned</span>

--- a/home/WEB-INF/jsp/profile/company-view.jsp
+++ b/home/WEB-INF/jsp/profile/company-view.jsp
@@ -10,7 +10,7 @@
 <c:set var="secs"
        value="${[SUMMARY, PRODUCTS, REPRESENTATIVE, CITATIONS]}"/>
 
-<z:dataPage sections="${secs}">
+<z:dataPage sections="${secs}" additionalBodyClass="company-view">
 
     <jsp:attribute name="entityName">
                 ${company.name}

--- a/home/WEB-INF/jsp/profile/lab-view-summary.jsp
+++ b/home/WEB-INF/jsp/profile/lab-view-summary.jsp
@@ -1,52 +1,52 @@
 <%@ include file="/WEB-INF/jsp-include/tag-import.jsp" %>
 
-<table>
+<table class="lab-view-summary-table">
     <tr>
         <td>
             <z:attributeList>
-                <z:attributeListItem label="Lab ID">
+                <z:attributeListItem dtColSize="3" label="Lab ID">
                     <span id="marker-id">${formBean.zdbID}</span>
                 </z:attributeListItem>
 
-                <z:attributeListItem label="PI / Directory">
+                <z:attributeListItem dtColSize="3" label="PI / Directory">
                     <zfin2:listMembers members="${members}" only="1" suppressTitle="true" suffix="<br>"/>
                 </z:attributeListItem>
 
                 <c:if test="${hasCoPi}">
-                    <z:attributeListItem label="Co-PI / Senior<br/> Researcher">
+                    <z:attributeListItem dtColSize="3" label="Co-PI / Senior<br/> Researcher">
                         <zfin2:listMembers members="${members}" only="2" suppressTitle="true" suffix="<br>"/>
                     </z:attributeListItem>
                 </c:if>
 
-                <z:attributeListItem label="Contact Person">
+                <z:attributeListItem dtColSize="3" label="Contact Person">
                     <zfin:link entity="${formBean.contactPerson}"/>
                 </z:attributeListItem>
 
-                <z:attributeListItem label="Email">
+                <z:attributeListItem dtColSize="3" label="Email">
                     <a href="mailto:${formBean.email}">${formBean.email}</a>
                 </z:attributeListItem>
 
-                <z:attributeListItem label="URL">
+                <z:attributeListItem dtColSize="3" label="URL">
                     <zfin2:uriDisplay uri="${formBean.url}"/>
                 </z:attributeListItem>
 
-                <z:attributeListItem label="Address">
+                <z:attributeListItem dtColSize="3" label="Address">
                     <span class="postal-address">${formBean.address}</span>
                 </z:attributeListItem>
 
-                <z:attributeListItem label="Country">
+                <z:attributeListItem dtColSize="3" label="Country">
                     <zfin2:uriDisplay uri="${country}"/>
                 </z:attributeListItem>
 
-                <z:attributeListItem label="Phone">
+                <z:attributeListItem dtColSize="3" label="Phone">
                     ${formBean.phone}
                 </z:attributeListItem>
 
-                <z:attributeListItem label="Fax">
+                <z:attributeListItem dtColSize="3" label="Fax">
                     ${formBean.fax}
                 </z:attributeListItem>
 
-                <z:attributeListItem label="Line Designation">
+                <z:attributeListItem dtColSize="3" label="Line Designation">
                     <c:choose>
                         <c:when test="${noPrefixes}">
                             <span class="no-data-tag">None assigned</span>

--- a/home/WEB-INF/jsp/profile/lab-view.jsp
+++ b/home/WEB-INF/jsp/profile/lab-view.jsp
@@ -11,7 +11,7 @@
 <c:set var="secs"
        value="${[SUMMARY, GENOMIC_FEATURES, STATEMENT, MEMBERS, CITATIONS]}"/>
 
-<z:dataPage sections="${secs}">
+<z:dataPage sections="${secs}" additionalBodyClass="lab-view">
 
     <jsp:attribute name="entityName">
                 ${formBean.name}

--- a/home/WEB-INF/tags/layout/attributeListItem.tag
+++ b/home/WEB-INF/tags/layout/attributeListItem.tag
@@ -3,12 +3,18 @@
 <%@ attribute name="label" required="true" rtexprvalue="true" %>
 <%@ attribute name="link" required="false" rtexprvalue="true" %>
 
+<%@ attribute name="dtColSize" required="false" type="java.lang.Integer" %>
+<c:set var="dtColSize" value="${(empty dtColSize) ? 2 : dtColSize}" />
+
+<%@ attribute name="ddColSize" required="false" type="java.lang.Integer" %>
+<c:set var="ddColSize" value="${(empty ddColSize) ? 12 - dtColSize : ddColSize}" />
+
 <c:choose>
     <c:when test="${link != null}">
-        <dt class="col-sm-2 mb-sm-2"><a href="${link}">${label}</a></dt>
+        <dt class="col-sm-${dtColSize} mb-sm-2"><a href="${link}">${label}</a></dt>
     </c:when>
     <c:otherwise>
-        <dt class="col-sm-2 mb-sm-2">${label}</dt>
+        <dt class="col-sm-${dtColSize} mb-sm-2">${label}</dt>
     </c:otherwise>
 </c:choose>
-<dd class="col-sm-10"><jsp:doBody /></dd>
+<dd class="col-sm-${ddColSize}"><jsp:doBody /></dd>

--- a/home/WEB-INF/tags/layout/dataPage.tag
+++ b/home/WEB-INF/tags/layout/dataPage.tag
@@ -6,10 +6,13 @@
 <%@ attribute name="title" required="false" %>
 <%@ attribute name="pageBar" required="false" %>
 
+<%@ attribute name="additionalBodyClass" required="false" type="java.lang.String" %>
+<c:set var="additionalBodyClass" value="${(empty additionalBodyClass) ? '' : additionalBodyClass}" />
+
 <jsp:invoke fragment="entityName" var="entityNameValue"/>
 <jsp:invoke fragment="entityNameAddendum" var="entityNameAddendumValue"/>
 
-<z:page bodyClass="data-page" bootstrap="true" title="${title}">
+<z:page bodyClass="data-page" additionalBodyClass="${additionalBodyClass}" bootstrap="true" title="${title}">
     <div class="d-flex h-100">
         <div class="data-page-nav-container">
             <ul class="nav nav-pills flex-column">

--- a/home/WEB-INF/tags/layout/page.tag
+++ b/home/WEB-INF/tags/layout/page.tag
@@ -8,6 +8,10 @@
 <%@ attribute name="bodyClass" rtexprvalue="true" required="false" type="java.lang.String" %>
 <%@ attribute name="bootstrap" required="false" type="java.lang.Boolean" %>
 
+<%@ attribute name="additionalBodyClass" required="false" type="java.lang.String" %>
+<c:set var="additionalBodyClass" value="${(empty additionalBodyClass) ? '' : additionalBodyClass}" />
+
+
 <c:if test="${empty title}">
     <c:set var="title">
         ZFIN ${dynamicTitle}
@@ -63,7 +67,7 @@ Community Action Needed: Please respond to the <a href="https://zfin.atlassian.n
 </pre>
         </div>
 --%>
-    <body class="${bodyClass}">
+    <body class="${bodyClass} ${additionalBodyClass}">
         <z:pageHeader/>
         <main>
             <jsp:doBody/>

--- a/home/css/datapage.scss
+++ b/home/css/datapage.scss
@@ -345,3 +345,25 @@ tr.spaceUnder > td{
         background: $grey-light;
     }
 }
+
+/* Lab and company page formatting */
+table.lab-view-summary-table td:first-child, table.company-view-summary-table td:first-child {
+    min-width: 440px;
+}
+table.lab-view-summary-table dt, table.company-view-summary-table dt,  {
+     white-space: nowrap;
+}
+table.lab-view-summary-table dd a, table.company-view-summary-table dd a {
+    white-space: nowrap;
+    width: 100%;
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.lab-view a.back-to-top-link, .company-view a.back-to-top-link {
+    display: inline;
+    white-space: normal;
+}
+/* End of lab page formatting */
+
+


### PR DESCRIPTION
Fix wrapping of dt values and dd values in lab and company pages. Fix display of long company and lab names so they use ellipses.

- add option to pass an additional body class tag for styling specific pages
- add option to adjust column width of dt/dd pairs in attributeListItem.tag