### PR TITLE
ZFIN-8093:

### DIFF
--- a/conf/hibernate.cfg.xml
+++ b/conf/hibernate.cfg.xml
@@ -168,6 +168,7 @@
         <mapping class="org.zfin.sequence.ProteinToInterPro"/>
         <mapping class="org.zfin.sequence.ProteinToPDB"/>
         <mapping class="org.zfin.sequence.MarkerToProtein"/>
+        <mapping class="org.zfin.sequence.ReferenceProtein"/>
         <mapping class="org.zfin.sequence.reno.Candidate"/>
         <mapping class="org.zfin.sequence.reno.NomenclatureRun"/>
         <mapping class="org.zfin.sequence.reno.RedundancyRun"/>

--- a/source/org/zfin/marker/presentation/MarkerLinkController.java
+++ b/source/org/zfin/marker/presentation/MarkerLinkController.java
@@ -349,6 +349,7 @@ public class MarkerLinkController {
     public String deleteMarkerLink(@PathVariable String linkId) {
         HibernateUtil.createTransaction();
         DBLink link = sequenceRepository.getDBLinkByID(linkId);
+        sequenceRepository.deleteReferenceProteinByDBLinkID(linkId);
         sequenceRepository.removeDBLinks(Collections.singletonList(link));
         HibernateUtil.flushAndCommitCurrentSession();
         return "OK";

--- a/source/org/zfin/marker/presentation/MarkerReferenceBean.java
+++ b/source/org/zfin/marker/presentation/MarkerReferenceBean.java
@@ -3,27 +3,16 @@ package org.zfin.marker.presentation;
 import org.zfin.publication.Publication;
 
 import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
 public class MarkerReferenceBean {
 
     private String zdbID;
     private String title;
-
-    public String getZdbID() {
-        return zdbID;
-    }
-
-    public void setZdbID(String zdbID) {
-        this.zdbID = zdbID;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
+    private String dataZdbID;
 
     public static MarkerReferenceBean convert(Publication publication) {
         MarkerReferenceBean bean = new MarkerReferenceBean();

--- a/source/org/zfin/marker/repository/HibernateMarkerRepository.java
+++ b/source/org/zfin/marker/repository/HibernateMarkerRepository.java
@@ -1969,7 +1969,9 @@ public class HibernateMarkerRepository implements MarkerRepository {
 
                 if (tuple.length > 11 && tuple[11] != null) {
                     reference.setTitle(tuple[11].toString());
-
+                }
+                if (tuple.length > 9 && tuple[9] != null) {
+                    reference.setDataZdbID(tuple[9].toString());
                 }
                 linkDisplay.addReference(reference);
             }
@@ -2000,12 +2002,13 @@ public class HibernateMarkerRepository implements MarkerRepository {
             Map<String, LinkDisplay> linkMap = new HashMap<>();
             for (Object o : list) {
                 LinkDisplay display = (LinkDisplay) o;
-                LinkDisplay displayStored = linkMap.get(display.getAccession());
+                String linkKey = display.getAccession() + ":" + display.getReferenceDatabaseZdbID();
+                LinkDisplay displayStored = linkMap.get(linkKey);
                 if (displayStored != null) {
                     displayStored.addReferences(display.getReferences());
-                    linkMap.put(displayStored.getAccession(), displayStored);
+                    linkMap.put(linkKey, displayStored);
                 } else {
-                    linkMap.put(display.getAccession(), display);
+                    linkMap.put(linkKey, display);
                 }
 
             }

--- a/source/org/zfin/sequence/repository/HibernateSequenceRepository.java
+++ b/source/org/zfin/sequence/repository/HibernateSequenceRepository.java
@@ -1256,6 +1256,15 @@ public class HibernateSequenceRepository implements SequenceRepository {
     public Integer deleteUnitProtProteome() {
         return HibernateUtil.currentSession().createQuery("delete ReferenceProtein").executeUpdate();
     }
+
+    @Override
+    public Integer deleteReferenceProteinByDBLinkID(String dbLinkID) {
+        Session session = HibernateUtil.currentSession();
+        String hql = "delete from ReferenceProtein rp where rp.uniprotAccession.zdbID = :dbLinkID";
+        Query query = session.createQuery(hql);
+        query.setParameter("dbLinkID", dbLinkID);
+        return query.executeUpdate();
+    }
 }
 
 

--- a/source/org/zfin/sequence/repository/SequenceRepository.java
+++ b/source/org/zfin/sequence/repository/SequenceRepository.java
@@ -153,6 +153,9 @@ public interface SequenceRepository {
     List<DBLink> getAllEnsemblTranscripts();
 
     Integer deleteUnitProtProteome();
+
+    Integer deleteReferenceProteinByDBLinkID(String dbLinkID);
+
 }
 
 


### PR DESCRIPTION
Do not aggregate sequence dblinks by accession on the marker edit page (eg. https://cell.zfin.org/action/marker/gene/prototype-edit/ZDB-GENE-090313-318).  Instead aggregate by combination of accession and foreign_db.

Also, if deleting a db_link, delete the associated link in the reference protein table.