### PR TITLE
ZFIN-8392: Fix duplicate options in dropdown on str edit page

### DIFF
--- a/home/WEB-INF/jsp/marker/sequenceTargetingReagent/sequence-targeting-reagent-edit.jsp
+++ b/home/WEB-INF/jsp/marker/sequenceTargetingReagent/sequence-targeting-reagent-edit.jsp
@@ -62,7 +62,7 @@
     <z:section title="${OTHERPAGES}">
         <div class="__react-root"
              id="MarkerEditDbLinks"
-             data-group="summary page"
+             data-group="str edit page"
              data-marker-id="${str.zdbID}">
         </div>
     </z:section>

--- a/source/org/zfin/db/postGmakePostloaddb/1140/ZFIN-8392-create-display-group-for-str-edit-dropdown.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1140/ZFIN-8392-create-display-group-for-str-edit-dropdown.sql
@@ -1,0 +1,47 @@
+--liquibase formatted sql
+--changeset rtaylor:zfin-8392
+
+ALTER TABLE foreign_db_contains_display_group
+    ADD CONSTRAINT fdbcdg_unique_name UNIQUE (fdbcdg_name);
+
+INSERT INTO foreign_db_contains_display_group (fdbcdg_name, fdbcdg_definition)
+    VALUES ('str edit page', 'a group of records available to select when adding external page link on str edit page');
+
+INSERT INTO foreign_db_contains_display_group_member (fdbcdgm_fdbcont_zdb_id, fdbcdgm_group_id)
+    SELECT
+        fdbcont_zdb_id,
+        fdbcdg_pk_id
+    FROM
+        foreign_db_contains,
+        foreign_db_contains_display_group
+    WHERE
+          fdbcdg_name = 'str edit page'
+      AND fdbcont_zdb_id IN
+        (
+         'ZDB-FDBCONT-040412-1',  -- [ foreign_db.fdb_db_name = Gene ]
+         'ZDB-FDBCONT-040412-14', -- [ foreign_db.fdb_db_name = VEGA ]
+         'ZDB-FDBCONT-040412-41', -- [ foreign_db.fdb_db_name = Sanger_Clone ]
+         'ZDB-FDBCONT-040826-2',  -- [ foreign_db.fdb_db_name = VEGA_Clone ]
+         'ZDB-FDBCONT-060417-1',  -- [ foreign_db.fdb_db_name = Vega_Trans ]
+         'ZDB-FDBCONT-060626-2',  -- [ foreign_db.fdb_db_name = Ensembl_SNP ]
+         'ZDB-FDBCONT-060626-3',  -- [ foreign_db.fdb_db_name = dbSNP ]
+         'ZDB-FDBCONT-061004-1',  -- [ foreign_db.fdb_db_name = Ensembl_Clone ]
+         'ZDB-FDBCONT-061018-1',  -- [ foreign_db.fdb_db_name = Ensembl(GRCz11) ]
+         'ZDB-FDBCONT-061129-1',  -- [ foreign_db.fdb_db_name = UniProtKB-KW ]
+         'ZDB-FDBCONT-070718-1',  -- [ foreign_db.fdb_db_name = PreEnsembl(Zv7) ]
+         'ZDB-FDBCONT-071009-1',  -- [ foreign_db.fdb_db_name = MODB ]
+         'ZDB-FDBCONT-071128-4',  -- [ foreign_db.fdb_db_name = NovelGene ]
+         'ZDB-FDBCONT-071228-1',  -- [ foreign_db.fdb_db_name = ZF-Espresso ]
+         'ZDB-FDBCONT-090929-3',  -- [ foreign_db.fdb_db_name = miRBASE Mature ]
+         'ZDB-FDBCONT-110301-1',  -- [ foreign_db.fdb_db_name = Ensembl_Trans ]
+         'ZDB-FDBCONT-120213-1',  -- [ foreign_db.fdb_db_name = zfishbook ]
+         'ZDB-FDBCONT-120411-1',  -- [ foreign_db.fdb_db_name = ZMP ]
+         'ZDB-FDBCONT-130516-2',  -- [ foreign_db.fdb_db_name = zfishbook-constructs ]
+         'ZDB-FDBCONT-140217-1',  -- [ foreign_db.fdb_db_name = CreZoo ]
+         'ZDB-FDBCONT-160128-1',  -- [ foreign_db.fdb_db_name = CRISPRz ]
+         'ZDB-FDBCONT-160215-1',  -- [ foreign_db.fdb_db_name = RRID ]
+         'ZDB-FDBCONT-171115-1',  -- [ foreign_db.fdb_db_name = CZRC ]
+         'ZDB-FDBCONT-131021-1',  -- [ foreign_db.fdb_db_name = Ensembl ]
+         'ZDB-FDBCONT-190723-1',  -- [ foreign_db.fdb_db_name = ABRegistry ]
+         'ZDB-FDBCONT-220301-1'   -- [ foreign_db.fdb_db_name = FishMiRNA ]
+        );

