### PR TITLE
ZFIN-8372: Show images side-by-side for figures with multiple images

### DIFF
--- a/home/WEB-INF/jsp/publication/publication-figures.jsp
+++ b/home/WEB-INF/jsp/publication/publication-figures.jsp
@@ -58,6 +58,7 @@
                 </button>
             </div>
         </div>
+
         <c:forEach var="figure" items="${figures}">
             <z:section title="${figure.label}">
                 <zfin-figure:imagesAndCaption

--- a/home/WEB-INF/jsp/publication/publication-figures.jsp
+++ b/home/WEB-INF/jsp/publication/publication-figures.jsp
@@ -9,7 +9,7 @@
 <c:set var="secs" value="${figureCaptions}"/>
 <c:set var="UNPUBLISHED" value="${PublicationType.UNPUBLISHED}"/>
 
-<z:dataPage sections="${secs}">
+<z:dataPage sections="${secs}" additionalBodyClass="all-figures">
 
     <jsp:attribute name="entityName">
         <div data-toggle="tooltip" data-placement="bottom" title="${publication.citation}">
@@ -58,7 +58,6 @@
                 </button>
             </div>
         </div>
-
         <c:forEach var="figure" items="${figures}">
             <z:section title="${figure.label}">
                 <zfin-figure:imagesAndCaption

--- a/home/WEB-INF/tags/figure/imagesAndCaption.tag
+++ b/home/WEB-INF/tags/figure/imagesAndCaption.tag
@@ -5,6 +5,9 @@
 <%@ attribute name="showCaption" type="java.lang.Boolean" rtexprvalue="true" required="false" %>
 <%@ attribute name="showMultipleMediumSizedImages" type="java.lang.Boolean" rtexprvalue="true" required="true" %>
 
+<!-- DEBUGGING -->
+<%--<c:set var="showMultipleMediumSizedImages" value="false"/>--%>
+
 <c:set var="showCaption" value="${!showCaption ? false : true }"/>
 <table class="figure-image-and-caption">
     <tr>
@@ -13,23 +16,52 @@
 
             <%--has permission to show, single image, can be video--%>
             <c:if test="${figure.publication.canShowImages && !empty figure.images && (fn:length(figure.images) == 1 || showMultipleMediumSizedImages) }">
-                <div style="max-width: 510px;"> <%-- this div causes multiple medium sized images to stack on top of one another, ZDB-PUB-990628-12 has an example--%>
-                    <c:forEach var="image" items="${figure.images}">
-                        <zfin-figure:showSingleImage image="${image}" medium="true" autoplayVideo="${autoplayVideo}"/>
-                    </c:forEach>
-                </div>
+                <c:choose>
+                    <c:when test="${fn:length(figure.images) > 1}">
+                        <%--CAPTION--%>
+                        <c:if test="${showCaption}">
+                            <!-- show caption -->
+                            <zfin-figure:figureLabelAndCaption figure="${figure}"/>
+                        </c:if>
+                        <div class="multiple-medium-images">
+                            <c:forEach var="image" items="${figure.images}">
+                                <!-- single image -->
+                                <zfin-figure:showSingleImage image="${image}" medium="true" autoplayVideo="${autoplayVideo}"/>
+                            </c:forEach>
+                        </div>
+                    </c:when>
+                    <c:otherwise>
+                        <div class="single-image" style="max-width: 510px;">
+                            <c:forEach var="image" items="${figure.images}">
+                                <!-- should only be a single image -->
+                                <zfin-figure:showSingleImage image="${image}" medium="true" autoplayVideo="${autoplayVideo}"/>
+                            </c:forEach>
+                        </div>
+
+                        <%--CAPTION--%>
+                        <c:if test="${showCaption}">
+                            <!-- show caption -->
+                            <zfin-figure:figureLabelAndCaption figure="${figure}"/>
+                        </c:if>
+                    </c:otherwise>
+                </c:choose>
             </c:if>
 
             <%--has permission to show, multiple images, should show them as thumbnails --%>
             <c:if test="${figure.publication.canShowImages && !empty figure.images && fn:length(figure.images) > 1 && !showMultipleMediumSizedImages}">
                 <c:forEach var="image" items="${figure.images}">
+                    <!-- multiple images, show as thumbnails -->
                     <zfin:link entity="${image}"/>
                 </c:forEach>
