### PR TITLE
ZFIN-8266: Fix construct search (example fli1:Dsred)

### DIFF
--- a/server_apps/solr/site_index/conf/db-data-config.xml
+++ b/server_apps/solr/site_index/conf/db-data-config.xml
@@ -1956,7 +1956,7 @@
                      full outer join fluorescent_marker as fm on fm.fm_mrkr_zdb_id = construct_zdb_id
                      full outer join fluorescent_color as fcm on fcm.fc_color = fm.fm_emission_color
                      full outer join fluorescent_color as fcx on fcx.fc_color = fm.fm_excitation_color
-                     where fm.fm_mrkr_zdb_id ~ 'CONSTRCT'
+                     where construct_zdb_id is not null
                     "
         >
 


### PR DESCRIPTION
Fix constraint to reference construct table instead of fluorescent_marker table so that search returns constructs even if they don't have relationships to fluorescent markers.