### PR TITLE
ZFIN-8360: Fix ImageBox on Publication View Page

### DIFF
--- a/home/javascript/react/containers/AntibodyTable.js
+++ b/home/javascript/react/containers/AntibodyTable.js
@@ -57,7 +57,7 @@ const AntibodyTable = ({url, title, navigationCounter}) => {
 AntibodyTable.propTypes = {
     url: PropTypes.string,
     title: PropTypes.string,
-    navigationCounter: PropTypes.node,
+    navigationCounter: PropTypes.object,
 };
 
 export default AntibodyTable;

--- a/home/javascript/react/containers/PublicationFigureDisplay.js
+++ b/home/javascript/react/containers/PublicationFigureDisplay.js
@@ -1,6 +1,5 @@
 import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
-import ImageBox from '../../zfin-common/imagebox';
 
 const PublicationFigureDisplay = ({title, imagesJson, publicationId, navigationCounter}) => {
     const images = JSON.parse(imagesJson);


### PR DESCRIPTION
ImageBox is available in the global scope. Importing as a module doesn't work without further refactoring. 
See https://trunk.zfin.org/ZDB-PUB-210213-15#figures for example
Fixed the PropType for navigationCounters.