### PR TITLE
ZFIN-8397: Fix rejected email messages due to multiple "To" headers

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -348,6 +348,18 @@
         <path refid="classpath"/>
     </path>
 
+    <target name="writeClassPath">
+        <pathconvert property="classpathProp1" refid="extended.classpath"/>
+        <tempfile property="classpathFile1" suffix=".txt" createfile="true" prefix="extended.classpath." destdir="/tmp"/>
+        <echo file="${classpathFile1}">${classpathProp1}</echo>
+        <echo>extended.classpath is written to ${classpathFile1}</echo>
+
+        <pathconvert property="classpathProp2" refid="unittest.classpath"/>
+        <tempfile property="classpathFile2" suffix=".txt" createfile="true" prefix="unittest.classpath." destdir="/tmp"/>
+        <echo file="${classpathFile2}">${classpathProp2}</echo>
+        <echo>unittest.classpath is written to ${classpathFile2}</echo>
+    </target>
+
     <target name="instrument" depends="compile">
         <taskdef name="instrument" classname="org.hibernate.tool.instrument.javassist.InstrumentTask">
             <classpath refid="extended.classpath"/>

--- a/source/org/zfin/framework/mail/IntegratedJavaMailSender.java
+++ b/source/org/zfin/framework/mail/IntegratedJavaMailSender.java
@@ -126,6 +126,22 @@ public class IntegratedJavaMailSender extends AbstractZfinMailSender {
         return emailAddress.replaceAll("\\\\@", "@");
     }
 
+    public JavaMailSender getMailSender() {
+        return mailSender;
+    }
+
+    public void setMailSender(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    public String getMailHost() {
+        return mailHost;
+    }
+
+    public void setMailHost(String mailHost) {
+        this.mailHost = mailHost;
+    }
+
     /**
      * Just a hacky test.
      *

--- a/source/org/zfin/framework/mail/IntegratedJavaMailSender.java
+++ b/source/org/zfin/framework/mail/IntegratedJavaMailSender.java
@@ -14,14 +14,16 @@ import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 /**
  * Uses JavaMail integrated with Spring to send email.
  */
 public class IntegratedJavaMailSender extends AbstractZfinMailSender {
 
-    private static Logger logger = LogManager.getLogger(IntegratedJavaMailSender.class);
+    private static final Logger logger = LogManager.getLogger(IntegratedJavaMailSender.class);
 
     private JavaMailSender mailSender = new JavaMailSenderImpl();
     private String mailHost = ZfinPropertiesEnum.SMTP_HOST.value();
@@ -124,22 +126,6 @@ public class IntegratedJavaMailSender extends AbstractZfinMailSender {
         return emailAddress.replaceAll("\\\\@", "@");
     }
 
-    public JavaMailSender getMailSender() {
-        return mailSender;
-    }
-
-    public void setMailSender(JavaMailSender mailSender) {
-        this.mailSender = mailSender;
-    }
-
-    public String getMailHost() {
-        return mailHost;
-    }
-
-    public void setMailHost(String mailHost) {
-        this.mailHost = mailHost;
-    }
-
     /**
      * Just a hacky test.
      *
@@ -151,12 +137,12 @@ public class IntegratedJavaMailSender extends AbstractZfinMailSender {
 
         String messageText = null;
         String subjectText = null;
-        String[] emailAddresses = ZfinProperties.getAdminEmailAddresses();
+        List<String> emailAddresses = List.of(ZfinProperties.getAdminEmailAddresses());
         StringBuilder stringBuilder = new StringBuilder();
         for (String arg : args) {
             stringBuilder.append(arg).append(" ");
         }
-        System.out.println("Sending mail with arguments: " + stringBuilder.toString() + " to " + emailAddresses[0]);
+
         if (args.length < 2) {
             subjectText = "test email from IntegratedJavaMailSender: " + new Date();
             messageText = "javamail message of test email: " + new Date();
@@ -164,12 +150,16 @@ public class IntegratedJavaMailSender extends AbstractZfinMailSender {
             subjectText = args[0] + " - " + new Date();
             messageText = args[1] + " - " + new Date();
             if (args.length > 2) {
-                emailAddresses = args[2].split(" ");
+                emailAddresses = new ArrayList<>();
+                for(int i = 2; i < args.length; i++) {
+                    emailAddresses.addAll(List.of(args[i].split(" ")));
+                }
             }
         }
+        System.out.println("Sending mail with arguments: " + stringBuilder.toString() + " to the following addresses: " + String.join(",", emailAddresses));
 
         MailSender sender = new IntegratedJavaMailSender();
-        sender.sendMail(subjectText, messageText, emailAddresses);
+        sender.sendMail(subjectText, messageText, emailAddresses.toArray(new String[0]));
     }
 
 }

--- a/source/org/zfin/publication/CorrespondenceComposedMessage.java
+++ b/source/org/zfin/publication/CorrespondenceComposedMessage.java
@@ -1,11 +1,15 @@
 package org.zfin.publication;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.zfin.profile.Person;
 
 import javax.persistence.*;
 import java.util.Date;
 import java.util.Set;
 
+@Setter
+@Getter
 @Entity
 @Table(name = "pub_correspondence_sent_email")
 public class CorrespondenceComposedMessage {
@@ -38,67 +42,4 @@ public class CorrespondenceComposedMessage {
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY, mappedBy = "message")
     private Set<CorrespondenceRecipient> recipients;
 
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
-
-    public Date getComposedDate() {
-        return composedDate;
-    }
-
-    public void setComposedDate(Date composedDate) {
-        this.composedDate = composedDate;
-    }
-
-    public Person getFrom() {
-        return from;
-    }
-
-    public void setFrom(Person from) {
-        this.from = from;
-    }
-
-    public String getText() {
-        return text;
-    }
-
-    public void setText(String text) {
-        this.text = text;
-    }
-
-    public String getSubject() {
-        return subject;
-    }
-
-    public void setSubject(String subject) {
-        this.subject = subject;
-    }
-
-    public Publication getPublication() {
-        return publication;
-    }
-
-    public void setPublication(Publication publication) {
-        this.publication = publication;
-    }
-
-    public String getRecipientEmailList() {
-        return recipientEmailList;
-    }
-
-    public void setRecipientEmailList(String recipientEmailList) {
-        this.recipientEmailList = recipientEmailList;
-    }
-
-    public Set<CorrespondenceRecipient> getRecipients() {
-        return recipients;
-    }
-
-    public void setRecipients(Set<CorrespondenceRecipient> recipients) {
-        this.recipients = recipients;
-    }
 }


### PR DESCRIPTION
Instead of sending a single email with multiple "To" headers, loop over the recipients and send individual emails.

Make it easier to test from the command line.

Example:

```
$ ant writeClassPath
...
 [echo] extended.classpath is written to /tmp/extended.classpath.1620.txt
 [echo] unittest.classpath is written to /tmp/unittest.classpath.1388.txt
...
$ java -cp `cat /tmp/extended.classpath.1620.txt` org.zfin.framework.mail.IntegratedJavaMailSender 'TEST SUBJECT' 'TEST BODY' someusername@zfin.org anotherusername@gmail.com onemoreusername@example.org
```