### PR TITLE
ZFIN-8218: partial refactor of HibernatePublicationRepository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ apply from: 'console.gradle'
 
 //apply from: file('setupTestsReports.gradle')
 
-sourceCompatibility = 15
-targetCompatibility = 15
+sourceCompatibility = 17
+targetCompatibility = 17
 
 //apply from : '../zfinGradle/build.gradle'
 
@@ -887,7 +887,15 @@ sourceSets {
 test {
     maxHeapSize = "2048m"
     useJUnitPlatform()
-
+    jvmArgs('--add-opens', 'java.base/jdk.internal.loader=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.util=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.lang.invoke=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.util=ALL-UNNAMED',
+            '--add-opens', 'java.prefs/java.util.prefs=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.nio.charset=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.net=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.util.concurrent.atomic=ALL-UNNAMED')
     testLogging {
         //showStandardStreams = true
     }

--- a/source/org/zfin/publication/presentation/PublicationEditController.java
+++ b/source/org/zfin/publication/presentation/PublicationEditController.java
@@ -64,7 +64,7 @@ public class PublicationEditController {
             @Override
             public void setAsText(String text) {
                 if (!text.isEmpty()) {
-                    Journal journal = publicationRepository.findJournalByAbbreviation(text);
+                    Journal journal = publicationRepository.getJournalByAbbreviation(text);
                     if (journal == null) {
                         throw new IllegalArgumentException("Could not find journal with abbreviation " + text);
                     }

--- a/source/org/zfin/publication/repository/HibernatePublicationRepository.java
+++ b/source/org/zfin/publication/repository/HibernatePublicationRepository.java
@@ -554,18 +554,19 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
         return new PaginationResult<Publication>(results);
     }
 
-    @SuppressWarnings("unchecked")
+    @Override
     public List<String> getDistinctFigureLabels(String publicationID) {
         Session session = HibernateUtil.currentSession();
+        CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
 
-        String hql = "select figure.label from Figure figure" +
-            "     where figure.publication.zdbID = :pubID " +
-            "    order by figure.orderingLabel ";
-        Query query = session.createQuery(hql);
-        query.setString("pubID", publicationID);
+        CriteriaQuery<String> query = criteriaBuilder.createQuery(String.class);
+        Root<Figure> figure = query.from(Figure.class);
 
-        return (List<String>) query.list();
+        query.select(figure.get("label"))
+                .where(criteriaBuilder.equal(figure.get("publication").get("zdbID"), publicationID))
+                .orderBy(criteriaBuilder.asc(figure.get("orderingLabel")));
 
+        return session.createQuery(query).getResultList();
     }
 
     /**

--- a/source/org/zfin/publication/repository/HibernatePublicationRepository.java
+++ b/source/org/zfin/publication/repository/HibernatePublicationRepository.java
@@ -500,19 +500,18 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
     }
 
     /**
-     * Retrieve Figue by ID
+     * Retrieve Figure by ID
      *
      * @param zdbID ID
      * @return Figure
      */
     public Figure getFigure(String zdbID) {
         Session session = HibernateUtil.currentSession();
-        return (Figure) session.get(Figure.class, zdbID);
+        return session.get(Figure.class, zdbID);
     }
 
-    public Figure getFigureByID(String figureZdbID) {
-        Session session = HibernateUtil.currentSession();
-        return (Figure) session.get(Figure.class, figureZdbID);
+    public Figure getFigureByID(String zdbID) {
+        return getFigure(zdbID);
     }
 
     public Image getImageById(String zdbID) {

--- a/source/org/zfin/publication/repository/HibernatePublicationRepository.java
+++ b/source/org/zfin/publication/repository/HibernatePublicationRepository.java
@@ -113,15 +113,18 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
         return pubIDs.stream().map(tuple -> tuple.get(0, String.class)).toList();
     }
 
+    //TODO: refactor to JPA Criteria?
+    //TODO: ScrollableResults makes it difficult to refactor to Tuple-based hql
     public PaginationResult<HighQualityProbe> getHighQualityProbeNames(Term term, int maxRow) {
 
-        String hql = "select distinct exp.probe, marker " +
-            "FROM ExpressionExperiment exp, ExpressionResult res, Marker marker " +
-            "WHERE  res.entity.superterm = :term " +
-            "AND res.expressionExperiment = exp " +
-            "AND exp.probe.rating = 4 " +
-            "AND exp.gene = marker " +
-            "ORDER by marker.abbreviationOrder  ";
+        String hql = """
+            select distinct exp.probe, marker
+            FROM ExpressionExperiment exp, ExpressionResult res, Marker marker
+            WHERE  res.entity.superterm = :term
+            AND res.expressionExperiment = exp
+            AND exp.probe.rating = 4
+            AND exp.gene = marker
+            ORDER by marker.abbreviationOrder""";
         Session session = HibernateUtil.currentSession();
         Query query = session.createQuery(hql);
         query.setParameter("term", term);

--- a/source/org/zfin/publication/repository/HibernatePublicationRepository.java
+++ b/source/org/zfin/publication/repository/HibernatePublicationRepository.java
@@ -396,9 +396,13 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
     @Override
     public List<Journal> getAllJournals() {
         Session session = HibernateUtil.currentSession();
-        Criteria jrnlCriteria = session.createCriteria(Journal.class);
-        jrnlCriteria.addOrder(Order.asc("name"));
-        return jrnlCriteria.list();
+        CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaQuery<Journal> cr = cb.createQuery(Journal.class);
+
+        Root<Journal> root = cr.from(Journal.class);
+        cr.select(root).orderBy(cb.asc(root.get("name")));
+
+        return session.createQuery(cr).list();
     }
 
     @Override

--- a/source/org/zfin/publication/repository/HibernatePublicationRepository.java
+++ b/source/org/zfin/publication/repository/HibernatePublicationRepository.java
@@ -85,21 +85,20 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
 
     public List<Publication> getExpressedGenePublications(String geneID, String anatomyItemID) {
         Session session = HibernateUtil.currentSession();
-        String hql = "SELECT distinct publication FROM Publication publication, ExpressionExperiment exp, ExpressionResult res   " +
-            "WHERE (res.entity.superterm.zdbID = :aoZdbID OR" +
-            "       res.entity.subterm.zdbID = :aoZdbID) " +
-            "AND publication = exp.publication " +
-            "AND res.expressionExperiment = exp " +
-            "AND exp.gene.zdbID = :zdbID " +
-            "AND res.expressionFound = :expressionFound ";
+        String hql = """
+            SELECT distinct publication FROM Publication publication, ExpressionExperiment exp, ExpressionResult res  \s
+            WHERE (res.entity.superterm.zdbID = :aoZdbID OR
+                   res.entity.subterm.zdbID = :aoZdbID)
+            AND publication = exp.publication
+            AND res.expressionExperiment = exp
+            AND exp.gene.zdbID = :zdbID
+            AND res.expressionFound is true""";
         String sql = addOrderByParameters(hql);
-        Query query = session.createQuery(sql);
+        Query<Publication> query = session.createQuery(sql, Publication.class);
         addPaginationParameters(query);
-        query.setString("zdbID", geneID);
-        query.setString("aoZdbID", anatomyItemID);
-        query.setBoolean("expressionFound", true);
-        List<Publication> list = query.list();
-        return list;
+        query.setParameter("zdbID", geneID);
+        query.setParameter("aoZdbID", anatomyItemID);
+        return query.list();
     }
 
     public List<String> getSNPPublicationIDs(Marker marker) {

--- a/source/org/zfin/publication/repository/HibernatePublicationRepository.java
+++ b/source/org/zfin/publication/repository/HibernatePublicationRepository.java
@@ -406,24 +406,16 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
     }
 
     @Override
-    public Journal getJournalByAbbreviation(String abbrevation) {
-        Criteria criteria = HibernateUtil.currentSession().createCriteria(Journal.class);
-        criteria.add(Restrictions.eq("abbreviation", abbrevation));
-        return (Journal) criteria.uniqueResult();
+    public Journal getJournalByAbbreviation(String abbreviation) {
+        return getJournalByProperty("abbreviation", abbreviation);
     }
 
     public Journal getJournalByPrintIssn(String pIssn) {
-        Session session = currentSession();
-        Criteria criteria = session.createCriteria(Journal.class);
-        criteria.add(Restrictions.eq("printIssn", pIssn));
-        return (Journal) criteria.uniqueResult();
+        return getJournalByProperty("printIssn", pIssn);
     }
 
     public Journal getJournalByEIssn(String eIssn) {
-        Session session = currentSession();
-        Criteria criteria = session.createCriteria(Journal.class);
-        criteria.add(Restrictions.eq("onlineIssn", eIssn));
-        return (Journal) criteria.uniqueResult();
+        return getJournalByProperty("onlineIssn", eIssn);
     }
 
     public SourceAlias addJournalAlias(Journal journal, String alias) {
@@ -2110,6 +2102,15 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
                 "where publication = :pub");
         query.setParameter("pub", publication);
         return (DOIAttempt) query.uniqueResult();
+    }
+
+    private Journal getJournalByProperty(String propertyName, String propertyValue) {
+        Session session = HibernateUtil.currentSession();
+        CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaQuery<Journal> cr = cb.createQuery(Journal.class);
+        Root<Journal> root = cr.from(Journal.class);
+        cr.select(root).where(cb.equal(root.get(propertyName), propertyValue));
+        return session.createQuery(cr).uniqueResult();
     }
 
     private List<Publication> getPublications(List<String> zdbIDs, boolean orderByDateDesc) {

--- a/source/org/zfin/publication/repository/HibernatePublicationRepository.java
+++ b/source/org/zfin/publication/repository/HibernatePublicationRepository.java
@@ -103,13 +103,14 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
 
     public List<String> getSNPPublicationIDs(Marker marker) {
         Session session = HibernateUtil.currentSession();
-        String sql = "select distinct snpdattr_pub_zdb_id " +
-            " from snp_download_attribution, snp_download " +
-            " where snpdattr_snpd_pk_id = snpd_pk_id and snpd_mrkr_zdb_id = :zdbID";
-        SQLQuery query = session.createSQLQuery(sql);
-        query.setString("zdbID", marker.getZdbID());
-        List<String> pubIDs = query.list();
-        return pubIDs;
+        String sql = """
+                select distinct snpdattr_pub_zdb_id
+                 from snp_download_attribution, snp_download
+                 where snpdattr_snpd_pk_id = snpd_pk_id and snpd_mrkr_zdb_id = :zdbID""";
+        Query<Tuple> query = session.createNativeQuery(sql, Tuple.class);
+        query.setParameter("zdbID", marker.getZdbID());
+        List<Tuple> pubIDs = query.list();
+        return pubIDs.stream().map(tuple -> tuple.get(0, String.class)).toList();
     }
 
     public PaginationResult<HighQualityProbe> getHighQualityProbeNames(Term term, int maxRow) {

--- a/source/org/zfin/publication/repository/HibernatePublicationRepository.java
+++ b/source/org/zfin/publication/repository/HibernatePublicationRepository.java
@@ -430,7 +430,7 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
     }
 
     @Override
-    public Journal findJournalByAbbreviation(String abbrevation) {
+    public Journal getJournalByAbbreviation(String abbrevation) {
         Criteria criteria = HibernateUtil.currentSession().createCriteria(Journal.class);
         criteria.add(Restrictions.eq("abbreviation", abbrevation));
         return (Journal) criteria.uniqueResult();

--- a/source/org/zfin/publication/repository/PublicationRepository.java
+++ b/source/org/zfin/publication/repository/PublicationRepository.java
@@ -139,7 +139,7 @@ public interface PublicationRepository extends PaginationParameter {
 
     List<Journal> getAllJournals();
 
-    Journal findJournalByAbbreviation(String abbrevation);
+    Journal getJournalByAbbreviation(String abbrevation);
 
     Journal getJournalByPrintIssn(String pIssn);
 

--- a/source/org/zfin/publication/repository/PublicationRepository.java
+++ b/source/org/zfin/publication/repository/PublicationRepository.java
@@ -98,8 +98,6 @@ public interface PublicationRepository extends PaginationParameter {
      */
     boolean publicationExists(String canonicalPublicationZdbID);
 
-    Figure getFigureByID(String figureZdbID);
-
     /**
      * Saves a list of publications in one transaction.
      *
@@ -128,10 +126,6 @@ public interface PublicationRepository extends PaginationParameter {
      */
     PaginationResult<Figure> getFiguresByFishAndAnatomy(Fish fish, GenericTerm term, boolean includeSubstructures);
 
-    PaginationResult<Figure> getFiguresByGenoExp(Genotype geno);
-
-    PaginationResult<Publication> getPublicationsWithFiguresbyGenoExp(Genotype genotype);
-
     /**
      * Retrieve figures for a given gene and anatomy term.
      *
@@ -153,15 +147,21 @@ public interface PublicationRepository extends PaginationParameter {
 
     SourceAlias addJournalAlias(Journal journal, String alias);
 
+    PaginationResult<Figure> getFiguresByGenoExp(Genotype geno);
+
+    PaginationResult<Publication> getPublicationsWithFiguresbyGenoExp(Genotype genotype);
+
     int getNumberAssociatedPublicationsForZdbID(String zdbID);
 
     /**
-     * Retrieve Figue by ID
+     * Retrieve Figure by ID
      *
      * @param zdbID ID
      * @return Figure
      */
     Figure getFigure(String zdbID);
+
+    Figure getFigureByID(String figureZdbID);
 
     Image getImageById(String zdbID);
 
@@ -257,7 +257,6 @@ public interface PublicationRepository extends PaginationParameter {
      */
     List<Antibody> getAntibodiesByPublication(String publicationID);
 
-
     /**
      * Retrieve antibodies by publication and associated gene
      *
@@ -344,7 +343,6 @@ public interface PublicationRepository extends PaginationParameter {
     int deleteExpressionExperimentIDswithNoExpressionResult(Publication publication);
 
     List<String> getTalenOrCrisprFeaturesWithNoRelationship(String pubZdbID);
-
 
     long getMarkerCount(Publication publication);
 
@@ -453,7 +451,7 @@ public interface PublicationRepository extends PaginationParameter {
     PublicationProcessingChecklistEntry getProcessingChecklistEntry(long id);
 
     List<PubmedPublicationAuthor> getPubmedPublicationAuthorsByPublication(Publication publication);
-    
+
     boolean isNewFeaturePubAttribution(Feature feature, String publicationId);
 
     boolean hasCuratedOrthology(Marker marker);
@@ -463,4 +461,5 @@ public interface PublicationRepository extends PaginationParameter {
     List<SequenceTargetingReagent> getSTRsByPublication(String publicationID, Pagination pagination);
 
     List<Image> getImages(Publication publication);
+
 }

--- a/source/org/zfin/publication/repository/PublicationRepository.java
+++ b/source/org/zfin/publication/repository/PublicationRepository.java
@@ -43,25 +43,6 @@ import java.util.*;
 public interface PublicationRepository extends PaginationParameter {
 
     /**
-     * Retrieve the number of publications that contain the
-     * a term 'abstractText' in its abstract. This count is
-     * done case insensitive.
-     *
-     * @param abstractText text
-     * @return number of publications
-     */
-    int getNumberOfPublications(String abstractText);
-
-    /**
-     * Retrieve all distinct publications that contain a high quality probe
-     * with a rating of 4.
-     *
-     * @param anatomyTerm Anatomy Term
-     * @return list of publications
-     */
-    List<Publication> getHighQualityProbePublications(GenericTerm anatomyTerm);
-
-    /**
      * Retrieve all publication for a given geneID and anatomical structure.
      *
      * @param geneID        gene ID
@@ -70,33 +51,6 @@ public interface PublicationRepository extends PaginationParameter {
     List<Publication> getExpressedGenePublications(String geneID, String anatomyItemID);
 
     List<String> getSNPPublicationIDs(Marker marker);
-
-    /**
-     * Retrieve the total number of publications for a given geneID and anatomical structure
-     * that contain figures.
-     *
-     * @param geneID        gene zdbID
-     * @param anatomyItemID anatomy ID
-     * @return number
-     */
-    int getNumberOfExpressedGenePublicationsWithFigures(String geneID, String anatomyItemID);
-
-    /**
-     * Retrieve all publication that are annotated to genes expressed in a given
-     * anatomical structure.
-     *
-     * @param anatomyItemID
-     */
-    List<Publication> getExpressedGenePublications(String anatomyItemID);
-
-    /**
-     * Retrieve the genes and CDNA/EST for the high-quality probes with
-     * rating of 4.
-     *
-     * @param term anatomy term
-     * @return list of High quality probes.
-     */
-    PaginationResult<HighQualityProbe> getHighQualityProbeNames(GenericTerm term);
 
     /**
      * Retrieve the genes and CDNA/EST for the high-quality probes with
@@ -110,17 +64,6 @@ public interface PublicationRepository extends PaginationParameter {
     PaginationResult<HighQualityProbe> getHighQualityProbeNames(Term term, int maxRow);
 
     /**
-     * Retrieve marker records that have a gene expression in the
-     * anatomy term, identified by the zdbID. The maxRow number
-     * limits the result set.
-     *
-     * @param zdbID  of the anatomy term.
-     * @param maxRow max number of records
-     * @return list of markers
-     */
-    List<Marker> getAllExpressedMarkers(String zdbID, int maxRow);
-
-    /**
      * Returns the appropriate # of records, as well as statistics on the total # of records.
      *
      * @param anatomyTerm term
@@ -129,15 +72,6 @@ public interface PublicationRepository extends PaginationParameter {
      * @return marker statistics
      */
     PaginationResult<MarkerStatistic> getAllExpressedMarkers(GenericTerm anatomyTerm, int firstRow, int maxRow);
-
-    /**
-     * Returns the appropriate # of records, as well as statistics on the total # of records.
-     *
-     * @param anatomyTerm term
-     * @return marker statistics
-     */
-    PaginationResult<MarkerStatistic> getAllExpressedMarkers(GenericTerm anatomyTerm);
-
 
     /**
      * Count the number of figures from all publications that have a gene
@@ -158,91 +92,13 @@ public interface PublicationRepository extends PaginationParameter {
     List<Publication> getPublications(List<String> zdbIDs);
 
     /**
-     * Retrieve a marker (gene) by its symbol name. If it is not unique a Hibernate runtime exception is thrown.
-     *
-     * @param symbol
-     */
-    Marker getMarker(String symbol);
-
-    /**
-     * Retrieve a marker by its zdbID
-     *
-     * @param zdbID
-     */
-    Marker getMarkerByZdbID(String zdbID);
-
-    /**
      * Check if a publication with the specified primary key exists.
      *
      * @param canonicalPublicationZdbID
      */
     boolean publicationExists(String canonicalPublicationZdbID);
 
-
-    /**
-     * Figure getFigureById(String zdbID);
-     * <p/>
-     * Retrieve the figures that can be found for a given publication and gene.
-     *
-     * @param geneID
-     * @param publicationID
-     */
-    List<Figure> getFiguresByGeneID(String geneID, String publicationID);
-
     Figure getFigureByID(String figureZdbID);
-
-    List<Figure> getFiguresByGeneAndPublication(String geneID, String publicationID);
-
-    List<FeatureMarkerRelationship> getFeatureMarkerRelationshipsByPubID(String publicationID);
-
-    /**
-     * Return all figures for a specified gene, probe and anatommical structure.
-     * Clone information is not required.
-     *
-     * @param gene   Gene
-     * @param clone  Probe
-     * @param aoTerm anatomical structure
-     * @return list of figures
-     */
-    List<Figure> getFiguresPerProbeAndAnatomy(Marker gene, Marker clone, GenericTerm aoTerm);
-
-    /**
-     * Return all Publications for a specified gene, probe and anatommical structure with figures associated.
-     *
-     * @param gene    Gene
-     * @param subGene Probe
-     * @param aoTerm  anatomical structure
-     * @return list of figures
-     */
-    List<Publication> getPublicationsWithFiguresPerProbeAndAnatomy(Marker gene, Marker subGene, GenericTerm aoTerm);
-
-    /**
-     * Retrieve the figures that can be found for a given publication and probe.
-     *
-     * @param probeID
-     * @param publicationID
-     */
-    List<Figure> getFiguresByProbeAndPublication(String probeID, String publicationID);
-
-
-    /**
-     * Used to add a sorting string onto the query.
-     *
-     * @param orderVariable
-     */
-    void addOrdering(String orderVariable);
-
-    void removeOrderByFields();
-
-
-    /**
-     * Retrieves publications with Accession Number's (pubmed Ids) but with null or 'none' DOIs.
-     *
-     * @param maxResults number
-     * @return list
-     */
-    List<Publication> getPublicationsWithAccessionButNoDOI(int maxResults);
-
 
     /**
      * Saves a list of publications in one transaction.
@@ -272,30 +128,9 @@ public interface PublicationRepository extends PaginationParameter {
      */
     PaginationResult<Figure> getFiguresByFishAndAnatomy(Fish fish, GenericTerm term, boolean includeSubstructures);
 
-    PaginationResult<Figure> getFiguresByGeno(Genotype geno);
-
     PaginationResult<Figure> getFiguresByGenoExp(Genotype geno);
 
-    PaginationResult<Publication> getPublicationsWithFiguresbyGeno(Genotype genotype);
-
     PaginationResult<Publication> getPublicationsWithFiguresbyGenoExp(Genotype genotype);
-
-
-    /**
-     * Retrieve publications that have phenotype data for a given term and genotype including
-     * substructures
-     *
-     * @param fish   Fish
-     * @param aoTerm ao term  @return Number of publications with figures per genotype and anatomy
-     */
-    PaginationResult<Publication> getPublicationsWithFigures(Fish fish, GenericTerm aoTerm, boolean includeSubstructures);
-
-    /**
-     * @param genotype Genotype
-     * @param aoTerm   ao term
-     * @return Number of publications with figures per genotype and anatomy
-     */
-    int getNumPublicationsWithFiguresPerGenotypeAndAnatomy(Genotype genotype, GenericTerm aoTerm);
 
     /**
      * Retrieve figures for a given gene and anatomy term.
@@ -310,11 +145,7 @@ public interface PublicationRepository extends PaginationParameter {
 
     List<Journal> getAllJournals();
 
-    Journal getJournalByTitle(String journalTitle);
-
     Journal findJournalByAbbreviation(String abbrevation);
-
-    void createJournal(Journal journal);
 
     Journal getJournalByPrintIssn(String pIssn);
 
@@ -323,8 +154,6 @@ public interface PublicationRepository extends PaginationParameter {
     SourceAlias addJournalAlias(Journal journal, String alias);
 
     int getNumberAssociatedPublicationsForZdbID(String zdbID);
-
-    PaginationResult<Publication> getAllAssociatedPublicationsForFeature(Feature feature, int maxPubs);
 
     /**
      * Retrieve Figue by ID
@@ -378,15 +207,6 @@ public interface PublicationRepository extends PaginationParameter {
     List<Feature> getFeaturesByPublication(String pubID);
 
     List<Fish> getFishByPublication(String pubID);
-
-    /**
-     * Retrieve distinct list of genes that are attributed to a given
-     * publication and used in an experiment.
-     *
-     * @param pubID publication id
-     * @return list of markers
-     */
-    List<Marker> getGenesByExperiment(String pubID);
 
     /**
      * Retrieve list of Genotypes being used in experiments for a given publication
@@ -490,17 +310,7 @@ public interface PublicationRepository extends PaginationParameter {
 
     List<Publication> getPublicationByPmid(Integer pubMedID);
 
-    Publication getSinglePublicationByPmid(Integer pubMedID);
-
     int getNumberDirectPublications(String zdbID);
-
-    /**
-     * Retrieve list of mutants and transgenics being used in a publication
-     *
-     * @param publicationID publication ID
-     * @return list of genotype (non-wt)
-     */
-    List<Genotype> getMutantsAndTgsByPublication(String publicationID);
 
     List<Ortholog> getOrthologListByPub(String pubID);
 
@@ -517,8 +327,6 @@ public interface PublicationRepository extends PaginationParameter {
     SortedSet<Publication> getPublicationForJournal(Journal journal);
 
     Journal getJournalByID(String zdbID);
-
-    List<Journal> findJournalByAbbreviationAndName(String query);
 
     SortedSet<Publication> getAllPublicationsForGenotype(Genotype genotype);
 
@@ -592,8 +400,6 @@ public interface PublicationRepository extends PaginationParameter {
 
     List<Publication> getAllPublications();
 
-    List<Publication> getAllPubMedPublications();
-
     List<Publication> getAllOpenPublications();
 
     List<Publication> getAllOpenPublicationsOfJournalType(PublicationType type);
@@ -632,8 +438,6 @@ public interface PublicationRepository extends PaginationParameter {
 
     Long getDirectlyAttributed(Publication publication);
 
-    PublicationAttribution createPublicationAttribution(Publication publication, Marker marker);
-
     List<MetricsByDateBean> getMetricsByDate(Calendar start,
                                              Calendar end,
                                              PublicationMetricsFormBean.QueryType query,
@@ -649,9 +453,7 @@ public interface PublicationRepository extends PaginationParameter {
     PublicationProcessingChecklistEntry getProcessingChecklistEntry(long id);
 
     List<PubmedPublicationAuthor> getPubmedPublicationAuthorsByPublication(Publication publication);
-
-    boolean isNewGenePubAttribution(Marker marker, String publicationId);
-
+    
     boolean isNewFeaturePubAttribution(Feature feature, String publicationId);
 
     boolean hasCuratedOrthology(Marker marker);

--- a/source/org/zfin/publication/repository/PublicationRepository.java
+++ b/source/org/zfin/publication/repository/PublicationRepository.java
@@ -139,7 +139,7 @@ public interface PublicationRepository extends PaginationParameter {
 
     List<Journal> getAllJournals();
 
-    Journal getJournalByAbbreviation(String abbrevation);
+    Journal getJournalByAbbreviation(String abbreviation);
 
     Journal getJournalByPrintIssn(String pIssn);
 

--- a/test/org/zfin/DbUnitTests.java
+++ b/test/org/zfin/DbUnitTests.java
@@ -46,6 +46,7 @@ import org.zfin.ontology.repository.OntologyRepositoryTest;
 import org.zfin.orthology.OrthologyRepositoryTest;
 import org.zfin.profile.repository.ProfileRepositoryTest;
 import org.zfin.profile.service.ProfileServiceTest;
+import org.zfin.publication.repository.PublicationRepositoryRefactorTest;
 import org.zfin.publication.repository.PublicationRepositoryTest;
 import org.zfin.sequence.*;
 import org.zfin.sequence.blast.BlastRepositoryTest;
@@ -122,6 +123,7 @@ import org.zfin.wiki.service.AntibodyWikiWebServiceTest;
         ProfileRepositoryTest.class,
         ProfileServiceTest.class,
         PublicationRepositoryTest.class,
+//        PublicationRepositoryRefactorTest.class, //temporarily used while refactoring PublicationRepository
         RecordAttributionTest.class,
         RenoMultiRunTest.class,
         RenoRedundancyCandidateControllerTest.class,

--- a/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
+++ b/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
@@ -13,6 +13,8 @@ import org.zfin.framework.presentation.PaginationResult;
 import org.zfin.marker.Marker;
 import org.zfin.marker.presentation.HighQualityProbe;
 import org.zfin.ontology.GenericTerm;
+import org.zfin.ontology.Ontology;
+import org.zfin.ontology.repository.OntologyRepository;
 import org.zfin.publication.Journal;
 import org.zfin.publication.Publication;
 
@@ -126,4 +128,66 @@ public class PublicationRepositoryRefactorTest extends AbstractDatabaseTest {
         assertEquals( "Nature communications", journal.getName());
     }
 
+    @Test
+    public void getNumberAssociatedPublicationsForMarker() {
+
+        Marker m;
+        int numberPubs;
+
+        m = getMarkerRepository().getMarkerByID("ZDB-GENE-051005-1");
+        numberPubs = publicationRepository.getNumberAssociatedPublicationsForZdbID(m.getZdbID());
+        assertTrue(numberPubs > 15);
+        assertTrue(numberPubs < 35);
+//        assertEquals(28, numberPubs);
+
+        m = getMarkerRepository().getMarkerByAbbreviation("pax6a");
+        numberPubs = publicationRepository.getNumberAssociatedPublicationsForZdbID(m.getZdbID());
+        assertTrue(numberPubs > 190);
+        assertTrue(numberPubs < 500);
+//        assertEquals(334, numberPubs);
+
+    }
+
+    @Test
+    public void getNumberOfPublicationForPax2aAndMHB() {
+        String termName = "midbrain hindbrain boundary";
+        OntologyRepository aoRepository = getOntologyRepository();
+        GenericTerm item = aoRepository.getTermByName(termName, Ontology.ANATOMY);
+        Marker pax2a = getMarkerRepository().getMarkerByAbbreviation("pax2a");
+
+        PaginationResult<Publication> qualityPubs = publicationRepository.getPublicationsWithFigures(pax2a, item);
+        assertTrue(qualityPubs != null);
+        assertEquals("122 pubs", 122, qualityPubs.getPopulatedResults().size());
+
+    }
+
+    @Test
+    public void getPublicationsWithFigures() {
+        Marker marker = getMarkerRepository().getMarker("ZDB-GENE-990415-8");
+        OntologyRepository aoRepository = getOntologyRepository();
+        GenericTerm item = aoRepository.getTermByZdbID("ZDB-TERM-100331-40");
+
+        PaginationResult<Publication> pubs = publicationRepository.getPublicationsWithFigures(marker, item);
+        assertEquals("122 pubs", 122, pubs.getPopulatedResults().size());
+
+//        pubs = publicationRepository.getPublicationsWithFigures_New(marker, item);
+//        assertEquals("122 pubs", 122, pubs.getPopulatedResults().size());
+    }
+
+    @Test
+    public void getPublicationsWithFigures2() {
+        //tbxta
+        Marker marker = getMarkerRepository().getMarker("ZDB-GENE-980526-437");
+        OntologyRepository aoRepository = getOntologyRepository();
+
+        //dorsal region
+        GenericTerm item = aoRepository.getTermByZdbID("ZDB-TERM-100722-81");
+
+        PaginationResult<Publication> pubs = publicationRepository.getPublicationsWithFigures(marker, item);
+        assertEquals("5 pubs", 5, pubs.getPopulatedResults().size());
+
+//        pubs = publicationRepository.getPublicationsWithFigures_New(marker, item);
+//        assertEquals("5 pubs", 5, pubs.getPopulatedResults().size());
+
+    }
 }

--- a/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
+++ b/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
@@ -50,6 +50,7 @@ public class PublicationRepositoryRefactorTest extends AbstractDatabaseTest {
         assertNotNull(pubs);
         assertEquals(1, pubs.size());
         assertEquals("ZDB-PUB-070427-10", pubs.get(0));
+
     }
 
     @Test
@@ -63,6 +64,27 @@ public class PublicationRepositoryRefactorTest extends AbstractDatabaseTest {
         HighQualityProbe firstResult = hqp.getPopulatedResults().get(0);
         Marker firstGene = ((Marker)(firstResult.getGenes().toArray()[0]));
         assertEquals("ZDB-GENE-010328-3", firstGene.getZdbID());
+    }
+
+    @Test
+    public void getPublications() {
+        List<String> testPubs = List.of("ZDB-PUB-180130-17", "ZDB-PUB-190613-8");
+        List<Publication> pubs = publicationRepository.getPublications(testPubs);
+        assertEquals(2, pubs.size());
+
+        testPubs.containsAll(List.of(pubs.get(0).getZdbID(),pubs.get(1).getZdbID()));
+
+        pubs = publicationRepository.getPublications(null);
+        assertEquals(0, pubs.size());
+    }
+
+    @Test
+    public void publicationExists() {
+        boolean exists = publicationRepository.publicationExists("ZDB-PUB-180130-17");
+        assertTrue(exists);
+
+        boolean notExists = publicationRepository.publicationExists("BOGUS-IDENTIFIER");
+        assertFalse(notExists);
     }
 
 }

--- a/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
+++ b/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
@@ -108,4 +108,22 @@ public class PublicationRepositoryRefactorTest extends AbstractDatabaseTest {
         assertTrue( journals.size() > 3000);
     }
 
+    @Test
+    public void getJournalByAbbreviation() {
+        Journal journal = publicationRepository.getJournalByAbbreviation("Food Chem X");
+        assertEquals( "Food chemistry: X", journal.getName());
+    }
+
+    @Test
+    public void getJournalByPrintIssn() {
+        Journal journal = publicationRepository.getJournalByPrintIssn("2590-1575");
+        assertEquals( "Food chemistry: X", journal.getName());
+    }
+
+    @Test
+    public void getJournalByEIssn() {
+        Journal journal = publicationRepository.getJournalByEIssn("2041-1723");
+        assertEquals( "Nature communications", journal.getName());
+    }
+
 }

--- a/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
+++ b/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
@@ -190,4 +190,20 @@ public class PublicationRepositoryRefactorTest extends AbstractDatabaseTest {
 //        assertEquals("5 pubs", 5, pubs.getPopulatedResults().size());
 
     }
+
+
+    @Test
+    public void getFigureLabels() {
+        String zdbID = "ZDB-PUB-990507-16";
+
+        List<String> experiments = publicationRepository.getDistinctFigureLabels(zdbID);
+        assertTrue(experiments != null);
+        assertTrue(experiments.size() > 0);
+        assertTrue(experiments.size() == 6);
+
+//        experiments = publicationRepository.getDistinctFigureLabels_New(zdbID);
+//        assertTrue(experiments != null);
+//        assertTrue(experiments.size() > 0);
+//        assertTrue(experiments.size() == 6);
+    }
 }

--- a/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
+++ b/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
@@ -8,6 +8,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.zfin.AbstractDatabaseTest;
 import org.zfin.AppConfig;
+import org.zfin.expression.Figure;
 import org.zfin.framework.presentation.PaginationResult;
 import org.zfin.marker.Marker;
 import org.zfin.marker.presentation.HighQualityProbe;
@@ -85,6 +86,12 @@ public class PublicationRepositoryRefactorTest extends AbstractDatabaseTest {
 
         boolean notExists = publicationRepository.publicationExists("BOGUS-IDENTIFIER");
         assertFalse(notExists);
+    }
+
+    @Test
+    public void getFigureById() {
+        Figure fig = publicationRepository.getFigureByID("ZDB-FIG-080617-24"); //has xpat, pheno & AB
+        assertNotNull(fig);
     }
 
 }

--- a/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
+++ b/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
@@ -1,0 +1,39 @@
+package org.zfin.publication.repository;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.zfin.AbstractDatabaseTest;
+import org.zfin.AppConfig;
+import org.zfin.publication.Publication;
+
+import java.util.List;
+import static org.junit.Assert.*;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {AppConfig.class})
+@WebAppConfiguration
+public class PublicationRepositoryRefactorTest extends AbstractDatabaseTest {
+
+    @Autowired
+    private PublicationRepository publicationRepository;
+
+    @Test
+    public void getExpressedGenePublications() {
+        List<Publication> pubs = publicationRepository.getExpressedGenePublications("ZDB-GENE-001103-4 ", "ZDB-TERM-100331-8");
+        assertNotNull(pubs);
+
+        pubs = publicationRepository.getExpressedGenePublications("ZDB-GENE-001103-4", "ZDB-TERM-100331-8");
+        assertNotNull(pubs);
+        assertTrue(pubs.size() > 5); //was 10 at the time of this test writing
+
+        //basilar artery -> cyp1a
+        pubs = publicationRepository.getExpressedGenePublications("ZDB-GENE-011219-1", "ZDB-TERM-100331-1678");
+        assertNotNull(pubs);
+        assertTrue(pubs.size() >= 1);
+        assertEquals("ZDB-PUB-170818-4", pubs.get(0).getZdbID());
+    }
+}

--- a/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
+++ b/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
@@ -8,10 +8,12 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.zfin.AbstractDatabaseTest;
 import org.zfin.AppConfig;
+import org.zfin.marker.Marker;
 import org.zfin.publication.Publication;
 
 import java.util.List;
 import static org.junit.Assert.*;
+import static org.zfin.repository.RepositoryFactory.getMarkerRepository;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {AppConfig.class})
@@ -36,4 +38,14 @@ public class PublicationRepositoryRefactorTest extends AbstractDatabaseTest {
         assertTrue(pubs.size() >= 1);
         assertEquals("ZDB-PUB-170818-4", pubs.get(0).getZdbID());
     }
+
+    @Test
+    public void getSNPPublicationIDs() {
+        Marker marker = getMarkerRepository().getMarker("ZDB-BAC-050218-656");
+        List<String> pubs = publicationRepository.getSNPPublicationIDs(marker);
+        assertNotNull(pubs);
+        assertEquals(1, pubs.size());
+        assertEquals("ZDB-PUB-070427-10", pubs.get(0));
+    }
+
 }

--- a/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
+++ b/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
@@ -8,12 +8,16 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.zfin.AbstractDatabaseTest;
 import org.zfin.AppConfig;
+import org.zfin.framework.presentation.PaginationResult;
 import org.zfin.marker.Marker;
+import org.zfin.marker.presentation.HighQualityProbe;
+import org.zfin.ontology.GenericTerm;
 import org.zfin.publication.Publication;
 
 import java.util.List;
 import static org.junit.Assert.*;
 import static org.zfin.repository.RepositoryFactory.getMarkerRepository;
+import static org.zfin.repository.RepositoryFactory.getOntologyRepository;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {AppConfig.class})
@@ -46,6 +50,19 @@ public class PublicationRepositoryRefactorTest extends AbstractDatabaseTest {
         assertNotNull(pubs);
         assertEquals(1, pubs.size());
         assertEquals("ZDB-PUB-070427-10", pubs.get(0));
+    }
+
+    @Test
+    public void getHighQualityProbeNames() {
+        GenericTerm anatomyTerm = getOntologyRepository().getTermByZdbID("ZDB-TERM-100331-107");
+        PaginationResult<HighQualityProbe> hqp = publicationRepository.getHighQualityProbeNames(anatomyTerm, 5);
+
+        int total = hqp.getTotalCount();
+        assertEquals(27, total);
+
+        HighQualityProbe firstResult = hqp.getPopulatedResults().get(0);
+        Marker firstGene = ((Marker)(firstResult.getGenes().toArray()[0]));
+        assertEquals("ZDB-GENE-010328-3", firstGene.getZdbID());
     }
 
 }

--- a/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
+++ b/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
@@ -1,5 +1,6 @@
 package org.zfin.publication.repository;
 
+import lombok.SneakyThrows;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,15 +10,20 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import org.zfin.AbstractDatabaseTest;
 import org.zfin.AppConfig;
 import org.zfin.expression.Figure;
+import org.zfin.framework.presentation.PaginationBean;
 import org.zfin.framework.presentation.PaginationResult;
+import org.zfin.marker.Clone;
 import org.zfin.marker.Marker;
+import org.zfin.marker.MarkerType;
 import org.zfin.marker.presentation.HighQualityProbe;
+import org.zfin.mutant.SequenceTargetingReagent;
 import org.zfin.ontology.GenericTerm;
 import org.zfin.ontology.Ontology;
 import org.zfin.ontology.repository.OntologyRepository;
 import org.zfin.publication.Journal;
 import org.zfin.publication.Publication;
 
+import java.lang.reflect.Method;
 import java.util.List;
 import static org.junit.Assert.*;
 import static org.zfin.repository.RepositoryFactory.getMarkerRepository;
@@ -206,4 +212,95 @@ public class PublicationRepositoryRefactorTest extends AbstractDatabaseTest {
 //        assertTrue(experiments.size() > 0);
 //        assertTrue(experiments.size() == 6);
     }
+
+    @Test
+    public void getGenesAndMarkersByPublication() {
+        String zdbID = "ZDB-PUB-990507-16";
+
+        List<Marker> markers = publicationRepository.getGenesAndMarkersByPublication(zdbID);
+        assertTrue(markers != null);
+        assertTrue(markers.size() > 0);
+        assertTrue(markers.size() == 2);
+
+        String zdbID2 = "ZDB-PUB-150809-4";
+
+//        List<Marker> markers2 = publicationRepository.getMarkersPulledThroughSTRs(zdbID2);
+        List<Marker> markers2 = getMarkersPulledThroughSTRs(zdbID2);
+
+        markers2 = publicationRepository.getGenesAndMarkersByPublication(zdbID2);
+        assertTrue(markers2 != null);
+        assertTrue(markers2.size() > 0);
+        assertTrue(markers2.size() == 29);
+
+//        List<Marker> markers3 = publicationRepository.getMarkersPulledThroughSTRs_New(zdbID2);
+//        assertEquals(markers3.size(), markers2.size());
+    }
+
+    @Test
+    public void getMarkersByTypeForPublication() {
+        String publicationID = "ZDB-PUB-220412-11";
+        MarkerType efgType = getMarkerRepository().getMarkerTypeByName(Marker.Type.EFG.name());
+        List<Marker> markers = publicationRepository.getMarkersByTypeForPublication(publicationID, efgType);
+
+        assertEquals(3, markers.size());
+
+    }
+
+    @Test
+    public void getSTRsByPublication() {
+        MarkerType morpholinoMarkerType = getMarkerRepository().getMarkerTypeByName("MRPHLNO");
+        MarkerType crisprMarkerType = getMarkerRepository().getMarkerTypeByName("CRISPR");
+        String publicationID = "ZDB-PUB-190215-8";
+        List<SequenceTargetingReagent> morpholinos = publicationRepository.getSTRsByPublication(publicationID, morpholinoMarkerType);
+        List<SequenceTargetingReagent> crisprs = publicationRepository.getSTRsByPublication(publicationID, crisprMarkerType);
+
+        assertEquals(2, morpholinos.size());
+        assertEquals(3, crisprs.size());
+    }
+
+    @Test
+    public void getClonesByPublication() {
+        PaginationBean paginationBean = new PaginationBean();
+        PaginationResult<Clone> clones = publicationRepository.getClonesByPublication("ZDB-PUB-080422-3", paginationBean);
+        assertNotNull(clones);
+        assertEquals(1, clones.getTotalCount());
+    }
+
+    @Test
+    public void getMarkersByPublication() throws Exception {
+        Marker.TypeGroup typeGroup = Marker.TypeGroup.GENEDOM;
+        List<MarkerType> markerTypes = getMarkerRepository().getMarkerTypesByGroup(typeGroup);
+        markerTypes.add(getMarkerRepository().getMarkerTypeByName(Marker.Type.EFG.toString()));
+
+//        test private method, similar to the following if it were a public method:
+//        List<Marker> markers1 = publicationRepository.getMarkersByPublication("ZDB-PUB-080422-3", markerTypes);
+//        List<Marker> markers2 = publicationRepository.getMarkersByPublication("ZDB-PUB-190215-8", markerTypes);
+        List<Marker> markers1 = getMarkersByPublication("ZDB-PUB-080422-3", markerTypes);
+        List<Marker> markers2 = getMarkersByPublication("ZDB-PUB-190215-8", markerTypes);
+
+        assertTrue(markers1.size() > 5);
+        assertTrue(markers2.size() > 5);
+    }
+
+    // similar to the following method call, but with a workaround to access private method:
+    //   List<Marker> markers = publicationRepository.getMarkersPulledThroughSTRs(zdbID2);
+    @SneakyThrows
+    private List<Marker> getMarkersPulledThroughSTRs(String zdbID) {
+        Method getMarkersPulledThroughSTRs = HibernatePublicationRepository.class.getDeclaredMethod(
+                "getMarkersPulledThroughSTRs", String.class);
+
+        getMarkersPulledThroughSTRs.setAccessible(true);
+        return (List<Marker>) getMarkersPulledThroughSTRs.invoke(publicationRepository, zdbID);
+    }
+
+    // similar to the following method call, but with a workaround to access private method:
+    //   List<Marker> markers = publicationRepository.getMarkersByPublication(zdbID);
+    @SneakyThrows
+    private List<Marker> getMarkersByPublication(String zdbID, List<MarkerType> markerTypes) {
+        Method getMarkersByPublication = HibernatePublicationRepository.class.getDeclaredMethod(
+                "getMarkersByPublication", String.class, List.class);
+        getMarkersByPublication.setAccessible(true);
+        return (List<Marker>) getMarkersByPublication.invoke(publicationRepository, zdbID, markerTypes);
+    }
+
 }

--- a/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
+++ b/test/org/zfin/publication/repository/PublicationRepositoryRefactorTest.java
@@ -13,6 +13,7 @@ import org.zfin.framework.presentation.PaginationResult;
 import org.zfin.marker.Marker;
 import org.zfin.marker.presentation.HighQualityProbe;
 import org.zfin.ontology.GenericTerm;
+import org.zfin.publication.Journal;
 import org.zfin.publication.Publication;
 
 import java.util.List;
@@ -92,6 +93,19 @@ public class PublicationRepositoryRefactorTest extends AbstractDatabaseTest {
     public void getFigureById() {
         Figure fig = publicationRepository.getFigureByID("ZDB-FIG-080617-24"); //has xpat, pheno & AB
         assertNotNull(fig);
+    }
+
+    @Test
+    public void getPubsForDisplay() {
+        assertTrue(publicationRepository.getPubsForDisplay("ZDB-GENE-040426-1855").size() > 10);
+        assertTrue(publicationRepository.getPubsForDisplay("ZDB-GENE-051005-1").size() > 15);
+        assertEquals(0, publicationRepository.getPubsForDisplay("ZDB-SSLP-000315-3").size());
+    }
+
+    @Test
+    public void getAllJournals() {
+        List<Journal> journals = publicationRepository.getAllJournals();
+        assertTrue( journals.size() > 3000);
     }
 
 }

--- a/test/org/zfin/publication/repository/PublicationRepositoryTest.java
+++ b/test/org/zfin/publication/repository/PublicationRepositoryTest.java
@@ -102,16 +102,6 @@ public class PublicationRepositoryTest extends AbstractDatabaseTest {
     }
 
     @Test
-    public void getNumberOfPubWithFigures() {
-        //  neural rod
-        String aoZdbID = "ZDB-TERM-100331-125";
-        String zdbID = "ZDB-GENE-980526-36";
-        int number = publicationRepository.getNumberOfExpressedGenePublicationsWithFigures(zdbID, aoZdbID);
-//        assertEquals("2 publications", 2, number);
-        assertTrue(number > 0);
-    }
-
-    @Test
     public void getNumberOfFiguresPerAnatomyStructure() {
         String termName = "neural rod";
         GenericTerm term = ontologyRepository.getTermByName(termName, Ontology.ANATOMY);
@@ -200,26 +190,6 @@ public class PublicationRepositoryTest extends AbstractDatabaseTest {
         assertTrue(number > 0);
     }
 
-    @Test
-    public void getFigurePublicationsForProbes() {
-        //  probe eu815
-        String probeZdbID = "ZDB-EST-051103-38";
-        Marker probe = new Marker();
-        probe.setZdbID(probeZdbID);
-        //  gene ascl1b
-        String geneZdbID = "ZDB-GENE-980526-174";
-        Marker gene = new Marker();
-        gene.setZdbID(geneZdbID);
-        // neural rod
-        String aoZdbID = "ZDB-ANAT-010921-561";
-        GenericTerm item = new GenericTerm();
-        item.setZdbID(aoZdbID);
-        List<Publication> pubs = publicationRepository.getPublicationsWithFiguresPerProbeAndAnatomy(gene, probe, item);
-        assertTrue(pubs != null);
-//        assertEquals("1 publication", 1, pubs.size());
-
-    }
-
     /**
      * anterior lateral line ganglia is expressed in a double mutant: fgf3t24149/+;fgf8ti282a/+
      */
@@ -294,43 +264,6 @@ public class PublicationRepositoryTest extends AbstractDatabaseTest {
     }
 
     @Test
-    public void getPublicationsForGenoAndAoIncludingSubstructures() {
-        Fish geno = new Fish();
-        geno.setZdbID("ZDB-FISH-150901-25831");
-        // actinotrichium
-        GenericTerm item = getOntologyRepository().getTermByOboID("ZFA:0005435");
-        PaginationResult<Publication> publications = publicationRepository.getPublicationsWithFigures(geno, item, true);
-        assertNotNull(publications.getPopulatedResults());
-        assertTrue(publications.getPopulatedResults().size() > 0);
-    }
-
-    @Test
-    public void getFiguresForGeno() {
-        //  genotype adss^hi1433Tg
-        String genoZdbID = "ZDB-GENO-980202-822";
-        Genotype geno = new Genotype();
-        geno.setZdbID(genoZdbID);
-        // brain
-        PaginationResult<Figure> figs = publicationRepository.getFiguresByGeno(geno);
-        assertTrue(figs.getPopulatedResults() != null);
-    }
-
-
-    @Test
-    public void getPubsForFeature() {
-        //  genotype adss^hi1433Tg
-        String featZdbID = "ZDB-ALT-980413-502";
-        Feature feature = new Feature();
-        feature.setZdbID(featZdbID);
-        // brain
-
-        PaginationResult<Publication> pubs = publicationRepository.getAllAssociatedPublicationsForFeature(feature, 0);
-        assertTrue(pubs.getPopulatedResults() != null);
-//        assertEquals("1 figure", 1, figs.size());
-
-    }
-
-    @Test
     public void getFiguresForGenotypeExp() {
         //  genotype adss^hi1433Tg
         String genoZdbID = "ZDB-GENO-020426-5";
@@ -346,42 +279,12 @@ public class PublicationRepositoryTest extends AbstractDatabaseTest {
     }
 
     @Test
-    public void getPublicationsForFiguresForGenotype() {
-        //  genotype adss^hi1433Tg
-        String genoZdbID = "ZDB-GENO-020426-5";
-        Genotype geno = new Genotype();
-        geno.setZdbID(genoZdbID);
-        // brain
-        String aoZdbID = "ZDB-TERM-100331-8";
-        GenericTerm item = new GenericTerm();
-        item.setZdbID(aoZdbID);
-        int publicationCount = publicationRepository.getNumPublicationsWithFiguresPerGenotypeAndAnatomy(geno, item);
-        assertTrue(publicationCount > 0);
-//        assertEquals("1 publication", 1, publications.size());
-
-    }
-
-    @Test
     public void getFeatureCountForPub() {
         //  genotype adss^hi1433Tg
         String pubZdbID = "ZDB-PUB-140403-2";
         Publication pub = publicationRepository.getPublication(pubZdbID);
         long ftrCount = publicationRepository.getFeatureCount(pub);
         assertTrue(ftrCount > 0);
-//        assertEquals("1 publication", 1, publications.size());
-
-    }
-
-    @Test
-    public void getPublicationsForFiguresForGeno() {
-        //  genotype adss^hi1433Tg
-        String genoZdbID = "ZDB-GENO-070615-1";
-        Genotype geno = new Genotype();
-        geno.setZdbID(genoZdbID);
-        // brain
-
-        PaginationResult<Publication> pubs = publicationRepository.getPublicationsWithFiguresbyGeno(geno);
-        assertTrue(pubs.getPopulatedResults() != null);
 //        assertEquals("1 publication", 1, publications.size());
 
     }
@@ -398,17 +301,6 @@ public class PublicationRepositoryTest extends AbstractDatabaseTest {
         item.setZdbID(aoZdbID);
         List<Figure> figs = publicationRepository.getFiguresByGeneAndAnatomy(marker, item);
         assertTrue(figs != null);
-    }
-
-    @Test
-    public void getHighQualityProbePublicationsForBrain() {
-        String termName = "neural rod";
-        OntologyRepository aoRepository = RepositoryFactory.getOntologyRepository();
-        GenericTerm item = aoRepository.getTermByName(termName, Ontology.ANATOMY);
-        List<Publication> qualityPubs = publicationRepository.getHighQualityProbePublications(item);
-        assertTrue(qualityPubs != null);
-//        assertEquals("2 pubs", 2, qualityPubs.size());
-
     }
 
     @Test


### PR DESCRIPTION
This is a partial refactor of HibernatePublicationRepository.

Converted some appended strings into text blocks
Converted Query objects to parameterized Query objects
Converted some queries to the JPA Criteria Builder style
Removed methods that seem to be unused
Re-ordered methods in HibernatePublicationRepository to match order in PublicationRepository
Changed public methods to private methods if they are only used in HibernatePublicationRepository (and moved them to the bottom of the file)
Added test file: PublicationRepositoryRefactorTest to test methods that were converted (if not covered by PublicationRepositoryTest)
Removed tests for removed methods