### PR TITLE
Make list of conditions easier to read.

### DIFF
--- a/source/org/zfin/antibody/Antibody.java
+++ b/source/org/zfin/antibody/Antibody.java
@@ -66,26 +66,24 @@ public class Antibody extends Marker {
      * @return Whether or not an antibody label can be merged.
      */
     private boolean canMergeAntibodyLabel(ExpressionExperiment eea, ExpressionExperiment eeb) {
-        if (!eea.getPublication().equals(eeb.getPublication())) return true;
-        if (!eea.getFishExperiment().equals(eeb.getFishExperiment())) return true;
-        if (!eea.getAssay().equals(eeb.getAssay())) return true;
+        //if any of these conditions are true, return true, otherwise, false
+        return List.of(
+            !eea.getPublication().equals(eeb.getPublication()),
+            !eea.getFishExperiment().equals(eeb.getFishExperiment()),
+            !eea.getAssay().equals(eeb.getAssay()),
 
-        if (eea.getProbe() == null && eeb.getProbe() != null) return true;
-        if (eea.getProbe() != null && eeb.getProbe() == null) return true;
-        if (eea.getProbe() != null && eeb.getProbe() != null &&
-                !eea.getProbe().equals(eeb.getProbe())) return true;
+            eea.getProbe() == null && eeb.getProbe() != null,
+            eea.getProbe() != null && eeb.getProbe() == null,
+            eea.getProbe() != null && eeb.getProbe() != null && !eea.getProbe().equals(eeb.getProbe()),
 
-        if (eea.getGene() == null && eeb.getGene() != null) return true;
-        if (eea.getGene() != null && eeb.getGene() == null) return true;
-        if (eea.getGene() != null && eeb.getGene() != null &&
-                !eea.getGene().equals(eeb.getGene())) return true;
+            eea.getGene() == null && eeb.getGene() != null,
+            eea.getGene() != null && eeb.getGene() == null,
+            eea.getGene() != null && eeb.getGene() != null && !eea.getGene().equals(eeb.getGene()),
 
-        if (eea.getMarkerDBLink() == null && eeb.getMarkerDBLink() != null) return true;
-        if (eea.getMarkerDBLink() != null && eeb.getMarkerDBLink() == null) return true;
-        if (eea.getMarkerDBLink() != null && eeb.getMarkerDBLink() != null
-                && !eea.getMarkerDBLink().equals(eeb.getMarkerDBLink())) return true;
-
-        return false;
+            eea.getMarkerDBLink() == null && eeb.getMarkerDBLink() != null,
+            eea.getMarkerDBLink() != null && eeb.getMarkerDBLink() == null,
+            eea.getMarkerDBLink() != null && eeb.getMarkerDBLink() != null && !eea.getMarkerDBLink().equals(eeb.getMarkerDBLink())
+        ).contains(true);
     }
 
     @Override


### PR DESCRIPTION
Intellij gave a suggestion to change one of the conditionals here. As I looked at the method, it bothered me how unreadable it is (at least to my eyes).  I think the changes here make it easier to ready while preserving the logic.  The only difference should be that in the new version all of the conditions are evaluated while in the former version, it would "short circuit" at the first true condition.  I don't see this causing any issues since the null checks are in place.

I would like to further improve by changing this pattern:

```
a == null && b != null,
a != null && b == null,
a != null && b != null && a.equals(b)
```

to simply:
```
!Objects.equals(a,b)
```

The only thing holding me back is that I believe they would behave differently if both a and b are null. In the first version, it would return false, but in the second version, it would return true.

However, this might be a bug? The description in the comments above the method suggest that if both are null, it should return true.