### PR TITLE
ZFIN-8450: Adjust the height of jbrowse on mapping details page.

### DIFF
--- a/home/WEB-INF/tags/gbrowse/genomeBrowserImageComponent.tag
+++ b/home/WEB-INF/tags/gbrowse/genomeBrowserImageComponent.tag
@@ -14,6 +14,7 @@
          data-link-url="${image.linkUrl}"
          data-build="${image.build}"
          data-chromosome="${image.chromosome}"
+         data-height="${image.height}"
     ></div>
 </c:if>
 <c:if test="${empty image}">

--- a/home/javascript/react/containers/JbrowseImage.js
+++ b/home/javascript/react/containers/JbrowseImage.js
@@ -7,19 +7,10 @@ const GBROWSE_PADDING = 90;
 const IMAGE_SIZE_STEP = 200;
 const DEBOUNCE_INTERVAL = 250;
 
-const JbrowseImage = ({imageUrl, linkUrl, build, chromosome}) => {
-//    const [imageLoaded, setImageLoaded] = useState(false);
+const JbrowseImage = ({imageUrl, linkUrl, build, chromosome, height = '400'}) => {
     const [imgSrc, setImageSrc] = useState(null);
     const containerRef = useRef(null);
     const sep = imageUrl.indexOf('?') < 0 ? '?' : '&';
-    /*
-        const hiddenStyle = {
-            position: 'absolute',
-            height: 0,
-            width: '100%',
-            overflow: 'hidden',
-        };
-    */
 
     // useLayoutEffect instead of useEffect since we're going to measure elements inside
     useLayoutEffect(() => {
@@ -57,7 +48,7 @@ const JbrowseImage = ({imageUrl, linkUrl, build, chromosome}) => {
                     <object
                         type='text/html'
                         width='1000'
-                        height='400'
+                        height={height}
                         className='d-block mx-auto mb-3 pe-none'
                         data={imgSrc}
                         //onLoad={() => setImageLoaded(true)}

--- a/source/org/zfin/gbrowse/presentation/GBrowseImage.java
+++ b/source/org/zfin/gbrowse/presentation/GBrowseImage.java
@@ -101,6 +101,12 @@ public class GBrowseImage implements GenomeBrowserImage {
     }
 
     @Override
+    public Integer getHeight() {
+        //not used by gbrowse
+        return null;
+    }
+
+    @Override
     public String getBuild() {
         return build.getValue();
     }

--- a/source/org/zfin/gbrowse/presentation/GBrowseImageBuilder.java
+++ b/source/org/zfin/gbrowse/presentation/GBrowseImageBuilder.java
@@ -32,6 +32,7 @@ public class GBrowseImageBuilder implements GenomeBrowserImageBuilder {
     private Marker highlightMarker;
     private Feature highlightFeature;
     private String highlightString;
+    private Integer height;
 
     @Override
     public GenomeBrowserImage build() {
@@ -122,6 +123,12 @@ public class GBrowseImageBuilder implements GenomeBrowserImageBuilder {
     }
 
     @Override
+    public GenomeBrowserImageBuilder withHeight(int height) {
+        this.height = height;
+        return this;
+    }
+
+    @Override
     public GenomeBrowserImageBuilder tracks(GenomeBrowserTrack... tracks) {
         return tracks(Arrays.asList(tracks));
     }
@@ -196,4 +203,8 @@ public class GBrowseImageBuilder implements GenomeBrowserImageBuilder {
         return highlightFeature;
     }
 
+    @Override
+    public Integer getHeight() {
+        return height;
+    }
 }

--- a/source/org/zfin/genomebrowser/presentation/GenomeBrowserImage.java
+++ b/source/org/zfin/genomebrowser/presentation/GenomeBrowserImage.java
@@ -18,6 +18,8 @@ public interface GenomeBrowserImage {
 
     GenomeBrowserType getType();
 
+    Integer getHeight();
+
     @Override
     boolean equals(Object o);
 

--- a/source/org/zfin/genomebrowser/presentation/GenomeBrowserImageBuilder.java
+++ b/source/org/zfin/genomebrowser/presentation/GenomeBrowserImageBuilder.java
@@ -36,6 +36,8 @@ public interface GenomeBrowserImageBuilder {
 
     GenomeBrowserImageBuilder withPadding(int v);
 
+    GenomeBrowserImageBuilder withHeight(int height);
+
     GenomeBrowserImageBuilder grid(boolean grid);
 
     String getLandmark();
@@ -53,4 +55,6 @@ public interface GenomeBrowserImageBuilder {
     Feature getHighlightFeature();
 
     GenomeBrowserImage buildForClone(Clone clone);
+
+    Integer getHeight();
 }

--- a/source/org/zfin/jbrowse/presentation/JBrowseImage.java
+++ b/source/org/zfin/jbrowse/presentation/JBrowseImage.java
@@ -24,6 +24,9 @@ public class JBrowseImage implements GenomeBrowserImage {
     private String linkUrlBase;
     private String linkUrl;
 
+    private static final int DEFAULT_HEIGHT = 400;
+    private Integer height = DEFAULT_HEIGHT;
+
     private GenomeBrowserBuild build;
     private GenomeBrowserType type = GenomeBrowserType.JBROWSE;
 
@@ -33,7 +36,7 @@ public class JBrowseImage implements GenomeBrowserImage {
         this.highlightFeature = builder.getHighlightLandmark();
         this.highlightColor = builder.getHighlightColor();
         this.grid = builder.isGrid();
-
+        this.height = builder.getHeight();
         this.build = builder.getGenomeBuild();
         this.linkUrlBase = this.build.getPath();
         this.imageUrlBase= this.build.getImagePath();
@@ -126,6 +129,14 @@ public class JBrowseImage implements GenomeBrowserImage {
     @Override
     public GenomeBrowserType getType() {
         return type;
+    }
+
+    @Override
+    public Integer getHeight() {
+        if (height == null) {
+            return DEFAULT_HEIGHT;
+        }
+        return height;
     }
 
     @Override

--- a/source/org/zfin/jbrowse/presentation/JBrowseImageBuilder.java
+++ b/source/org/zfin/jbrowse/presentation/JBrowseImageBuilder.java
@@ -39,6 +39,7 @@ public class JBrowseImageBuilder implements GenomeBrowserImageBuilder {
     private Marker highlightMarker;
     private Feature highlightFeature;
     private String highlightString;
+    private Integer height;
 
     @Override
     public GenomeBrowserImage build() {
@@ -166,6 +167,12 @@ public class JBrowseImageBuilder implements GenomeBrowserImageBuilder {
     }
 
     @Override
+    public GenomeBrowserImageBuilder withHeight(int height) {
+        this.height = height;
+        return this;
+    }
+
+    @Override
     public GenomeBrowserImageBuilder tracks(GenomeBrowserTrack... tracks) {
         return tracks(Arrays.asList(tracks));
     }
@@ -244,5 +251,9 @@ public class JBrowseImageBuilder implements GenomeBrowserImageBuilder {
         return highlightFeature;
     }
 
+    @Override
+    public Integer getHeight() {
+        return height;
+    }
 
 }

--- a/source/org/zfin/mapping/presentation/MappingDetailController.java
+++ b/source/org/zfin/mapping/presentation/MappingDetailController.java
@@ -254,6 +254,7 @@ public class MappingDetailController {
                         .withCenteredRange(500000)
                         .highlight(trackingGene) //ignored if using jbrowse for now
                         .highlightColor("pink")
+                        .withHeight(200)
                         .tracks(GBrowseService.getGBrowseTracks(marker))
                         .build()
                 );


### PR DESCRIPTION
Add a height attribute to jbrowse component so we can set a shorter height on the mapping details page.