### PR TITLE
Fix issue with running tests in intellij

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -887,7 +887,15 @@ sourceSets {
 test {
     maxHeapSize = "2048m"
     useJUnitPlatform()
-
+    jvmArgs('--add-opens', 'java.base/jdk.internal.loader=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.util=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.lang.invoke=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.util=ALL-UNNAMED',
+            '--add-opens', 'java.prefs/java.util.prefs=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.nio.charset=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.net=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.util.concurrent.atomic=ALL-UNNAMED')
     testLogging {
         //showStandardStreams = true
     }


### PR DESCRIPTION
Add the necessary "--add-opens" options to the jvm to be able to run gradle unit tests through intellij.
If there is a better way to do this, let me know and we can delete this PR.