### PR TITLE
ZFIN-8482: Show captions on figures

### DIFF
--- a/home/WEB-INF/jsp/figure/figure-view-prototype.jsp
+++ b/home/WEB-INF/jsp/figure/figure-view-prototype.jsp
@@ -27,6 +27,7 @@
 
         <z:section title="${figure.label}" sectionID="${zfn:makeDomIdentifier(FIGURE_CAPTION)}">
             <zfin-figure:imagesAndCaptionPrototype figure="${figure}"
+                                          showCaption="${true}"
                                                    showMultipleMediumSizedImages="${showMultipleMediumSizedImages}"/>
         </z:section>
 

--- a/home/WEB-INF/jsp/publication/publication-figures.jsp
+++ b/home/WEB-INF/jsp/publication/publication-figures.jsp
@@ -61,7 +61,7 @@
 
         <c:forEach var="figure" items="${figures}">
             <z:section title="${figure.label}" entity="${figure}">
-                <zfin-figure:imagesAndCaption
+                <zfin-figure:imagesAndCaptionPrototype
                         figure="${figure}"
                         autoplayVideo="false"
                         showMultipleMediumSizedImages="${showMultipleMediumSizedImages}"
@@ -84,7 +84,7 @@
                     </c:if>
                     <zfin-figure:constructLinks figure="${figure}"/>
 
-                </zfin-figure:imagesAndCaption>
+                </zfin-figure:imagesAndCaptionPrototype>
             </z:section>
         </c:forEach>
 

--- a/home/WEB-INF/tags/figure/imagesAndCaption.tag
+++ b/home/WEB-INF/tags/figure/imagesAndCaption.tag
@@ -13,52 +13,23 @@
 
             <%--has permission to show, single image, can be video--%>
             <c:if test="${figure.publication.canShowImages && !empty figure.images && (fn:length(figure.images) == 1 || showMultipleMediumSizedImages) }">
-                <c:choose>
-                    <c:when test="${fn:length(figure.images) > 1}">
-                        <%--CAPTION--%>
-                        <c:if test="${showCaption}">
-                            <!-- show caption -->
-                            <zfin-figure:figureLabelAndCaption figure="${figure}"/>
-                        </c:if>
-                        <div class="multiple-medium-images">
-                            <c:forEach var="image" items="${figure.images}">
-                                <!-- single image -->
-                                <zfin-figure:showSingleImage image="${image}" medium="true" autoplayVideo="${autoplayVideo}"/>
-                            </c:forEach>
-                        </div>
-                    </c:when>
-                    <c:otherwise>
-                        <div class="single-image" style="max-width: 510px;">
-                            <c:forEach var="image" items="${figure.images}">
-                                <!-- should only be a single image -->
-                                <zfin-figure:showSingleImage image="${image}" medium="true" autoplayVideo="${autoplayVideo}"/>
-                            </c:forEach>
-                        </div>
-
-                        <%--CAPTION--%>
-                        <c:if test="${showCaption}">
-                            <!-- show caption -->
-                            <zfin-figure:figureLabelAndCaption figure="${figure}"/>
-                        </c:if>
-                    </c:otherwise>
-                </c:choose>
+                <div style="max-width: 510px;"> <%-- this div causes multiple medium sized images to stack on top of one another, ZDB-PUB-990628-12 has an example--%>
+                    <c:forEach var="image" items="${figure.images}">
+                        <zfin-figure:showSingleImage image="${image}" medium="true" autoplayVideo="${autoplayVideo}"/>
+                    </c:forEach>
+                </div>
             </c:if>
 
             <%--has permission to show, multiple images, should show them as thumbnails --%>
             <c:if test="${figure.publication.canShowImages && !empty figure.images && fn:length(figure.images) > 1 && !showMultipleMediumSizedImages}">
                 <c:forEach var="image" items="${figure.images}">
-                    <!-- multiple images, show as thumbnails -->
                     <zfin:link entity="${image}"/>
                 </c:forEach>
-
-                <%--CAPTION--%>
-                <c:if test="${showCaption}">
-                    <!-- show caption -->
-                    <zfin-figure:figureLabelAndCaption figure="${figure}"/>
-                </c:if>
-
             </c:if>
 
+            <c:if test="${showCaption}">
+                <zfin-figure:figureLabelAndCaption figure="${figure}"/>
+            </c:if>
 
             <%-- on all figure view, we want to also show some data tables, so they'll be passed in as the
              'body' of this tag --%>

--- a/home/WEB-INF/tags/figure/imagesAndCaptionPrototype.tag
+++ b/home/WEB-INF/tags/figure/imagesAndCaptionPrototype.tag
@@ -2,30 +2,72 @@
 
 <%@ attribute name="figure" type="org.zfin.expression.Figure" rtexprvalue="true" required="true" %>
 <%@ attribute name="autoplayVideo" type="java.lang.Boolean" rtexprvalue="true" required="false" %>
