### PR TITLE
Security Context Fix for Testing -- version 1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -711,6 +711,9 @@ dependencies {
     implementation group: 'org.springframework', name: 'spring-context-support', version: '4.2.2.RELEASE'
     implementation group: 'org.springframework.security', name: 'spring-security-web', version: '4.0.3.RELEASE'
     implementation group: 'org.springframework.security', name: 'spring-security-crypto', version: '4.0.3.RELEASE'
+    implementation group: 'org.springframework.security', name: 'spring-security-config', version: '4.0.3.RELEASE'
+    testImplementation 'org.springframework.security:spring-security-test:4.2.2.RELEASE'
+
     implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
     implementation group: 'javax.el', name: 'javax.el-api', version: '3.0.0'
     implementation group: 'org.glassfish.web', name: 'javax.el', version: '2.2.4'

--- a/home/WEB-INF/spring/security.xml
+++ b/home/WEB-INF/spring/security.xml
@@ -32,7 +32,10 @@
         <constructor-arg value="ZFIN_KEY"/>
         <constructor-arg ref="userDetailsService"/>
         <property name="cookieName" value="ZFIN_REMEMBER_ME"/>
-        <property name="tokenValiditySeconds" value="${VALID_SESSION_TIMEOUT_SECONDS}"/>
+
+<!--        Remove this and use logic in the constructor to set it-->
+<!--        <property name="tokenValiditySeconds" value="${VALID_SESSION_TIMEOUT_SECONDS}"/>-->
+
         <!--want a parentColumn that is rated strong to reduce likelihood of reverse engineering-->
         <property name="useSecureCookie" value="false"/>
     </bean>

--- a/source/org/zfin/security/IpTokenRememberMeServices.java
+++ b/source/org/zfin/security/IpTokenRememberMeServices.java
@@ -7,6 +7,8 @@ import org.springframework.security.crypto.codec.Hex;
 import org.springframework.security.web.authentication.rememberme.InvalidCookieException;
 import org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices;
 import org.springframework.util.StringUtils;
+import org.zfin.properties.ZfinProperties;
+import org.zfin.properties.ZfinPropertiesEnum;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -24,6 +26,10 @@ public class IpTokenRememberMeServices extends TokenBasedRememberMeServices{
 
     public IpTokenRememberMeServices(String key, UserDetailsService userDetailsService) {
         super(key, userDetailsService);
+
+        String timeout = ZfinPropertiesEnum.VALID_SESSION_TIMEOUT_SECONDS.value();
+        this.setTokenValiditySeconds(Integer.parseInt(timeout));
+
     }
 
     @Override

--- a/test/org/zfin/AppConfig.java
+++ b/test/org/zfin/AppConfig.java
@@ -3,11 +3,13 @@ package org.zfin;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.core.session.SessionRegistryImpl;
 
 @Configuration
 @ComponentScan(basePackages = {"org.zfin"})
+@ImportResource("classpath:WEB-INF/spring/security.xml") //see: https://stackoverflow.com/a/27979838
 public class AppConfig {
 
     @Bean


### PR DESCRIPTION
This seems like the right approach to getting failing tests to work due to autowiring the bcrypt bean failing.

We need to tell the test to load the security.xml file.  The problem is the security.xml file in the source tree contains placeholders that get replaced later (${SECUREPORT}, etc.).  That makes this approach a bigger restructuring.