### PR TITLE
ZFIN-8280: Publication Navigation Counts

### DIFF
--- a/home/WEB-INF/jsp/publication/publication-image-gallery.jsp
+++ b/home/WEB-INF/jsp/publication/publication-image-gallery.jsp
@@ -1,12 +1,6 @@
 <%@ include file="/WEB-INF/jsp-include/tag-import.jsp" %>
 <%@ page import="org.zfin.properties.ZfinPropertiesEnum" %>
 
-<style>
-    #xpresimg_control_box {
-        margin-top: 20px;
-    }
-</style>
-
 <c:if test="${!empty imageResults}">
     <div id="xpresimg_all">
         <input type="hidden" name="xpatsel_thumbnail_page" id="xpatsel_thumbnail_page_hidden_field" value="1"/>

--- a/home/WEB-INF/jsp/publication/publication-view.jsp
+++ b/home/WEB-INF/jsp/publication/publication-view.jsp
@@ -45,13 +45,14 @@
     </c:otherwise>
 </c:choose>
 
-<z:dataPage sections="${secs}">
+<z:dataPage sections="${secs}" useNavigationCounter="${useNavigationCounter}" additionalBodyClass="publication-view">
 
     <jsp:attribute name="entityName">
         <div data-toggle="tooltip" data-placement="bottom" title="${publication.citation}">
                 ${publication.shortAuthorList}
         </div>
     </jsp:attribute>
+
     <jsp:attribute name="entityNameAddendum">
         <div style="font-size: 12px">
                 ${publication.zdbID}
@@ -97,68 +98,96 @@
         </z:section>
 
         <z:section title="${GENES}">
-            <div class="__react-root" id="PublicationMarkerTable"
-                 data-url="/action/api/publication/${publication.zdbID}/marker"></div>
+            <div class="__react-root __use-navigation-counter" id="PublicationMarkerTable__0"
+                 data-url="/action/api/publication/${publication.zdbID}/marker"
+                 data-title="${GENES}"
+            ></div>
         </z:section>
 
         <z:section title="${FIGURES}" infoPopup="/ZFIN/help_files/expression_help.html">
-            <jsp:include page="publication-image-gallery.jsp"/>
+            <div class="__react-root __use-navigation-counter" id="PublicationFigureDisplay"
+                 data-title="${FIGURES}"
+                 data-images-json="${imagesJson}"
+                 data-publication-id="${publication.zdbID}"
+            ></div>
         </z:section>
 
         <z:section title="${EXPRESSION}">
-            <div class="__react-root" id="FigureExpressionTable"
-                 data-url="/action/api/publication/${publication.zdbID}/expression"></div>
+            <div class="__react-root __use-navigation-counter" id="FigureExpressionTable"
+                 data-url="/action/api/publication/${publication.zdbID}/expression"
+                 data-title="${EXPRESSION}"
+            ></div>
         </z:section>
 
         <z:section title="${PHENOTYPE}">
-            <div class="__react-root" id="FigurePhenotypeTable"
-                 data-url="/action/api/publication/${publication.zdbID}/phenotype"></div>
+            <div class="__react-root __use-navigation-counter" id="FigurePhenotypeTable"
+                 data-url="/action/api/publication/${publication.zdbID}/phenotype"
+                 data-title="${PHENOTYPE}"
+            ></div>
         </z:section>
 
         <z:section title="${MUTATION}">
-            <div class="__react-root" id="PublicationMutationTable"
-                 data-url="/action/api/publication/${publication.zdbID}/features"></div>
+            <div class="__react-root __use-navigation-counter" id="PublicationMutationTable"
+                 data-url="/action/api/publication/${publication.zdbID}/features"
+                 data-title="${MUTATION}"
+            ></div>
         </z:section>
 
         <z:section title="${DISEASE}">
