### PR TITLE
ZFIN-8477: Fix one of the links in expression table on figure view page

### DIFF
--- a/home/javascript/react/components/PostComposedEntity.js
+++ b/home/javascript/react/components/PostComposedEntity.js
@@ -23,7 +23,7 @@ const PostComposedEntity = ({postComposedEntity}) => {
             <div key={postComposedEntity.superterm.zdbID + postComposedEntity.subterm.zdbID}>
                 <a
                     key={postComposedEntity.superterm.zdbID + postComposedEntity.subterm.zdbID}
-                    href={'/action/ontology/post-composed-term-detail?superTermID=' + postComposedEntity.superterm.oboID + '&subTermID=' + postComposedEntity.superterm.oboID}
+                    href={'/action/ontology/post-composed-term-detail?superTermID=' + postComposedEntity.superterm.oboID + '&subTermID=' + postComposedEntity.subterm.oboID}
                     dangerouslySetInnerHTML={{__html: postComposedEntity.superterm.termName + ' ' + postComposedEntity.subterm.termName}}
                 />
                 <a


### PR DESCRIPTION
Fix one of the links that was previously passing the superterm id twice instead of the superterm and subterm