### PR TITLE
ZFIN-8392: Remove duplicates from MarkerEditDbLinks dialog

### DIFF
--- a/source/org/zfin/gwt/root/dto/ReferenceDatabaseDTO.java
+++ b/source/org/zfin/gwt/root/dto/ReferenceDatabaseDTO.java
@@ -1,71 +1,28 @@
 package org.zfin.gwt.root.dto;
 
 import com.google.gwt.user.client.rpc.IsSerializable;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  */
+@Setter
+@Getter
 @SuppressWarnings({"CloneDoesntCallSuperClone", "CloneDoesntDeclareCloneNotSupportedException"})
 public class ReferenceDatabaseDTO implements IsSerializable {
 
     private String zdbID;
     private String name;
+    private String originalDbName;
     private String type;
     private String superType;
     private String blastName;
     private String url;
 
-    public String getZdbID() {
-        return zdbID;
-    }
-
-    public void setZdbID(String zdbID) {
-        this.zdbID = zdbID;
-    }
-
     public String getNameAndType() {
         return name + " - " + type;
     }
 
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    public String getSuperType() {
-        return superType;
-    }
-
-    public void setSuperType(String superType) {
-        this.superType = superType;
-    }
-
-    public String getBlastName() {
-        return blastName;
-    }
-
-    public void setBlastName(String blastName) {
-        this.blastName = blastName;
-    }
-
-
-    public String getUrl() {
-        return url;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
 
     public ReferenceDatabaseDTO clone() {
         ReferenceDatabaseDTO refdbDTO = new ReferenceDatabaseDTO();

--- a/source/org/zfin/gwt/root/server/DTOConversionService.java
+++ b/source/org/zfin/gwt/root/server/DTOConversionService.java
@@ -300,6 +300,7 @@ public class DTOConversionService {
         ReferenceDatabaseDTO referenceDatabaseDTO = new ReferenceDatabaseDTO();
         referenceDatabaseDTO.setZdbID(referenceDatabase.getZdbID());
         referenceDatabaseDTO.setName(referenceDatabase.getForeignDB().getDbName().toString());
+        referenceDatabaseDTO.setOriginalDbName(referenceDatabase.getForeignDB().getOriginalDbName());
         referenceDatabaseDTO.setType(referenceDatabase.getForeignDBDataType().getDataType().toString());
         referenceDatabaseDTO.setSuperType(referenceDatabase.getForeignDBDataType().getSuperType().toString());
         if (referenceDatabase.getPrimaryBlastDatabase() != null) {

--- a/source/org/zfin/sequence/ForeignDB.java
+++ b/source/org/zfin/sequence/ForeignDB.java
@@ -1,10 +1,15 @@
 package org.zfin.sequence;
 
 import com.fasterxml.jackson.annotation.JsonView;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.Formula;
 import org.zfin.framework.api.View;
 
 import javax.persistence.*;
 
+@Setter
+@Getter
 @Entity
 @Table(name = "FOREIGN_DB")
 public class ForeignDB implements Comparable<ForeignDB> {
@@ -17,6 +22,10 @@ public class ForeignDB implements Comparable<ForeignDB> {
     @org.hibernate.annotations.Type(type = "org.zfin.framework.StringEnumValueUserType",
             parameters = {@org.hibernate.annotations.Parameter(name = "enumClassname", value = "org.zfin.sequence.ForeignDB$AvailableName")})
     private AvailableName dbName;
+
+    @Formula("fdb_db_name")
+    private String originalDbName;
+
     @Column(name = "fdb_db_query")
     @JsonView(View.MarkerRelationshipAPI.class)
     private String dbUrlPrefix;
@@ -28,54 +37,6 @@ public class ForeignDB implements Comparable<ForeignDB> {
     @JsonView(View.MarkerRelationshipAPI.class)
     @Column(name = "fdb_db_display_name")
     private String displayName;
-
-    public Long getDbID() {
-        return dbID;
-    }
-
-    public void setDbID(Long dbID) {
-        this.dbID = dbID;
-    }
-
-    public String getDbUrlPrefix() {
-        return dbUrlPrefix;
-    }
-
-    public void setDbUrlPrefix(String dbUrlPrefix) {
-        this.dbUrlPrefix = dbUrlPrefix;
-    }
-
-    public String getDbUrlSuffix() {
-        return dbUrlSuffix;
-    }
-
-    public void setDbUrlSuffix(String dbUrlSuffix) {
-        this.dbUrlSuffix = dbUrlSuffix;
-    }
-
-    public Integer getSignificance() {
-        return significance;
-    }
-
-    public void setSignificance(Integer significance) {
-        this.significance = significance;
-    }
-
-    public AvailableName getDbName() {
-        return dbName;
-    }
-
-    public void setDbName(AvailableName dbName) {
-        this.dbName = dbName;
-    }
-
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
-    }
 
     public int compareTo(ForeignDB other) {
         if (other == null)


### PR DESCRIPTION
Add the fdb_db_name column to the serialization of ForeignDB object. It already pulled that column, but transformed it to an enum.  This adds the column again, but as a string.

Remove duplicate entries from the dialog for MarkerEditDbLink (of identical options, favor the earliest zdbID).

Clean up the DisplayGroupRepository for modern hibernate.

lombokify where appropriate