### PR TITLE
Release 1139: Hotfix for ZFIN-8464 and ZFIN-8468

### DIFF
--- a/home/javascript/react/containers/MarkerEditDbLinks.js
+++ b/home/javascript/react/containers/MarkerEditDbLinks.js
@@ -99,7 +99,7 @@ const MarkerEditDbLinks = ({markerId, group = 'other marker pages'}) => {
                         <label className='col-md-2 col-form-label'>Citations</label>
                         <div className='col-md-10'>
                             {
-                                values.references.map((reference, idx) => (
+                                values.references && values.references.map((reference, idx) => (
                                     <div key={idx} className={`d-flex align-items-baseline ${idx > 0 ? 'mt-2' : ''}`}>
                                         <div className='flex-grow-1'>
                                             <InputField

--- a/source/org/zfin/infrastructure/repository/HibernateInfrastructureRepository.java
+++ b/source/org/zfin/infrastructure/repository/HibernateInfrastructureRepository.java
@@ -173,6 +173,9 @@ public class HibernateInfrastructureRepository implements InfrastructureReposito
     //todo: add a getter here, or do some mapping to objects so that we can test the insert in a routine way
 
     public RecordAttribution insertRecordAttribution(String dataZdbID, String sourceZdbID) {
+        if (sourceZdbID != null) {
+            sourceZdbID = sourceZdbID.trim();
+        }
         if (hasStandardPublicationAttribution(dataZdbID, sourceZdbID)) {
             return null;
         }

--- a/source/org/zfin/marker/presentation/MarkerLinkController.java
+++ b/source/org/zfin/marker/presentation/MarkerLinkController.java
@@ -397,6 +397,10 @@ public class MarkerLinkController {
         if (linkDisplays.size() > 1) {
             LOG.error("too many LinkDisplays returned for " + linkId);
         }
+        if (linkDisplays.size() == 0) {
+            LOG.error("zero LinkDisplays returned for " + linkId);
+            return null;
+        }
         return linkDisplays.get(0);
     }
 


### PR DESCRIPTION
Allow deleting a dblink without attribution from gene page.
Trim whitespace from pub ID when submitted for attribution.