### PR TITLE
ZFIN-7933: solr configuration change (splitOnNumerics)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -751,7 +751,7 @@ dependencies {
     implementation group: 'org.fusesource.restygwt', name: 'restygwt', version: '2.2.0'
     implementation group: 'org.jboss.spec.javax.ws.rs', name: 'jboss-jaxrs-api_2.1_spec', version: '2.0.1.Final'
 //    implementation group: 'javax.ws.rs', name: 'jsr311-api', version: '1.1.1'
-    implementation group: 'org.apache.solr', name: 'solr-solrj', version: '6.4.2'
+    implementation group: 'org.apache.solr', name: 'solr-solrj', version: '8.6.3'
     implementation group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.1'
     implementation group: 'commons-cli', name: 'commons-cli', version: '1.2'
     implementation group: 'org.freemarker', name: 'freemarker', version: '2.3.20'
@@ -905,6 +905,15 @@ test {
         includeTestsMatching "org.zfin.search.service.SolrQueryFacadeSpec"
         includeTestsMatching "org.zfin.search.service.MarkerSearchServiceSpec"
         includeTestsMatching "org.zfin.search.service.SearchSuggestionServiceSpec"
+
+        includeTestsMatching "org.zfin.ontology.service.RibbonServiceIntegrationSpec"
+        includeTestsMatching "org.zfin.uniquery.RelatedLinksSpec"
+
+//      Failing tests that we may want to bring back: (ZFIN-8271)
+//        includeTestsMatching "org.zfin.uniquery.CategoriesAndFacetsSpec"
+//        includeTestsMatching "org.zfin.uniquery.QuerySpec"
+//        includeTestsMatching "org.zfin.uniquery.ResultAttributesSpec"
+        
         includeTestsMatching "org.zfin.sequence.repository.SequenceRepositorySpec"
         includeTestsMatching "org.zfin.feature.FeatureServiceSpec"
         includeTestsMatching "org.zfin.curation.service.CurationDTOConversionServiceSpec"

--- a/buildfiles/solr-ant.xml
+++ b/buildfiles/solr-ant.xml
@@ -67,6 +67,7 @@
 
     <target name="build-solr-index">
         <echo message="Starting Solr index build via http..."/>
+        <echo message="URL: http://${SOLR_HOST}:${SOLR_PORT}/solr/${SOLR_CORE}/dataimport?command=full-import&amp;optimize=true&amp;clean=true&amp;wt=json&amp;indent=true"/>
         <exec executable="curl">
             <arg value="-s"/>
             <arg value="http://${SOLR_HOST}:${SOLR_PORT}/solr/${SOLR_CORE}/dataimport?command=full-import&amp;optimize=true&amp;clean=true&amp;wt=json&amp;indent=true"/>

--- a/server_apps/solr/site_index/conf/schema.xml
+++ b/server_apps/solr/site_index/conf/schema.xml
@@ -71,7 +71,7 @@
             <analyzer type="index">
                 <tokenizer class="solr.StandardTokenizerFactory"/>
                 <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-                <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="1" splitOnCaseChange="0" preserveOriginal="1"/>
+                <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="1" splitOnCaseChange="0" preserveOriginal="1" splitOnNumerics="0" types="wdgff_types.txt"/>
                 <filter class="solr.FlattenGraphFilterFactory"/>
                 <filter class="solr.ASCIIFoldingFilterFactory"/>
                 <filter class="solr.LowerCaseFilterFactory"/>
@@ -84,7 +84,7 @@
                 <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
                 <!-- it's possible that we don't want preserveOriginal here, since it puts in a pair of queries that both need to match....but then, because preserve original is on above,
                      they both sould be in there... something to consider at least -->
-                <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="1" splitOnCaseChange="0" preserveOriginal="1"/>
+                <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="1" splitOnCaseChange="0" preserveOriginal="1" splitOnNumerics="0" types="wdgff_types.txt"/>
                 <filter class="solr.ASCIIFoldingFilterFactory"/>
                 <filter class="solr.LowerCaseFilterFactory"/>
                 <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>

--- a/server_apps/solr/site_index/conf/wdgff_types.txt
+++ b/server_apps/solr/site_index/conf/wdgff_types.txt
@@ -1,0 +1,15 @@
+# A customized type mapping for WordDelimiterFilterFactory
+# the allowable types are: LOWER, UPPER, ALPHA, DIGIT, ALPHANUM, SUBWORD_DELIM
+#
+# the default for any character without a mapping is always computed from
+# Unicode character properties
+
+# Map the $, %, '.', and ',' characters to DIGIT
+# This might be useful for financial data.
+
+# Example for indexing text like twitter's hash and at symbol usage from https://stackoverflow.com/questions/9299614
+# @ => ALPHA
+# \u0023 => ALPHA
+
+# Including underscore as an ALPHA character for such terms as XM_694032
+_ => ALPHA


### PR DESCRIPTION
Add configuration splitOnNumerics="0" so that something like ENSDARG000000037177 doesn't get split into "ENSDARG" and "000000037177".