### PR TITLE
Fix eslint issues

### DIFF
--- a/home/javascript/react/components/ShowExpressionStructureList.js
+++ b/home/javascript/react/components/ShowExpressionStructureList.js
@@ -1,6 +1,5 @@
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
-import {publicationType} from '../utils/types';
 import CommaSeparatedList from './CommaSeparatedList';
 import {EntityLink} from './entity';
 
@@ -50,17 +49,7 @@ const ShowExpressionStructureList = ({expressionTerms}) => {
 };
 
 ShowExpressionStructureList.propTypes = {
-    allFiguresUrl: PropTypes.string,
-    statistics: PropTypes.shape({
-        numberOfPublications: PropTypes.number,
-        numberOfFigures: PropTypes.number,
-        imgInFigure: PropTypes.bool,
-        firstFigure: PropTypes.shape({
-            zdbID: PropTypes.string,
-            label: PropTypes.string,
-        }),
-        firstPublication: publicationType,
-    })
-}
+    expressionTerms: PropTypes.array,
+};
 
 export default ShowExpressionStructureList;

--- a/home/javascript/react/components/entity/EntityAbbreviation.js
+++ b/home/javascript/react/components/entity/EntityAbbreviation.js
@@ -27,7 +27,7 @@ const EntityAbbreviation = ({entity}) => {
 
     if (match) {
         type = match[1];
-        for (const typeClass of TYPE_CLASSES) {
+        for (const typeClass of Object.values(TYPE_CLASSES)) { // eslint-disable-line no-unused-vars
             if (typeClass.types.indexOf(type) >= 0) {
                 className = typeClass.className;
                 break;

--- a/home/javascript/react/components/entity/EntityGroupList.js
+++ b/home/javascript/react/components/entity/EntityGroupList.js
@@ -17,7 +17,7 @@ const EntityGroupList = ({entities, showLink, stringOnly}) => (
                         <li><EntityAbbreviation key={entity.zdbID} entity={entity}/></li>
                     </>
                 } else {
-                    return <li>{entity}</li>
+                    return <li key={entity.zdbID}>{entity}</li>
                 }
             }
         })}

--- a/home/javascript/react/components/entity/TermName.js
+++ b/home/javascript/react/components/entity/TermName.js
@@ -23,7 +23,7 @@ const EntityAbbreviation = ({entity}) => {
 
     if (match) {
         type = match[1];
-        for (const typeClass of TYPE_CLASSES) {
+        for (const typeClass of TYPE_CLASSES) { // eslint-disable-line no-unused-vars
             if (typeClass.types.indexOf(type) >= 0) {
                 className = typeClass.className;
                 break;

--- a/home/javascript/react/components/marker-edit/EditOrthologyEvidenceCell.js
+++ b/home/javascript/react/components/marker-edit/EditOrthologyEvidenceCell.js
@@ -90,7 +90,7 @@ const EditOrthologyEvidenceCell = ({defaultPubId, evidenceCodes, evidenceSet, or
 
     const evidenceGroupedByPub = {};
     evidenceSet.forEach(evidence => {
-        if (!evidenceGroupedByPub.hasOwnProperty(evidence.publication.zdbID)) {
+        if (!Object.hasOwn(evidenceGroupedByPub, evidence.publication.zdbID)) {
             evidenceGroupedByPub[evidence.publication.zdbID] = [];
         }
         evidenceGroupedByPub[evidence.publication.zdbID].push(evidence.evidenceCode);
@@ -115,7 +115,7 @@ const EditOrthologyEvidenceCell = ({defaultPubId, evidenceCodes, evidenceSet, or
     }
 
     const setModalItem = (item, isEdit, isInputChange) => {
-        const exists = evidenceGroupedByPub.hasOwnProperty(item.publicationID);
+        const exists = Object.hasOwn(evidenceGroupedByPub, item.publicationID);
         if ((!isEdit || isInputChange) && exists) {
             setModalWarning(`${item.publicationID} is already a reference for ${ortholog.organism} ${ortholog.abbreviation} orthology. You are now editing the existing record.`);
         } else {
@@ -127,7 +127,7 @@ const EditOrthologyEvidenceCell = ({defaultPubId, evidenceCodes, evidenceSet, or
 
     const handlePubInputChange = (event) => {
         const pubId = event.target.value;
-        const isEdit = evidenceGroupedByPub.hasOwnProperty(pubId);
+        const isEdit = Object.hasOwn(evidenceGroupedByPub, pubId);
         setModalItem({
             publicationID: pubId,
             orthologID: orthoZdbId,


### PR DESCRIPTION
These are the issues reported by eslint.  I fixed them all except for the ones that say "error  'typeClass' is defined but never used  no-unused-vars".  Those ones are actually a false positive.  This is reported here: https://stackoverflow.com/questions/57833013/why-am-i-getting-a-no-unused-vars-warning-in-a-for-of-loop-and-how-do-i-fix.  The fix is to upgrade babel-eslint to 10.0.3, but that brings other problems so I just marked those 2 cases as ignore.

```
/opt/zfin/source_roots/zfin.org/home/javascript/react/components/ShowExpressionStructureList.js
   7:39   error  'expressionTerms' is missing in props validation         react/prop-types
  11:53   error  'expressionTerms.slice' is missing in props validation   react/prop-types
  28:34   error  'expressionTerms.length' is missing in props validation  react/prop-types
  29:104  error  'expressionTerms.length' is missing in props validation  react/prop-types
  37:34   error  'expressionTerms.map' is missing in props validation     react/prop-types

/opt/zfin/source_roots/zfin.org/home/javascript/react/components/entity/EntityAbbreviation.js
  30:20  error  'typeClass' is defined but never used  no-unused-vars

/opt/zfin/source_roots/zfin.org/home/javascript/react/components/entity/EntityGroupList.js
  20:28  error  Missing "key" prop for element in iterator  react/jsx-key

/opt/zfin/source_roots/zfin.org/home/javascript/react/components/entity/TermName.js
  26:20  error  'typeClass' is defined but never used  no-unused-vars

/opt/zfin/source_roots/zfin.org/home/javascript/react/components/marker-edit/EditOrthologyEvidenceCell.js
   93:35  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
  118:45  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
  130:45  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
```