### PR TITLE
ZFIN-8537: Human Diseases Section Failing on Publication Page

### DIFF
--- a/home/javascript/react/components/entity/EntityGroupList.js
+++ b/home/javascript/react/components/entity/EntityGroupList.js
@@ -6,7 +6,7 @@ import {EntityAbbreviation} from './index';
 
 const EntityGroupList = ({entities, showLink, stringOnly}) => (
     <ul className='unordered'>
-        {entities.map(entity => {
+        {entities && entities.map(entity => {
             if (showLink) {
                 return <>
                     <li><SpecialEntityLink key={entity.zdbID} entity={entity} displayName={entity.name}/></li>


### PR DESCRIPTION
Fixed by checking for undefined or null before map.
However, I noticed that the PublicationDiseaseTable react component (https://github.com/zfin/zfin/blob/main/home/javascript/react/containers/PublicationDiseaseTable.js#L25-L25)
 is expecting an "evidenceCodeList" that is undefined. Should we be providing that list from the backend?

Here's the backend URL:
https://zfin.org/action/api/publication/ZDB-PUB-181215-18/diseases

