### PR TITLE
ZFIN-8293: Hotfix for Release-1137 v2

### DIFF
--- a/source/org/zfin/marker/repository/HibernateMarkerRepository.java
+++ b/source/org/zfin/marker/repository/HibernateMarkerRepository.java
@@ -2024,10 +2024,20 @@ public class HibernateMarkerRepository implements MarkerRepository {
 
     public String getABRegID(String zdbID) {
         Session session = HibernateUtil.currentSession();
-        String hql = "select accessionNumber from DBLink where dataZdbID = :dataZdbID and " +
-                " accessionNumber like 'AB%' order by zdbID desc ";
+        String hql = """
+                        SELECT
+                            accessionNumber
+                        FROM
+                            DBLink
+                        WHERE
+                            dataZdbID = :dataZdbID
+                            AND accessionNumber LIKE 'AB%'
+                        ORDER BY
+                            zdbID DESC
+                    """;
         return session.createQuery(hql, String.class)
                 .setParameter("dataZdbID", zdbID)
+                .setMaxResults(1)
                 .uniqueResult();
     }
 


### PR DESCRIPTION
ZFIN-8293: another hotfix to handle the empty results case for uniqueResult

This is a fix to the fix for ZFIN-8293. The first one handled a result set
with more than one row returned.  It didn't properly handle an empty result
set. This fixes that.
