### PR TITLE
Release 1138: ZFIN-8380: Fix issue adding supplier

### DIFF
--- a/source/org/zfin/marker/service/MarkerService.java
+++ b/source/org/zfin/marker/service/MarkerService.java
@@ -846,15 +846,8 @@ public class MarkerService {
     }
 
     public static boolean markerHasSupplier(Marker marker, Organization supplier) {
-        Collection<MarkerSupplier> suppliers = marker.getSuppliers();
-        if (CollectionUtils.isNotEmpty(suppliers)) {
-            for (MarkerSupplier markerSupplier : marker.getSuppliers()) {
-                if (markerSupplier.getOrganization().equals(supplier)) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        MarkerSupplier result = getProfileRepository().getSpecificSupplier(marker, supplier);
+        return result != null;
     }
 
     public static boolean markerHasAlias(Marker marker, String alias) {


### PR DESCRIPTION

The Error
---

Adding a supplier on an antibody page was throwing this exception on flushAndCommit:

```
org.hibernate.HibernateException: identifier of an instance of org.zfin.profile.MarkerSupplier was altered from org.zfin.profile.ObjectSupplier$HibernateBasicProxy$qApBYh43@1068326678 to org.zfin.profile.MarkerSupplier@21bef2a9
```

The Context
---
This check happens in the hibernate code in the DefaultFlushEntityEventListener class at the checkId method. It seems to be comparing the ID of an object in memory with the new ID to be persisted and makes sure they are the same.  When debugging that method and observing the check on our typical domain objects (like an antibody for example), the ID that it is checking is a string like "ZDB-ATB-081121-4".  However, in this case when checking a MarkerSupplier object, the ID is an object (a hibernate proxy object) and is checked against a string representing the MarkerSupplier (org.zfin.profile.MarkerSupplier@21bef2a9*).

I think the root of this issue is in the fact that the MarkerSupplier is a weird object. It is based on a table without a single primary key and instead has a composite key of the marker and the supplier. Also, MarkerSupplier inherits from the ObjectSupplier class which adds some complexity. 

The Fix
---
I came up with this fix when I compared the legacy code with the newer code and the only difference was the call to `markerHasSupplier`.  That method loops over all the suppliers for a marker and seems to load some objects into memory that later cause the weird ID comparison issue.  I replaced that method with a simpler DB call that accomplishes the same thing and fixes this issue.

The Better Fix
---
It would probably be good to either add a single primary key field to the ObjectSupplier class and table (int_data_supplier), or use a different strategy for working with the composite key. Here is a website that lays out 2 strategies for working with composite keys:

https://www.jpa-buddy.com/blog/the-ultimate-guide-on-composite-ids-in-jpa-entities/



----
Notes:
* When I overrode the toString() method of ObjectSupplier, the error message changed to:
```
javax.persistence.PersistenceException: org.hibernate.HibernateException: identifier of an instance of org.zfin.profile.MarkerSupplier was altered from org.zfin.profile.ObjectSupplier$HibernateBasicProxy$oFctwQDh@3808
84474 to ObjectSupplier{dataZdbID=ZDB-ATB-081121-4,orgZdbID=ZDB-COMPANY-080225-1}
```