-            <div class="__react-root" id="PublicationDiseaseTable"
-                 data-url="/action/api/publication/${publication.zdbID}/diseases"></div>
+            <div class="__react-root __use-navigation-counter" id="PublicationDiseaseTable"
+                 data-url="/action/api/publication/${publication.zdbID}/diseases"
+                 data-title="${DISEASE}"
+            ></div>
         </z:section>
 
         <z:section title="${STRS}">
-            <div class="__react-root" id="StrTable"
-                 data-url="/action/api/publication/${publication.zdbID}/strs"></div>
+            <div class="__react-root __use-navigation-counter" id="StrTable"
+                 data-url="/action/api/publication/${publication.zdbID}/strs"
+                 data-title="${STRS}"
+            ></div>
         </z:section>
 
         <z:section title="${FISH}">
-            <div class="__react-root" id="PublicationFishTable"
-                 data-url="/action/api/publication/${publication.zdbID}/fish"></div>
+            <div class="__react-root __use-navigation-counter" id="PublicationFishTable"
+                 data-url="/action/api/publication/${publication.zdbID}/fish"
+                 data-title="${FISH}"
+            ></div>
         </z:section>
 
         <z:section title="${ANTIBODIES}" infoPopup="/action/marker/note/antibodies">
-            <div class="__react-root" id="AntibodyTable"
-                 data-url="/action/api/publication/${publication.zdbID}/antibodies"></div>
+            <div class="__react-root __use-navigation-counter" id="AntibodyTable"
+                 data-url="/action/api/publication/${publication.zdbID}/antibodies"
+                 data-title="${ANTIBODIES}"
+            ></div>
         </z:section>
 
         <z:section title="${ORTHOLOGY}">
-            <div class="__react-root" id="PublicationOrthologyTable"
-                 data-url="/action/api/publication/${publication.zdbID}/orthology"></div>
+            <div class="__react-root __use-navigation-counter" id="PublicationOrthologyTable"
+                 data-url="/action/api/publication/${publication.zdbID}/orthology"
+                 data-title="${ORTHOLOGY}"
+            ></div>
         </z:section>
 
         <z:section title="${EFGs}">
-            <div class="__react-root" id="PublicationMarkerTable"
-                 data-url="/action/api/publication/${publication.zdbID}/efgs"></div>
+            <div class="__react-root __use-navigation-counter" id="PublicationMarkerTable__1"
+                 data-url="/action/api/publication/${publication.zdbID}/efgs"
+                 data-title="${EFGs}"
+            ></div>
         </z:section>
 
         <z:section title="${MAPPING}">
-            <div class="__react-root" id="PublicationMappingTable"
-                 data-url="/action/api/publication/${publication.zdbID}/mapping"></div>
+            <div class="__react-root __use-navigation-counter" id="PublicationMappingTable"
+                 data-url="/action/api/publication/${publication.zdbID}/mapping"
+                 data-title="${MAPPING}"
+            ></div>
         </z:section>
 
         <authz:authorize access="hasRole('root')">
             <z:section title="${DIRECTLY_ATTRIBUTED_DATA}">
-                <div class="__react-root" id="PublicationAttributionTable"
-                     data-url="/action/api/publication/${publication.zdbID}/direct-attribution"></div>
+                <div class="__react-root __use-navigation-counter" id="PublicationAttributionTable"
+                     data-url="/action/api/publication/${publication.zdbID}/direct-attribution"
+                     data-title="${DIRECTLY_ATTRIBUTED_DATA}"
+                ></div>
             </z:section>
         </authz:authorize>
 

--- a/home/WEB-INF/tags/layout/dataPage.tag
+++ b/home/WEB-INF/tags/layout/dataPage.tag
@@ -5,8 +5,9 @@
 <%@ attribute name="entityNameAddendum" required="false" fragment="true" %>
 <%@ attribute name="title" required="false" %>
 <%@ attribute name="pageBar" required="false" %>
-
 <%@ attribute name="additionalBodyClass" required="false" type="java.lang.String" %>