--- a/source/org/zfin/db/postGmakePostloaddb/1140/db.changelog.master.xml
+++ b/source/org/zfin/db/postGmakePostloaddb/1140/db.changelog.master.xml
@@ -11,6 +11,7 @@
     <include file="source/org/zfin/db/postGmakePostloaddb/1140/ZFIN-8396-add-password-last-updated-field.sql" />
     <include file="source/org/zfin/db/postGmakePostloaddb/1140/ZFIN-8396-clear-old-passwords.sql" />
     <include file="source/org/zfin/db/postGmakePostloaddb/1140/ZFIN-8226.sql" />
+    <include file="source/org/zfin/db/postGmakePostloaddb/1140/ZFIN-8392-create-display-group-for-str-edit-dropdown" />
 
 
 

--- a/source/org/zfin/sequence/DisplayGroup.java
+++ b/source/org/zfin/sequence/DisplayGroup.java
@@ -1,7 +1,12 @@
 package org.zfin.sequence;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.util.Set;
 
+@Setter
+@Getter
 public class DisplayGroup implements Comparable<DisplayGroup>{
 
 
@@ -9,38 +14,6 @@ public class DisplayGroup implements Comparable<DisplayGroup>{
     private GroupName groupName;
     private String definition;
     private Set<ReferenceDatabase> referenceDatabases;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public GroupName getGroupName() {
-        return groupName;
-    }
-
-    public void setGroupName(GroupName groupName) {
-        this.groupName = groupName;
-    }
-
-    public String getDefinition() {
-        return definition;
-    }
-
-    public void setDefinition(String definition) {
-        this.definition = definition;
-    }
-
-    public Set<ReferenceDatabase> getReferenceDatabases() {
-        return referenceDatabases;
-    }
-
-    public void setReferenceDatabases(Set<ReferenceDatabase> referenceDatabases) {
-        this.referenceDatabases = referenceDatabases;
-    }
 
     public enum GroupName {
         ADDABLE_NUCLEOTIDE_SEQUENCE("addable nucleotide sequence"),
@@ -58,6 +31,7 @@ public class DisplayGroup implements Comparable<DisplayGroup>{
         MICRORNA_TARGETS("microrna targets"),
         SUMMARY_PAGE("summary page"),
         GENE_VIEW_STEM_LOOP("gene view stem loop"),
+        STR_EDIT_PAGE("str edit page"),
         TRANSCRIPT_EDIT_ADDABLE_PROTEIN_SEQUENCE("transcript edit addable protein sequence"),
         TRANSCRIPT_EDIT_ADDABLE_NUCLEOTIDE_SEQUENCE("transcript edit addable nucleotide sequence"),
         TRANSCRIPT_EDIT_ADDABLE_MIRNA_NUCLEOTIDE_SEQUENCE("transcript edit addable miRNA nucleotide sequence"),
@@ -66,7 +40,7 @@ public class DisplayGroup implements Comparable<DisplayGroup>{
         PATHWAYS("pathways")
         ;
 
-        private String value;
+        private final String value;
 
         GroupName(String value) {
             this.value = value;


### PR DESCRIPTION
Create a new "DisplayGroup" to show on the str edit page that does not contain the duplication reported in the bug report.  Also, remove the alliance options since we don't expect to manually add alliance links.