### PR TITLE
ZFIN-8191: Clean up record_attribution table

### DIFF
--- a/source/org/zfin/db/postGmakePostloaddb/1135/db.changelog.master.xml
+++ b/source/org/zfin/db/postGmakePostloaddb/1135/db.changelog.master.xml
@@ -10,6 +10,7 @@
     <include file="source/org/zfin/db/postGmakePostloaddb/1135/ZFIN-8152.sql" />
     <include file="source/org/zfin/db/postGmakePostloaddb/1135/ZFIN-8188-remove-unmatched-closing-div-tag.sql" />
     <include file="source/org/zfin/db/postGmakePostloaddb/1135/ZFIN-8167-add-timestamp-columns-to-record-attribution.sql" />
+    <include file="source/org/zfin/db/postGmakePostloaddb/1135/ZFIN-8191.sql" />
 
 
 </databaseChangeLog>


### PR DESCRIPTION
Using the record_attribution table snapshots from 3/10/22 to 9/25/22 as a guide, this liquibase script reverts the changes that happened due to a bug (ZFIN-8167).