### PR TITLE
Postgres 14 compatibility tweak

### DIFF
--- a/lib/DB_functions/aoterm_overlaps_stg_window.sql
+++ b/lib/DB_functions/aoterm_overlaps_stg_window.sql
@@ -4,7 +4,7 @@ aoterm_overlaps_stg_window (
   startStageZdbId text,
   endStageZdbId   text)
 
-  returns boolean as $true$
+  returns boolean as $DELIMITER$
 
   -- Returns true if the stage window the anatomy item exists in overlaps in
   -- any way with stage window passed in to the routine
@@ -17,7 +17,7 @@ aoterm_overlaps_stg_window (
    anatEnd           stage.stg_hours_start%TYPE;
    windowStartStart  stage.stg_hours_start%TYPE;
    windowEndEnd      stage.stg_hours_start%TYPE;
-   overlaps         boolean;
+   isOverlapping         boolean;
    consistent   	  boolean := stg_window_consistent(startStageZdbId, endStageZdbId);
 
  begin
@@ -42,14 +42,14 @@ aoterm_overlaps_stg_window (
     from stage
     where stg_zdb_id = endStageZdbId;
 
-  overlaps = 't';
+  isOverlapping := 't';
 
   if (anatStart >= windowEndEnd or
       anatEnd   <= windowStartStart) then
-     overlaps = 'f';
+     isOverlapping := 'f';
   end if;
 
-  return overlaps;
+  return isOverlapping;
 
 end
-$true$ LANGUAGE plpgsql
+$DELIMITER$ LANGUAGE plpgsql;

--- a/lib/DB_functions/fimg_overlaps_stg_window.sql
+++ b/lib/DB_functions/fimg_overlaps_stg_window.sql
@@ -18,7 +18,7 @@ fimg_overlaps_stg_window (
    imgEndEnd       stage.stg_hours_start%TYPE;
    windowStartStart stage.stg_hours_start%TYPE;
    windowEndEnd     stage.stg_hours_start%TYPE;
-   overlaps         boolean;
+   isOverlapping         boolean;
    consistent   	  boolean;
 
   begin
@@ -44,7 +44,7 @@ fimg_overlaps_stg_window (
   -- Window we are checking for is consistent.
   -- Get fish_image_stage records until we find one that overlaps.
 
-  overlaps = 'f';
+  isOverlapping = 'f';
   for imgStartStart, imgEndEnd in
     select startStg.stg_hours_start, endStg.stg_hours_end
       from image_stage, stage startStg, stage endStg
@@ -55,12 +55,12 @@ fimg_overlaps_stg_window (
 
 	if (windowStartStart < fimgEndEnd and
        	    windowEndEnd > fimgStartStart) then
-       	    overlaps = 't';
+       	    isOverlapping = 't';
     	    exit;          -- !!!! EXIT LOOP EARLY
      	end if;
     end loop;
  
-  return overlaps;
+  return isOverlapping;
 
 end 
 

--- a/lib/DB_functions/stg_windows_overlap.sql
+++ b/lib/DB_functions/stg_windows_overlap.sql
@@ -6,7 +6,7 @@ create or replace function stg_windows_overlap(
 
   returns boolean as $true$
 
-  -- Returns true if the first stage window overlaps in any way with the 
+  -- Returns true if the first stage window isOverlapping in any way with the
   -- second stage window.
   -- A -746 error is returned if any of these conditions fails.
   --   All parameters must be non-null.  
@@ -16,7 +16,7 @@ create or replace function stg_windows_overlap(
    w1EndEnd      stage.stg_hours_start%TYPE;
    w2StartStart  stage.stg_hours_start%TYPE;
    w2EndEnd      stage.stg_hours_start%TYPE;
-   overlaps     boolean;
+   isOverlapping     boolean;
    consistent   boolean;
 
  begin 
@@ -53,14 +53,14 @@ create or replace function stg_windows_overlap(
 
   -- Data looks good, do the check.
 
-  overlaps := 't';
+  isOverlapping := 't';
 
   if (w1StartStart >= w2EndEnd or
       w1EndEnd   <= w2StartStart) then
-    overlaps := 'f';
+    isOverlapping := 'f';
   end if;
 
-  return overlaps;
+  return isOverlapping;
 
 end
 $true$ LANGUAGE plpgsql;


### PR DESCRIPTION
My local pg environment did not like the variable to be named "overlaps" due to conflict with keyword.