### PR TITLE
Gradle Feature Deprecation: "enabled" is deprecated and replaced with "required".

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -974,8 +974,8 @@ test {
     }
 
     reports {
-        junitXml.enabled = true
-        html.enabled = true
+        junitXml.required = true
+        html.required = true
     }
 }
 tasks.withType(Test) {

--- a/docker/compile/Dockerfile
+++ b/docker/compile/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:jdk17
+FROM gradle:7-jdk17
 
 RUN apt update && apt install -y --no-install-recommends \
        ant groovy postgresql-client tcsh sudo \


### PR DESCRIPTION
See: https://docs.gradle.org/7.5.1/javadoc/org/gradle/api/reporting/Report.html

<img width="1165" alt="Screenshot 2023-03-13 at 11 40 24 AM" src="https://user-images.githubusercontent.com/90803397/224799712-4516a567-8ee1-4f55-b569-796bc5bc97fb.png">
