### PR TITLE
ZFIN-8293: Hotfix for Main Branch v2

### DIFF
--- a/source/org/zfin/marker/repository/HibernateMarkerRepository.java
+++ b/source/org/zfin/marker/repository/HibernateMarkerRepository.java
@@ -2035,14 +2035,10 @@ public class HibernateMarkerRepository implements MarkerRepository {
                         ORDER BY
                             zdbID DESC
                     """;
-        List<String> resultList = session.createQuery(hql, String.class)
+        return session.createQuery(hql, String.class)
                 .setParameter("dataZdbID", zdbID)
                 .setMaxResults(1)
-                .list();
-        if (resultList.isEmpty()) {
-            throw new RuntimeException("No ABReg ID found for " + zdbID);
-        }
-        return resultList.get(0);
+                .uniqueResult();
     }
 
     public List<LinkDisplay> getMarkerLinkDisplay(String dbLinkId) {


### PR DESCRIPTION
another hotfix to handle the empty results case for uniqueResult

This is a fix to the fix for ZFIN-8293. The first one handled a result set with more than one row returned.  It didn't properly handle an empty result set. This fixes that.