### PR TITLE
ZFIN-8213: Genotype prototype title overflow in left nav

### DIFF
--- a/home/WEB-INF/jsp/fish/genotype-view.jsp
+++ b/home/WEB-INF/jsp/fish/genotype-view.jsp
@@ -9,7 +9,7 @@
 <c:set var="COMPOSITION" value="Genotype Composition"/>
 <c:set var="CITATIONS" value="Citations"/>
 
-<z:dataPage sections="${[SUMMARY, NOTE, COMPOSITION, FISH, CITATIONS]}">
+<z:dataPage sections="${[SUMMARY, NOTE, COMPOSITION, FISH, CITATIONS]}" additionalBodyClass="genotype-view">
 
 <jsp:attribute name="entityName">
         <zfin:name entity="${genotype}"/>

--- a/home/css/datapage.scss
+++ b/home/css/datapage.scss
@@ -367,3 +367,9 @@ table.lab-view-summary-table dd a, table.company-view-summary-table dd a {
 /* End of lab page formatting */
 
 
+/* Genotype page formatting */
+.genotype-view a.back-to-top-link {
+    display: inline;
+    white-space: normal; /* <-- remove for ellipses truncation */
+}
+/* End of genotype page formatting */


### PR DESCRIPTION
Fix the overflow of the title in the left navigation for genotype pages.