+<%@ attribute name="showCaption" type="java.lang.Boolean" rtexprvalue="true" required="false" %>
 <%@ attribute name="showMultipleMediumSizedImages" type="java.lang.Boolean" rtexprvalue="true" required="true" %>
 
+<c:set var="showCaption" value="${!showCaption ? false : true }"/>
 <table class="figure-image-and-caption">
     <tr>
         <td>
             <zfin-figure:placeholderImages figure="${figure}"/>
 
             <%--has permission to show, single image, can be video--%>
-            <c:if test="${figure.publication.canShowImages && !empty figure.images && (fn:length(figure.images) == 1 || showMultipleMediumSizedImages) }">
-                <div style="max-width: 510px;"> <%-- this div causes multiple medium sized images to stack on top of one another, ZDB-PUB-990628-12 has an example--%>
-                    <c:forEach var="image" items="${figure.images}">
-                        <zfin-figure:showSingleImage image="${image}" medium="true" autoplayVideo="${autoplayVideo}"/>
-                    </c:forEach>
-                </div>
-            </c:if>
+            <!-- before branch A -->
+            <c:choose>
+            <c:when test="${figure.publication.canShowImages && !empty figure.images && (fn:length(figure.images) == 1 || showMultipleMediumSizedImages) }">
+                <c:choose>
+                    <c:when test="${fn:length(figure.images) > 1}">
+                        <%--CAPTION--%>
+                        <c:if test="${showCaption}">
+                            <!-- show caption -->
+                            <zfin-figure:figureLabelAndCaption figure="${figure}"/>
+                        </c:if>
+                        <div class="multiple-medium-images">
+                            <c:forEach var="image" items="${figure.images}">
+                                <!-- single image -->
+                                <zfin-figure:showSingleImage image="${image}" medium="true" autoplayVideo="${autoplayVideo}"/>
+                            </c:forEach>
+                        </div>
+                    </c:when>
+                    <c:otherwise>
+                        <div class="single-image" style="max-width: 510px;">
+                            <c:forEach var="image" items="${figure.images}">
+                                <!-- should only be a single image -->
+                                <zfin-figure:showSingleImage image="${image}" medium="true" autoplayVideo="${autoplayVideo}"/>
+                            </c:forEach>
+                        </div>
 
-            <%--has permission to show, multiple images, should show them as thumbnails --%>
-            <c:if test="${figure.publication.canShowImages && !empty figure.images && fn:length(figure.images) > 1 && !showMultipleMediumSizedImages}">
+                        <%--CAPTION--%>
+                        <c:if test="${showCaption}">
+                            <!-- show caption -->
+                            <zfin-figure:figureLabelAndCaption figure="${figure}"/>
+                        </c:if>
+                    </c:otherwise>
+                </c:choose>
+            </c:when>
+            <c:when test="${figure.publication.canShowImages && !empty figure.images && fn:length(figure.images) > 1 && !showMultipleMediumSizedImages}">
+                <!-- branch B -->
                 <c:forEach var="image" items="${figure.images}">
+                    <!-- multiple images, show as thumbnails -->
                     <zfin:link entity="${image}"/>
                 </c:forEach>
-            </c:if>
 
-            <zfin-figure:figureLabelAndCaption figure="${figure}" hideLabel="true"/>
+                <%--CAPTION--%>
+                <c:if test="${showCaption}">
+                    <!-- show caption -->
+                    <zfin-figure:figureLabelAndCaption figure="${figure}"/>
+                </c:if>
+
+            </c:when>
+            <c:otherwise>
+                <%--CAPTION--%>
+                <c:if test="${showCaption}">
+                    <!-- show caption -->
+                    <zfin-figure:figureLabelAndCaption figure="${figure}"/>
+                </c:if>
+            </c:otherwise>
+
+            </c:choose>
 
             <%-- on all figure view, we want to also show some data tables, so they'll be passed in as the
              'body' of this tag --%>

--- a/home/css/zfin.css
+++ b/home/css/zfin.css
@@ -517,7 +517,7 @@ video {
     border: 1px solid blue;
 }
 
-.figure-image-and-caption tbody {
+.data-page .figure-image-and-caption tbody {
     background-color: #FFF;
 }
 


### PR DESCRIPTION
The tags imagesAndCaption.tag and imagesAndCaptionPrototype.tag were reversed (the prototype one was used on legacy pages, and the non-prototype one was used on prototype pages). This reverses that to avoid confusion.

Also, fix bug where captions were not being displayed even though showCaption was true.