+<%@ attribute name="useNavigationCounter" required="false" type="java.lang.Boolean" %>
+
 <c:set var="additionalBodyClass" value="${(empty additionalBodyClass) ? '' : additionalBodyClass}" />
 
 <jsp:invoke fragment="entityName" var="entityNameValue"/>
@@ -29,9 +30,7 @@
                     </li>
                 </c:if>
                 <c:forEach var="section" items="${sections}">
-                    <li class="nav-item" role="presentation">
-                        <a class="nav-link" href="#${zfn:makeDomIdentifier(section)}">${section}</a>
-                    </li>
+                    <z:navigationItem title="${section}" useNavigationCounter="${useNavigationCounter}" />
                 </c:forEach>
             </ul>
         </div>

--- a/home/WEB-INF/tags/layout/navigationItem.tag
+++ b/home/WEB-INF/tags/layout/navigationItem.tag
@@ -1,0 +1,13 @@
+<%@ include file="/WEB-INF/jsp-include/tag-import.jsp" %>
+<%@ tag pageEncoding="UTF-8" %>
+<%@ attribute name="title" type="java.lang.String" required="true" description="title of this navigation item" %>
+<%@ attribute name="useNavigationCounter" required="false" %>
+
+<li class="nav-item" role="presentation">
+    <a class="nav-link" href="#${zfn:makeDomIdentifier(title)}">
+        ${title}
+        <c:if test="${useNavigationCounter}">
+            <span class="__react-root __use-navigation-counter" id="NavigationItem" data-title="${title}"></span>
+        </c:if>
+    </a>
+</li>

--- a/home/css/datapage.scss
+++ b/home/css/datapage.scss
@@ -367,3 +367,8 @@ table.lab-view-summary-table dd a, table.company-view-summary-table dd a {
     display: inline;
     white-space: normal; /* <-- remove for ellipses truncation */
 }
+
+/* Set margin for figure component on publication view page */
+.publication-view #xpresimg_control_box {
+    margin-top: 20px;
+}

