### PR TITLE
Suppress the noisy alert for genotype ZDB-GENO-191211-5

### DIFF
--- a/server_apps/DB_maintenance/validatedata/Check-Genotype-Name-Function-Mismatch_d.sql
+++ b/server_apps/DB_maintenance/validatedata/Check-Genotype-Name-Function-Mismatch_d.sql
@@ -5,10 +5,13 @@ SELECT
 FROM
     genotype
 WHERE
-    trim(get_genotype_display (geno_zdb_id)) != trim(geno_display_name)
+    (trim(get_genotype_display (geno_zdb_id)) != trim(geno_display_name)
     OR trim(geno_display_name) = ''
     OR trim(get_genotype_display (geno_zdb_id)) = ''
-    OR trim(geno_display_name) = '_'
+    OR trim(geno_display_name) = '_')
+  AND NOT
+    -- IGNORE THIS ENTRY FOR NOW: ZFIN-7922
+    -- DUE TO FEATURES THAT ARE ALLELES OF MULTIPLE GENES
+    ( geno_zdb_id = 'ZDB-GENO-191211-5' and geno_display_name = 'mir183<sup>lri70/lri70</sup> ; mir96<sup>lri79/lri79</sup> ; mir182<sup>lri81/lri81</sup>')
 ORDER BY
     geno_zdb_id
-


### PR DESCRIPTION
We are getting daily emails with the following content. Last I checked, we aren't planning on changing the naming conventions to address this one case, so I added a specific exemption for it.

1 Genotypes with names that do not match the naming function output

Geno ZDB ID | Current Genotype Name | Function Genotype Name
-- | -- | --
ZDB-GENO-191211-5 | mir183lri70/lri70 ; mir96lri79/lri79 ; mir182lri81/lri81 | dre-mir-183lri70/lri70; dre-mir-182lri81/lri81; dre-mir-96lri79/lri79; dre-mir-182lri81/lri81; dre-mir-96lri79/lri79

Link to report:
https://zfin.org//jobs/job/Check-Genotype-Name-Function-Mismatch_d/308/

Related ticket: ZFIN-7922