+
+                <%--CAPTION--%>
+                <c:if test="${showCaption}">
+                    <!-- show caption -->
+                    <zfin-figure:figureLabelAndCaption figure="${figure}"/>
+                </c:if>
+
             </c:if>
 
-            <c:if test="${showCaption}">
-                <zfin-figure:figureLabelAndCaption figure="${figure}"/>
-            </c:if>
 
             <%-- on all figure view, we want to also show some data tables, so they'll be passed in as the
              'body' of this tag --%>

--- a/home/WEB-INF/tags/figure/imagesAndCaption.tag
+++ b/home/WEB-INF/tags/figure/imagesAndCaption.tag
@@ -5,9 +5,6 @@
 <%@ attribute name="showCaption" type="java.lang.Boolean" rtexprvalue="true" required="false" %>
 <%@ attribute name="showMultipleMediumSizedImages" type="java.lang.Boolean" rtexprvalue="true" required="true" %>
 
-<!-- DEBUGGING -->
-<%--<c:set var="showMultipleMediumSizedImages" value="false"/>--%>
-
 <c:set var="showCaption" value="${!showCaption ? false : true }"/>
 <table class="figure-image-and-caption">
     <tr>

--- a/home/WEB-INF/tags/figure/showSingleImage.tag
+++ b/home/WEB-INF/tags/figure/showSingleImage.tag
@@ -3,6 +3,7 @@
 <%@ attribute name="image" type="org.zfin.expression.Image" rtexprvalue="true" required="true"  %>
 <%@ attribute name="autoplayVideo" type="java.lang.Boolean" rtexprvalue="true" required="false" %>
 <%@ attribute name="medium" type="java.lang.Boolean" rtexprvalue="true" required="false" %>
+<%@ attribute name="directLink" type="java.lang.Boolean" rtexprvalue="true" required="false" %>
 
 <c:set var="autoplay" value=""/>
 <c:if test="${autoplayVideo}">
@@ -31,8 +32,18 @@
         </video>
     </c:when>
     <c:otherwise>
-        <zfin:link entity="${image}">
-            <img class="figure-image ${medium ? 'medium' : ''}" src="/imageLoadUp/${filename}"/>
-        </zfin:link>
+        <!-- if the directLink attribute is true, link to the image source -->
+        <c:choose>
+            <c:when test="${!empty directLink}">
+                <a href="/imageLoadUp/${filename}" target="_blank">
+                    <img class="figure-image ${medium ? 'medium' : ''}" src="/imageLoadUp/${filename}"/>
+                </a>
+            </c:when>
+            <c:otherwise>
+                <zfin:link entity="${image}">
+                    <img class="figure-image ${medium ? 'medium' : ''}" src="/imageLoadUp/${filename}"/>
+                </zfin:link>
+            </c:otherwise>
+        </c:choose>
     </c:otherwise>
 </c:choose>

--- a/home/css/datapage.scss
+++ b/home/css/datapage.scss
@@ -402,3 +402,31 @@ table.lab-view-summary-table dd a, table.company-view-summary-table dd a {
     columns: 15em;
     column-gap: 1em;
 }
+
+/* All Figures View Page */
+.all-figures {
+    & div.multiple-medium-images {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        & a:hover {
+            box-shadow: 0 0 10px #555;
+        }
+        & a img.figure-image {
+            /* These two lines could be uncommented to make the images fill the row height */
+            /*object-fit: cover;*/
+            /*height: 100%;*/
+            margin: 0;
+            border: none;
+        }
+    }
+    & div.single-image {
+        & a img:hover {
+            box-shadow: 0 0 10px #555;
+        }
+        & a img.figure-image {
+            border: none;
+        }
+    }
+}
+

--- a/source/org/zfin/publication/presentation/ImageViewController.java
+++ b/source/org/zfin/publication/presentation/ImageViewController.java
@@ -83,6 +83,7 @@ public class ImageViewController {
             model.addAttribute("probe", probe);
         }
 
+        model.addAttribute("directLink", true);
         return "figure/image-view";
     }
 


### PR DESCRIPTION
For figures that have multiple images, show them in rows instead of one at a time vertically.

I preserved the behavior of showMultipleMediumSizedImages, though I'm not sure why we want that flag.

On the image page, clicking on the image just redirects you back to the same page.  I changed it to open just the raw image as I think that is the expected behavior.