--- a/home/javascript/react/components/data-table/DataProvider.js
+++ b/home/javascript/react/components/data-table/DataProvider.js
@@ -37,7 +37,7 @@ const DataProvider = ({
     const data = useTableDataFetch(dataUrl, tableState);
     useEffect(() => {
         if (typeof onDataLoaded === 'function' && !data.loading && !data.rejected && data.value && data.value.total > 0) {
-            onDataLoaded();
+            onDataLoaded(data.value);
         }
         if (typeof onDataLoadedCount === 'function' && !data.loading && !data.rejected && data.value &&
             data.value.supplementalData && data.value.supplementalData.countIncludingChildren) {

--- a/home/javascript/react/containers/AntibodyTable.js
+++ b/home/javascript/react/containers/AntibodyTable.js
@@ -4,7 +4,7 @@ import DataTable from '../components/data-table';
 import CommaSeparatedList from '../components/CommaSeparatedList';
 import {EntityLink, EntityList} from '../components/entity';
 
-const AntibodyTable = ({url}) => {
+const AntibodyTable = ({url, title, navigationCounter}) => {
     const columns = [
         {
             label: 'Name',
@@ -36,12 +36,20 @@ const AntibodyTable = ({url}) => {
             ),
         },
     ];
+
+    const handleDataLoadedCount = (data) => {
+        if (navigationCounter && navigationCounter.setCounts && data.total) {
+            navigationCounter.setCounts(title, data.total);
+        }
+    };
+
     return (
         <DataTable
             columns={columns}
             dataUrl={url}
             rowKey={row => row.zdbID}
             pagination={true}
+            onDataLoaded={handleDataLoadedCount}
         />
     );
 };

--- a/home/javascript/react/containers/FigureExpressionTable.js
+++ b/home/javascript/react/containers/FigureExpressionTable.js
@@ -7,7 +7,7 @@ import PostComposedEntity from '../components/PostComposedEntity';
 import Figure from '../components/Figure';
 
 
-const FigureExpressionTable = ({url, hideFigureColumn = false}) => {
+const FigureExpressionTable = ({url, hideFigureColumn = false, navigationCounter, title}) => {
 
     const columns = [
         {
@@ -81,12 +81,20 @@ const FigureExpressionTable = ({url, hideFigureColumn = false}) => {
             hidden: hideFigureColumn
         },
     ];
+
+    const handleDataLoadedCount = (data) => {
+        if (navigationCounter && navigationCounter.setCounts && data.total) {
+            navigationCounter.setCounts(title, data.total);
+        }
+    };
+
     return (
         <DataTable
             columns={columns}
             dataUrl={url}
             rowKey={row => row.id}
             pagination={true}
+            onDataLoaded={handleDataLoadedCount}
         />
     );
 };
@@ -94,6 +102,7 @@ const FigureExpressionTable = ({url, hideFigureColumn = false}) => {
 FigureExpressionTable.propTypes = {
     url: PropTypes.string,
     hideFigureColumn: PropTypes.bool,
+    navigationCounter: PropTypes.object,
 };
 
 export default FigureExpressionTable;

--- a/home/javascript/react/containers/FigurePhenotypeTable.js
+++ b/home/javascript/react/containers/FigurePhenotypeTable.js
@@ -6,7 +6,7 @@ import Figure from '../components/Figure';
 import PhenotypeStatement from '../components/PhenotypeStatement';
 
 
-const FigurePhenotypeTable = ({url, hideFigureColumn = false}) => {
+const FigurePhenotypeTable = ({url, hideFigureColumn = false, navigationCounter, title}) => {
     const columns = [
         {
             label: 'Fish',
@@ -52,11 +52,19 @@ const FigurePhenotypeTable = ({url, hideFigureColumn = false}) => {
         },
 
     ];
+
+    const handleDataLoadedCount = (data) => {
+        if (navigationCounter && navigationCounter.setCounts && data.total) {
+            navigationCounter.setCounts(title, data.total);
+        }
+    };
+
     return (
         <DataTable
             columns={columns}
             dataUrl={url}
             rowKey={row => row.rowKey}
+            onDataLoaded={handleDataLoadedCount}
             //sortOptions={sortOptions}
         />
     );

--- a/home/javascript/react/containers/NavigationItem.js
+++ b/home/javascript/react/containers/NavigationItem.js
@@ -1,0 +1,22 @@
+import React, {useState}  from 'react';
+import PropTypes from 'prop-types';
+
+const NavigationItem = ({ title, navigationCounter }) => {
+    const [count, setCount] = useState(null);
+    navigationCounter.subscribe(title, newCount => setCount(newCount));
+
+    if (count) {
+        return (
+            <><span className="badge badge-pill badge-secondary">{count}</span></>
+        );
+    } else {
+        return (<></>);
+    }
+};
+
+NavigationItem.propTypes = {
+    title: PropTypes.string,
+    navigationCounter: PropTypes.object,
+}
+
+export default NavigationItem;

--- a/home/javascript/react/containers/PublicationAttributionTable.js
+++ b/home/javascript/react/containers/PublicationAttributionTable.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import DataTable from '../components/data-table';
 
-const PublicationAttributionTable = ({url}) => {
+const PublicationAttributionTable = ({url, title, navigationCounter}) => {
     const columns = [
         {
             label: 'Entity ID',
@@ -11,12 +11,20 @@ const PublicationAttributionTable = ({url}) => {
             filterName: 'entityID',
         },
     ];
+
+    const handleDataLoadedCount = (data) => {
+        if (navigationCounter && navigationCounter.setCounts && data.total) {
+            navigationCounter.setCounts(title, data.total);
+        }
+    };
+
     return (
         <DataTable
             columns={columns}
             dataUrl={url}
             rowKey={row => row}
             pagination={true}
+            onDataLoaded={handleDataLoadedCount}
         />
     );
 };

--- a/home/javascript/react/containers/PublicationDiseaseTable.js
+++ b/home/javascript/react/containers/PublicationDiseaseTable.js
@@ -4,7 +4,7 @@ import DataTable from '../components/data-table';
 import EntityGroupList from '../components/entity/EntityGroupList';
 import TermLink from '../components/entity/TermLink';
 
-const PublicationDiseaseTable = ({url}) => {
+const PublicationDiseaseTable = ({url, title, navigationCounter}) => {
     const columns = [
         {
             label: 'Human Disease',
@@ -26,12 +26,20 @@ const PublicationDiseaseTable = ({url}) => {
             width: '80px',
         },
     ];
+
+    const handleDataLoadedCount = (data) => {
+        if (navigationCounter && navigationCounter.setCounts && data.total) {
+            navigationCounter.setCounts(title, data.total);
+        }
+    };
+
     return (
         <DataTable
             columns={columns}
             dataUrl={url}
             rowKey={row => row.zdbID}
             pagination={true}
+            onDataLoaded={handleDataLoadedCount}
         />
     );
 };

--- a/home/javascript/react/containers/PublicationFigureDisplay.js
+++ b/home/javascript/react/containers/PublicationFigureDisplay.js
@@ -1,0 +1,52 @@
+import React, {useEffect} from 'react';
+import PropTypes from 'prop-types';
+
+const PublicationFigureDisplay = ({title, imagesJson, publicationId, navigationCounter}) => {
+    const images = JSON.parse(imagesJson);
+    let storedpage = null;
+
+    useEffect(() => {
+        var imageBox = new ImageBox();
+        imageBox.setImageDivById("xpresimg_box");
+        imageBox.setControlDivById("xpresimg_controls");
+        imageBox.setHiddenCountFieldById("xpatsel_thumbnail_page_hidden_field");
+        imageBox.setMaxImages(5000);
+        imageBox.images = images.map(image => ({imgThumb: image.imageThumbnail, imgZdbId: image.imageZdbId}));
+        document.getElementById('xpresimg_thumbs_title').innerHTML = `Figure Gallery (${images.length} images)`;
+
+        function loadImages() {
+            storedpage = imageBox.getHiddenCountInput().value;
+            if ((storedpage != null) && (storedpage != "") && Number.isInteger(storedpage)) {
+                imageBox.jumpToPage(storedpage);
+            } else {
+                imageBox.displayFirstSet();
+            }
+        }
+
+        document.hasImages = true;
+        loadImages();
+        navigationCounter.setCounts(title, images.length);
+    });
+
+    return (
+        <>
+            <div id="xpresimg_all">
+                <input type="hidden" name="xpatsel_thumbnail_page" id="xpatsel_thumbnail_page_hidden_field" value="1"/>
+                <div id="xpresimg_control_box">
+                    <span id="xpresimg_thumbs_title" className="summary"/>
+                    <span id="xpresimg_controls"></span>
+                </div>
+                <div id="xpresimg_box"></div>
+                <div id="imagebox_maxnote" style={{display: 'none'}}></div>
+                <div id="xpresimg_imagePreload"></div>
+            </div>
+            <div><a href={`/action/figure/all-figure-view/${publicationId}`}>Show all Figures</a></div>
+        </>
+    );
+};
+
+PublicationFigureDisplay.propTypes = {
+    title: PropTypes.string,
+};
+
+export default PublicationFigureDisplay;

--- a/home/javascript/react/containers/PublicationFishTable.js
+++ b/home/javascript/react/containers/PublicationFishTable.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import DataTable from '../components/data-table';
 
-const PublicationFishTable = ({url}) => {
+const PublicationFishTable = ({url, title, navigationCounter}) => {
     const columns = [
         {
             label: 'Fish',
@@ -22,12 +22,20 @@ const PublicationFishTable = ({url}) => {
             width: '200px',
         },
     ];
+
+    const handleDataLoadedCount = (data) => {
+        if (navigationCounter && navigationCounter.setCounts && data.total) {
+            navigationCounter.setCounts(title, data.total);
+        }
+    };
+
     return (
         <DataTable
             columns={columns}
             dataUrl={url}
             rowKey={row => row.zdbID}
             pagination={true}
+            onDataLoaded={handleDataLoadedCount}
         />
     );
 };

--- a/home/javascript/react/containers/PublicationMappingTable.js
+++ b/home/javascript/react/containers/PublicationMappingTable.js
@@ -4,7 +4,7 @@ import DataTable from '../components/data-table';
 import {EntityLink} from '../components/entity';
 import DisplayLocation from '../components/DisplayLocation';
 
-const PublicationMappingTable = ({url}) => {
+const PublicationMappingTable = ({url, title, navigationCounter}) => {
     const columns = [
         {
             label: 'Entity Type',
@@ -21,12 +21,20 @@ const PublicationMappingTable = ({url}) => {
             content: row => <DisplayLocation entity={row}/>,
         },
     ];
+
+    const handleDataLoadedCount = (data) => {
+        if (navigationCounter && navigationCounter.setCounts && data.total) {
+            navigationCounter.setCounts(title, data.total);
+        }
+    };
+
     return (
         <DataTable
             columns={columns}
             dataUrl={url}
             rowKey={row => row.zdbID}
             pagination={true}
+            onDataLoaded={handleDataLoadedCount}
         />
     );
 };

--- a/home/javascript/react/containers/PublicationMarkerTable.js
+++ b/home/javascript/react/containers/PublicationMarkerTable.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import DataTable from '../components/data-table';
 import {EntityLink} from '../components/entity';
 
-const PublicationMarkerTable = ({url}) => {
+const PublicationMarkerTable = ({url, navigationCounter, title}) => {
     const columns = [
         {
             label: 'Marker',
@@ -20,12 +20,20 @@ const PublicationMarkerTable = ({url}) => {
             content: row => row.name,
         },
     ];
+
+    const handleDataLoadedCount = (data) => {
+        if (navigationCounter && navigationCounter.setCounts && data.total) {
+            navigationCounter.setCounts(title, data.total);
+        }
+    };
+
     return (
         <DataTable
             columns={columns}
             dataUrl={url}
             rowKey={row => row.zdbID}
             pagination={true}
+            onDataLoaded={handleDataLoadedCount}
         />
     );
 };

--- a/home/javascript/react/containers/PublicationMutationTable.js
+++ b/home/javascript/react/containers/PublicationMutationTable.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import DataTable from '../components/data-table';
 import {EntityLink, EntityList} from '../components/entity';
 
-const PublicationMarkerTable = ({url}) => {
+const PublicationMarkerTable = ({url, title, navigationCounter}) => {
     const columns = [
         {
             label: 'Allele',
@@ -24,12 +24,20 @@ const PublicationMarkerTable = ({url}) => {
             content: row => (<EntityList entities={row.affectedGenes}/>),
         },
     ];
+
+    const handleDataLoadedCount = (data) => {
+        if (navigationCounter && navigationCounter.setCounts && data.total) {
+            navigationCounter.setCounts(title, data.total);
+        }
+    };
+
     return (
         <DataTable
             columns={columns}
             dataUrl={url}
             rowKey={row => row.zdbID}
             pagination={true}
+            onDataLoaded={handleDataLoadedCount}
         />
     );
 };

--- a/home/javascript/react/containers/PublicationOrthologyTable.js
+++ b/home/javascript/react/containers/PublicationOrthologyTable.js
@@ -4,7 +4,7 @@ import DataTable from '../components/data-table';
 import {EntityLink} from '../components/entity';
 import OrthologyTable from './OrthologyTable';
 
-const PublicationOrthologyTable = ({url}) => {
+const PublicationOrthologyTable = ({url, title, navigationCounter}) => {
     const columns = [
         {
             label: 'Gene',
@@ -16,12 +16,20 @@ const PublicationOrthologyTable = ({url}) => {
             content: row => <OrthologyTable geneId={row.marker.zdbID} showDownload={false}/>,
         },
     ];
+
+    const handleDataLoadedCount = (data) => {
+        if (navigationCounter && navigationCounter.setCounts && data.total) {
+            navigationCounter.setCounts(title, data.total);
+        }
+    };
+
     return (
         <DataTable
             columns={columns}
             dataUrl={url}
             rowKey={row => row.zdbID}
             pagination={true}
+            onDataLoaded={handleDataLoadedCount}
         />
     );
 };

--- a/home/javascript/react/containers/StrTable.js
+++ b/home/javascript/react/containers/StrTable.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import DataTable from '../components/data-table';
 import {EntityLink} from '../components/entity';
 
-const StrTable = ({url}) => {
+const StrTable = ({url, title, navigationCounter}) => {
     const columns = [
         {
             label: 'Target',
@@ -23,12 +23,20 @@ const StrTable = ({url}) => {
             filterName: 'strName',
         },
     ];
+
+    const handleDataLoadedCount = (data) => {
+        if (navigationCounter && navigationCounter.setCounts && data.total) {
+            navigationCounter.setCounts(title, data.total);
+        }
+    };
+
     return (
         <DataTable
             columns={columns}
             dataUrl={url}
             rowKey={row => row.target.zdbID + row.str.zdbID}
             pagination={true}
+            onDataLoaded={handleDataLoadedCount}
         />
     );
 };

--- a/home/javascript/react/index.js
+++ b/home/javascript/react/index.js
@@ -3,6 +3,7 @@
 import 'regenerator-runtime/runtime';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import * as navigationCounter from './state/NavigationCounter';
 
 document
     .querySelectorAll('.__react-root')
@@ -12,7 +13,12 @@ document
         //     <div class="__react-root" id="MyContainer__one"></div>
         //     <div class="__react-root" id="MyContainer__two"></div>
         const container = element.id.split('__', 1)[0];
+
+        // this flag indicates that the component needs access to the navigation count state
+        const useNavigationCount = element.classList.contains('__use-navigation-counter');
+        const dataset = useNavigationCount ? {...element.dataset, navigationCounter} : {...element.dataset};
+
         import(`./containers/${container}`)
-            .then(Module => ReactDOM.render(<Module.default {...element.dataset} />, element))
+            .then(Module => ReactDOM.render(<Module.default {...dataset} />, element))
             .catch((error) => console.error('Unable to load container named: ' + container, error));
     });

--- a/home/javascript/react/state/NavigationCounter.js
+++ b/home/javascript/react/state/NavigationCounter.js
@@ -1,0 +1,16 @@
+
+let navigationCounts = {};
+let listeners = {};
+
+const subscribe = (keyName, callback) => {
+    const currentListeners = listeners[keyName] || [];
+    listeners[keyName] = [...currentListeners, callback];
+};
+
+const setCounts = (keyName, count) => {
+    navigationCounts[keyName] = count;
+    const currentListeners = listeners[keyName] || [];
+    currentListeners.forEach(listener => listener(count));
+};
+
+export { subscribe, setCounts };

--- a/source/org/zfin/framework/featureflag/FeatureFlagEnum.java
+++ b/source/org/zfin/framework/featureflag/FeatureFlagEnum.java
@@ -4,7 +4,7 @@ package org.zfin.framework.featureflag;
 public enum FeatureFlagEnum {
     JBROWSE("jBrowse"),
     CURATOR_JOB_POSTING("Curator Job Posting"),
-    FUTURE_FLAG_PLACEHOLDER("Placeholder For Future Feature");
+    USE_NAVIGATION_COUNTER("Show Navigation Counter");
 
     private String name;
 

--- a/source/org/zfin/publication/presentation/PublicationViewController.java
+++ b/source/org/zfin/publication/presentation/PublicationViewController.java
@@ -18,6 +18,8 @@ import org.zfin.figure.presentation.FigurePhenotypeSummary;
 import org.zfin.figure.service.FigureViewService;
 import org.zfin.framework.ComparatorCreator;
 import org.zfin.framework.api.Pagination;
+import org.zfin.framework.featureflag.FeatureFlagEnum;
+import org.zfin.framework.featureflag.FeatureFlags;
 import org.zfin.framework.presentation.LookupStrings;
 import org.zfin.framework.presentation.PaginationBean;
 import org.zfin.framework.presentation.PaginationResult;
@@ -52,7 +54,9 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang.StringEscapeUtils.escapeXml;
 import static org.zfin.repository.RepositoryFactory.getFigureRepository;
+import static org.zfin.util.ZfinStringUtils.objectToJson;
 
 @Controller
 @RequestMapping("/publication")
@@ -118,8 +122,13 @@ public class PublicationViewController {
         List<ImageResult> images = publicationService.getImageResults(publication);
         model.addAttribute("imageResults", images);
 
+        model.addAttribute("imagesJson", escapeXml(objectToJson(images)));
+
         model.addAttribute(LookupStrings.DYNAMIC_TITLE, getTitle(publication));
         model.addAttribute("relatedData", relatedDataService.getXrefsLinks(publication.getZdbID(), "Publication", null));
+
+        model.addAttribute("useNavigationCounter",
+                FeatureFlags.isFlagEnabled(FeatureFlagEnum.USE_NAVIGATION_COUNTER));
 
         return "publication/publication-view";
     }

--- a/source/org/zfin/publication/repository/HibernatePublicationRepository.java
+++ b/source/org/zfin/publication/repository/HibernatePublicationRepository.java
@@ -2714,9 +2714,11 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
     @Override
     public List<String> getDirectlyAttributedZdbids(String publicationId, Pagination pagination) {
         Session session = HibernateUtil.currentSession();
-        String sql = " select ra.recattrib_data_zdb_id  " +
-                " from record_attribution ra " +
-                " where :publicationZdbID = ra.recattrib_source_zdb_id ";
+        String sql = """
+                 select DISTINCT ra.recattrib_data_zdb_id  
+                 from record_attribution ra 
+                 where :publicationZdbID = ra.recattrib_source_zdb_id
+                 """;
         if (pagination.getFieldFilter(FieldFilter.ENTITY_ID) != null) {
             sql += " AND lower(ra.recattrib_data_zdb_id) like '%" + pagination.getFieldFilter(FieldFilter.ENTITY_ID).toLowerCase() + "%'";
         }

--- a/source/org/zfin/util/ZfinStringUtils.java
+++ b/source/org/zfin/util/ZfinStringUtils.java
@@ -1,5 +1,7 @@
 package org.zfin.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.zfin.marker.Marker;
 
 import java.util.ArrayList;
@@ -165,6 +167,15 @@ public class ZfinStringUtils {
 
     public static String removeHtmlTags(final String string) {
         return string.replaceAll("<.*?>", "");
+    }
+
+    public static String objectToJson(Object object) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+        }
+        return null;
     }
 
 }


### PR DESCRIPTION
Show numbers next to the navigation items on the left side of publication page. These numbers are updated as each react component for the various sections loads. There is a flag for the dataPage jsp tag called "useNavigationCounter" that can be set to true in order to use the react components on the left hand nav for displaying section counts, otherwise, it reverts to the old version without any react.

Add DISTINCT to sql query for directly attributed ids.

Use feature flags so make this behavior togglable for publications view page.

Convert the figures display section to a react component. (though it isn't very "reacty").