### PR TITLE
Release 1138 Patch: ZFIN-8413

### DIFF
--- a/source/org/zfin/profile/repository/HibernateProfileRepository.java
+++ b/source/org/zfin/profile/repository/HibernateProfileRepository.java
@@ -42,6 +42,9 @@ public class HibernateProfileRepository implements ProfileRepository {
 	private final Logger logger = LogManager.getLogger(HibernateProfileRepository.class);
 
 	public Person getPerson(String zdbID) {
+		if (zdbID == null) {
+			return null;
+		}
 		return HibernateUtil.currentSession().get(Person.class, zdbID);
 	}
 

--- a/test/org/zfin/profile/repository/ProfileRepositoryTest.java
+++ b/test/org/zfin/profile/repository/ProfileRepositoryTest.java
@@ -56,6 +56,13 @@ public class ProfileRepositoryTest extends AbstractDatabaseTest {
 
 	}
 
+
+	@Test
+	public void callGetPersonWithNullValue() {
+		Person person = profileRepository.getPerson(null);
+		assertNull(person);
+	}
+
 	@Test
 	public void createAndUpdateCuratorSessionWithNoPublication() {
 


### PR DESCRIPTION
getPerson should return null if given null for ID.

This was causing an exception in recording correspondences:

http://github.com/zfin/zfin/blob/ce8d5d9d8f4a63135c79ff7f7599215955cea8a4/source/org/zfin/publication/repository/HibernatePublicationRepository.java#L2599-L2599