### PR TITLE
ZFIN-8499: Refactorings of UniProt and RefSeq Matching

### DIFF
--- a/server_apps/data_transfer/SWISS-PROT/loadsp.pl
+++ b/server_apps/data_transfer/SWISS-PROT/loadsp.pl
@@ -237,13 +237,13 @@ runCmdOrFail("psql -v ON_ERROR_STOP=1 -d $ENV{'DB_NAME'} -a -f sp_addbackattr.sq
       "Failed to execute sp_addbackattr.sql");
 
 #--------------- Capture some history from last SWISS-PROT loading-----
-print "\n Capturing data from last SWISS-PROT loading.\n";
+print "\n Capturing data from last SWISS-PROT loading at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n";
 
 runCmdOrFail("psql -v ON_ERROR_STOP=1 -d $ENV{'DB_NAME'} -a -f sp_capture.sql >capturereport.txt",
     "Failed to execute sp_capture.sql");
 
 #--------------- Delete records from last SWISS-PROT loading-----
-print "\n delete records source from last SWISS-PROT loading.\n";
+print "\n delete records source from last SWISS-PROT loading at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n";
 
 runCmdOrFail("psql -v ON_ERROR_STOP=1 -d $ENV{'DB_NAME'} -a -f sp_delete.sql >deletereport.txt",
     "Failed to execute sp_delete.sql");
@@ -251,11 +251,12 @@ runCmdOrFail("psql -v ON_ERROR_STOP=1 -d $ENV{'DB_NAME'} -a -f sp_delete.sql >de
 # good records for loading
 # concatenate okfile ok2file
 
-system("cat ok2file >> okfile");
+# system("cat ok2file >> okfile");
+print "Skipping ok2file, uncomment to re-use ok2file\n";
 
 
 # ----------- Parse the SWISS-PROT file ----------------
-print "\n sp_parser.pl okfile \n";
+print "\n sp_parser.pl okfile  at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n";
 system ("$ENV{'ROOT_PATH'}/server_apps/data_transfer/SWISS-PROT/sp_parser.pl okfile");
 
 $count = 0;
@@ -287,7 +288,7 @@ while( !( -e "dr_dblink.unl" &&
 system("ls *.unl");
 
 # ------------ Parse spkw2go ---------------
-print "\nsptogo.pl spkw2go\n";
+print "\nsptogo.pl spkw2go  at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n";
 system ("$ENV{'ROOT_PATH'}/server_apps/data_transfer/SWISS-PROT/sptogo.pl spkw2go");
 $count = 0;
 $retry = 1;
@@ -313,7 +314,7 @@ while( !( -e "sp_mrkrgoterm.unl")) {
 }
 
 # ------------ Parse interpro2go ---------------
-print "\niptogo.pl interpro2go\n";
+print "\niptogo.pl interpro2go  at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n";
 system ("$ENV{'ROOT_PATH'}/server_apps/data_transfer/SWISS-PROT/iptogo.pl interpro2go");
 $count = 0;
 $retry = 1;
@@ -341,7 +342,7 @@ while( !( -e "ip_mrkrgoterm.unl")) {
 
 # ------------ Parse ec2go ---------------
 
-print "\nectogo.pl ec2go\n";
+print "\nectogo.pl ec2go at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n";
 system ("$ENV{'ROOT_PATH'}/server_apps/data_transfer/SWISS-PROT/ectogo.pl ec2go");
 $count = 0;
 $retry = 1;
@@ -368,7 +369,7 @@ while( !( -e "ec_mrkrgoterm.unl")) {
 
 
 # ------------ Loading ---------------------
-print "\nloading... at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n";
+print "\nloading (sp_load.sql) at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n";
 runCmdOrFail("psql -v ON_ERROR_STOP=1 -d $ENV{'DB_NAME'} -a -f sp_load.sql > report.txt",
     "Failed to execute sp_load.sql");
 

--- a/server_apps/data_transfer/SWISS-PROT/okfile_gp_misses.pl
+++ b/server_apps/data_transfer/SWISS-PROT/okfile_gp_misses.pl
@@ -1,0 +1,57 @@
+#!/opt/zfin/bin/perl 
+
+# quick check to what kinds of matches were made in okfile
+# run like: perl okfile_gp_misses.pl | sort | uniq -c
+# expect output like:
+#        59 A:GB match
+#       487 A:GP match
+#       452 B:ELSE
+#     11962 B:GP match
+#     20869 B:REFSEQ match
+#     10221 B:ZFIN_MATCH
+
+use strict;
+use warnings;
+use DBI;
+use POSIX;
+
+sub main {
+    $/ = "\/\/\n"; #custom record separator
+    open INPUT, "okfile" or die "Cannot open okfile";
+    foreach my $record (<INPUT>) {
+
+        if ($record =~ /GP_NO_MATCH/) {
+            if ($record =~ /GB match/) {
+                print "A:GB match";
+            } elsif ($record =~ /GP match/) {
+                print "A:GP match";
+            } elsif ($record =~ /REFSEQ match/) {
+                print "A:REFSEQ match";
+            } elsif ($record =~ /REFSEQ_NO_MATCH/) {
+                print "A:REFSEQ_NO_MATCH";
+            } elsif ($record =~ /DR   ZFIN/) {
+                print "A:ZFIN_MATCH";
+            } else {
+                print "A:ELSE";
+            }
+        } else {
+            if ($record =~ /GB match/) {
+                #Should never match this
+                print "B:GB match";
+            } elsif ($record =~ /GP match/) {
+                print "B:GP match";
+            } elsif ($record =~ /REFSEQ match/) {
+                print "B:REFSEQ match";
+            } elsif ($record =~ /REFSEQ_NO_MATCH/) {
+                print "B:REFSEQ_NO_MATCH";
+            } elsif ($record =~ /DR   ZFIN/) {
+                print "B:ZFIN_MATCH";
+            } else {
+                print "B:ELSE";
+            }
+        }
+        print "\n";
+    }
+}
+
+main();

--- a/server_apps/data_transfer/SWISS-PROT/pre_loadsp.pl
+++ b/server_apps/data_transfer/SWISS-PROT/pre_loadsp.pl
@@ -1,5 +1,7 @@
 #!/opt/zfin/bin/perl
 use strict ;
+use warnings;
+
 
 #
 # pre_loadsp.pl
@@ -10,13 +12,16 @@ use strict ;
 # Use environment variable "SKIP_SLEEP" to tell script not to sleep for 500 seconds at various parts
 # Use environment variable "SKIP_PRE_ZFIN_GEN" to tell script not to generate pre_zfin.dat
 # Use environment variable "ARCHIVE_ARTIFACTS" to tell script to save a copy of all generated artifacts
+# Use environment variable "CACHE_DOWNLOADS" to tell script to save downloaded files, otherwise the large uniprot files will be streamed to save disk space
+#
 # Flags are useful for being a good citizen and not putting too much strain on servers.
 #
 # Can run with those env vars in tcsh like so: (https://stackoverflow.com/questions/5946736/)
 #    env SKIP_DOWNLOADS=1 env SKIP_MANUAL_CHECK=1 ./runUniprotPreload.sh
 # or
 #     ( setenv SKIP_DOWNLOADS 1 ; setenv SKIP_MANUAL_CHECK 1; setenv SKIP_CLEANUP 1 ; setenv SKIP_SLEEP 1 ;  setenv SKIP_PRE_ZFIN_GEN 1 ; ./runUniprotPreload.sh )
-#
+# or bash:
+# SKIP_DOWNLOADS=1 SKIP_MANUAL_CHECK=1 SKIP_CLEANUP=1 SKIP_SLEEP=1 SKIP_PRE_ZFIN_GEN=1 ARCHIVE_ARTIFACTS=1 ./runUniprotPreload.sh
 
 use MIME::Lite;
 use LWP::Simple;
@@ -34,124 +39,245 @@ assertEnvironment('ROOT_PATH', 'PGHOST', 'DB_NAME', 'SWISSPROT_EMAIL_ERR', 'SWIS
 #------------------- Flush Output Buffer --------------
 $|=1;
 
-#------------------- Download -----------
+### Globals
 
-sub downloadOrUseLocalFile {
-        my ($url, $outfile) = @_;
-        if ($ENV{"SKIP_DOWNLOADS"}) {
-            print("Skipping download '$url' to '$outfile'\n");
-            my $outfileWithoutGz = $outfile  =~ s/\.gz$//r;
-            if (!-e $outfile && !-e $outfileWithoutGz) {
-                print "*************************************************\n";
-                print "* ERROR: The $outfile file does not exist, but we are running with SKIP_DOWNLOADS flag\n";
-                print "*************************************************\n";
-                exit -1;
-            } elsif (!-e $outfile && -e $outfileWithoutGz) {
-                print "$outfile file missing, continuing with $outfileWithoutGz\n";
+my $dbname;
+my $dbhost;
+my $username;
+my $password;
+my $dbh;
+
+my $ctManuallyEnteredUniProtIDs = 0;
+my @manuallyEnteredUniProtIDs = ();
+my $totalOnZfinDat = 0;
+my $totalOnDeleted = 0;
+
+#=======================================================
+#
+#   Main
+#
+#   Note from 3/16/23:
+#    Changed the structure for readability so that one can start reading at the main function
+#    similar to pattern described here: https://stackoverflow.com/questions/6763987
+#
+#=======================================================
+sub main {
+
+    chdir $ENV{'ROOT_PATH'} . "/server_apps/data_transfer/SWISS-PROT/";
+
+    fileCleanup();
+
+    initializeDB();
+
+    generateReportOfManuallyCuratedUniProtIDsWithMultipleGenes("manuallyCuratedUniProtIDsWithMultipleGenes.txt");
+
+    generateReportOfManuallyCuratedUniProtIDs("manuallyCuratedUniProtIDs.txt");
+
+    checkForInvalidManuallyCuratedUniProtIDs("invalidManuallyCuratedUniProtIDs.txt");
+
+    &downloadGOtermFiles();
+
+    &selectZebrafish ;
+
+    processPreZfinDatFileAndGenerateZfinDatFileEtCetera();
+
+    $dbh->disconnect();
+
+    generateReportOfCounts();
+
+    exit;
+}
+
+
+sub fileCleanup {
+
+    #remove old files
+    if ($ENV{'SKIP_CLEANUP'}) {
+        print "Skipping file cleanup\n";
+    } else {
+        print "Cleaning up old files\n";
+        system("rm -f ./ccnote/*");
+        system("rmdir ./ccnote");
+        system("rm -f *.ontology");
+        system("rm -f *2go");
+        system("rm -f prob*");
+        system("rm -f okfile");
+        system("rm -f pubmed_not_in_zfin");
+        system("rm -f *.unl");
+        system("rm -f *.txt");
+        system("rm -f *.dat.gz");
+        system("mkdir ./ccnote");
+    }
+
+}
+
+sub initializeDB {
+    $dbname = $ENV{'DB_NAME'};
+    $dbhost = $ENV{'PGHOST'};
+    $username = "";
+    $password = "";
+
+    ### open a handle on the db
+    $dbh = DBI->connect("DBI:Pg:dbname=$dbname;host=$dbhost", $username, $password)
+        or die "Cannot connect to PostgreSQL database: $DBI::errstr\n";
+}
+
+########################################################################################################
+#
+#  Validate manually-added UniProt IDs attributed to the new publication, ZDB-PUB-170131-9
+#  Here we check for IDs that were manually curated (eg. attrib'd to ZDB-PUB-170131-9)
+#  with the additional check that the IDs are also associated with multiple genes.
+#  (Historical note: for FB case 15015)
+#
+#  Accepts as first argument the name of the file to write the report to (manuallyCuratedUniProtIDsWithMultipleGenes.txt).
+#
+########################################################################################################
+sub generateReportOfManuallyCuratedUniProtIDsWithMultipleGenes {
+    my $reportFilename = $_[0];
+
+    my $sqlGetManuallyEnteredUniProtIDsWithMultGenes = "select distinct db1.dblink_acc_num from db_link db1
+                                                     where exists(select 'x' from record_attribution
+                                                                   where db1.dblink_zdb_id = recattrib_data_zdb_id
+                                                                     and recattrib_source_zdb_id = 'ZDB-PUB-170131-9')
+                                                       and exists(select 'x' from db_link db2
+                                                                   where db2.dblink_acc_num = db1.dblink_acc_num
+                                                                     and db2.dblink_linked_recid != db1.dblink_linked_recid);";
+
+    my $curGetManuallyEnteredUniProtIDsWithMultGenes = $dbh->prepare_cached($sqlGetManuallyEnteredUniProtIDsWithMultGenes);
+    $curGetManuallyEnteredUniProtIDsWithMultGenes->execute();
+    my $manuallyEnteredUniProtIDWithMultGenes;
+    $curGetManuallyEnteredUniProtIDsWithMultGenes->bind_columns(\$manuallyEnteredUniProtIDWithMultGenes);
+    open MULTIPLE, ">$reportFilename" || die("Cannot open $reportFilename !");
+    my $ctManuallyEnteredUniProtIDsWithMultGenes = 0;
+    while ($curGetManuallyEnteredUniProtIDsWithMultGenes->fetch()) {
+        print MULTIPLE "$manuallyEnteredUniProtIDWithMultGenes\n";
+        $ctManuallyEnteredUniProtIDsWithMultGenes++;
+    }
+    $curGetManuallyEnteredUniProtIDsWithMultGenes->finish();
+
+    close(MULTIPLE);
+
+    print "\nNumber of manually curated UniProt IDs with multiple genes: $ctManuallyEnteredUniProtIDsWithMultGenes at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n\n";
+
+    if ($ctManuallyEnteredUniProtIDsWithMultGenes > 0) {
+        my $subject = "Auto from SWISS-PROT: manually curated UniProt IDs with multiple genes";
+        ZFINPerlModules->sendMailWithAttachedReport($ENV{'SWISSPROT_EMAIL_REPORT'}, "$subject", $reportFilename);
+        #  system("cp $reportFilename log/");
+    }
+}
+
+########################################################################################################
+#
+#  Validate manually-added UniProt IDs attributed to the new publication, ZDB-PUB-170131-9
+#
+#  Accepts as first argument the name of the file to write the report to (manuallyCuratedUniProtIDs.txt).
+#
+########################################################################################################
+sub generateReportOfManuallyCuratedUniProtIDs {
+    my $reportFilename = $_[0];
+
+    my $sqlGetManuallyEnteredUniProtIDs = "select dblink_acc_num from db_link
+                                        where exists(select 'x' from record_attribution
+                                                      where dblink_zdb_id = recattrib_data_zdb_id
+                                                        and recattrib_source_zdb_id = 'ZDB-PUB-170131-9');";
+
+    my $curGetManuallyEnteredUniProtIDs = $dbh->prepare_cached($sqlGetManuallyEnteredUniProtIDs);
+    $curGetManuallyEnteredUniProtIDs->execute();
+    my $manuallyEnteredUniProtID;
+    $curGetManuallyEnteredUniProtIDs->bind_columns(\$manuallyEnteredUniProtID);
+
+    open MCIDS, ">$reportFilename" || die("Cannot open $reportFilename !");
+    while ($curGetManuallyEnteredUniProtIDs->fetch()) {
+        $manuallyEnteredUniProtIDs[$ctManuallyEnteredUniProtIDs] = $manuallyEnteredUniProtID;
+        print MCIDS "$manuallyEnteredUniProtID\n";
+        $ctManuallyEnteredUniProtIDs++;
+    }
+    $curGetManuallyEnteredUniProtIDs->finish();
+    close(MCIDS);
+
+    print "\nNumber of manually curated UniProt IDs: $ctManuallyEnteredUniProtIDs at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n\n";
+
+}
+
+########################################################################################################
+#
+#  Check for invalid manually curated UniProt IDs
+#  This iterates over every manually curated UniProt ID and checks to see if it is valid by making a
+#  web request to https://rest.uniprot.org/uniprotkb/{$ID} and checking for a 404.
+#
+#  Accepts as first argument the name of the file to write the report to (invalidManuallyCuratedUniProtIDs.txt).
+#
+########################################################################################################
+sub checkForInvalidManuallyCuratedUniProtIDs {
+    my $uniprotId;
+    my $url;
+    my $uniProtURL = "https://rest.uniprot.org/uniprotkb/";
+    my $reportFilename = $_[0];
+
+    if ($ENV{"SKIP_MANUAL_CHECK"}) {
+        print("Skipping check for invalid manually entered uniprot IDs\n");
+    }
+    else {
+        open INVALID, ">$reportFilename" || die("Cannot open $reportFilename !");
+        my $numInvalidUniProtIDs = 0;
+
+        if ($ctManuallyEnteredUniProtIDs > 0) {
+            print "Checking for invalid manually entered uniprot IDs at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n";
+            foreach $uniprotId (@manuallyEnteredUniProtIDs) {
+                ZFINPerlModules->printWhirleyToStderr();
+                $url = $uniProtURL . $uniprotId;
+                my $status_code = getstore($url, "/dev/null");
+                if ($status_code != 200) {
+                    print INVALID "$uniprotId\n";
+                    $numInvalidUniProtIDs++;
+                }
+                undef $status_code;
             }
-        } else {
-            print("Downloading '$url' to '$outfile'\n");
-
-            #set the number of bytes that a dot represents in wget progress bar to 10M
-            system("/local/bin/wget --progress=dot -e dotbytes=10M '$url' -O '$outfile'");
+            print("\n");
         }
+
+        close(INVALID);
+
+        print "\nNumber of Invalid Manually curated UniProt IDs: $numInvalidUniProtIDs\n\n";
+
+        if ($numInvalidUniProtIDs > 0) {
+            my $subject = "Auto from SWISS-PROT: invalid manually curated UniProt IDs";
+            ZFINPerlModules->sendMailWithAttachedReport($ENV{'SWISSPROT_EMAIL_REPORT'}, "$subject", "$reportFilename");
+            #      system("cp $reportFilename log");
+        }
+    }
 }
 
 sub downloadGOtermFiles () {
-   downloadOrUseLocalFile("http://www.geneontology.org/external2go/uniprotkb_kw2go", "spkw2go");
-   downloadOrUseLocalFile("http://www.geneontology.org/external2go/interpro2go", "interpro2go");
-   downloadOrUseLocalFile("http://www.geneontology.org/external2go/ec2go", "ec2go");
+   downloadOrUseLocalFile("https://current.geneontology.org/ontology/external2go/uniprotkb_kw2go", "spkw2go");
+   downloadOrUseLocalFile("https://current.geneontology.org/ontology/external2go/interpro2go", "interpro2go");
+   downloadOrUseLocalFile("https://current.geneontology.org/ontology/external2go/ec2go", "ec2go");
 
    if (!-e "spkw2go" || !-e "interpro2go" || !-e "ec2go") {
-      print "One or more of the go translation files not exisiting. Exit.\n";
+      print "One or more of the go translation files not existing. Exit.\n";
       exit -1;
    } else {
       print "\nDone with downloading the go translation files.\n\n\n";
    }
 
-   &select_zebrafish ;
-
-   if (!-e "pre_zfin.dat") {
-      print "\nSomething is wrong with pre_zfin.dat. Exit.\n\n";
-      exit -1;
-   } else {
-      print "\nDone with generating pre_zfin.dat at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n\n";
-   }
-
-    if ($ENV{'SKIP_SLEEP'}) {
-        print "Skipping sleep clause 1\n";
-    } else {
-        print "\nSleeping for 8 minutes at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n\n";
-       my $sleepNumDownload1 = 500;
-       while($sleepNumDownload1--){
-          sleep(1);
-       }
-   }
-
-   system("touch pre_zfin.dat");
-
-    if ($ENV{'SKIP_SLEEP'}) {
-        print "Skipping sleep clause 2 (what is the purpose of these sleeps?)\n";
-    } else {
-        print "\nSleeping for another 8 minutes at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n\n";
-       my $sleepNumDownload2 = 500;
-       while($sleepNumDownload2--){
-          sleep(1);
-       }
-   }
-
    system("touch *2go");
+   print "Finished downloading GO term files at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n";
 
  }
-
-# ----------------- Send Error Report -------------
-# Parameter
-#   $    Error message
-
-sub sendErrorReport ($) {
-    my $subject = "Auto from SWISS-PROT:".$_[0];
-    ZFINPerlModules->sendMailWithAttachedReport($ENV{'SWISSPROT_EMAIL_ERR'},"$subject","report.txt");
-#    system("cp report.txt log");
-}
-
-#------------------ Send Running Result ----------------
-# No parameter
-#
-sub sendRunningResult {
-  my $dbname = $_[0];
-  #----- One mail send out the checking report----
-  my $subject = "Auto from $dbname: SWISS-PROT check report";
-  ZFINPerlModules->sendMailWithAttachedReport($ENV{'SWISSPROT_EMAIL_REPORT'},"$subject","checkreport.txt");
-#  system("cp checkreport.txt log");
-
-  #----- Another mail send out problem files ----
-  $subject = "Auto from $dbname: SWISS-PROT problem file";
-  ZFINPerlModules->sendMailWithAttachedReport($ENV{'SWISSPROT_EMAIL_REPORT'},"$subject","allproblems.txt");
-#  system("cp allproblems.txt log");
-
-  #----- Another mail send out problem files ----
-  $subject = "Auto from $dbname: PubMed not in ZFIN";
-  ZFINPerlModules->sendMailWithAttachedReport($ENV{'SWISSPROT_EMAIL_REPORT'},"$subject","pubmed_not_in_zfin");
-#  system("cp pubmed_not_in_zfin log");
-
-  #----- Another mail send out problem files ----
-  $subject = "Auto from $dbname: report of processing pre_zfin.org";
-  ZFINPerlModules->sendMailWithAttachedReport($ENV{'SWISSPROT_EMAIL_REPORT'},"$subject","redGeneReport.txt");
-#  system("cp redGeneReport.txt log");
-}
-
 
 # ====================================
 #
 # Extracts only zfin data from vertebrates.
 #
-sub select_zebrafish {
+sub selectZebrafish {
     my $cwd = `pwd`;
     chomp $cwd;
 
     #where to find the uniprot files (can override with env var, for example with a file:/// URL)
     my $TREMBL_FILE_URL = "https://ftp.expasy.org/databases/uniprot/current_release/knowledgebase/taxonomic_divisions/uniprot_trembl_vertebrates.dat.gz";
-    if ($ENV{'TREMBL_FILE_URL'}) {
+    if ($ENV{'SKIP_PRE_ZFIN_GEN'}) {
+        print "Skipping trembl file download due to flag: SKIP_PRE_ZFIN_GEN\n";
+    } elsif ($ENV{'TREMBL_FILE_URL'}) {
         $TREMBL_FILE_URL = $ENV{'TREMBL_FILE_URL'};
     } elsif ($ENV{'SKIP_DOWNLOADS'}) {
         assertFileExists('./uniprot_trembl_vertebrates.dat.gz', 'Missing uniprot tremble file and SKIP_DOWNLOADS set to 1');
@@ -159,7 +285,9 @@ sub select_zebrafish {
     }
 
     my $SPROT_FILE_URL = "https://ftp.expasy.org/databases/uniprot/current_release/knowledgebase/taxonomic_divisions/uniprot_sprot_vertebrates.dat.gz";
-    if ($ENV{'SPROT_FILE_URL'}) {
+    if ($ENV{'SKIP_PRE_ZFIN_GEN'}) {
+        print "Skipping sprot file download due to flag: SKIP_PRE_ZFIN_GEN\n";
+    } elsif ($ENV{'SPROT_FILE_URL'}) {
         $SPROT_FILE_URL = $ENV{'SPROT_FILE_URL'};
     } elsif ($ENV{'SKIP_DOWNLOADS'}) {
         assertFileExists('./uniprot_sprot_vertebrates.dat.gz', 'Missing uniprot tremble file and SKIP_DOWNLOADS set to 1');
@@ -182,8 +310,8 @@ sub select_zebrafish {
         }
         open(DAT1, "curl -s '$TREMBL_FILE_URL' $cache_tee | gunzip -c |") || die("Could not open uniprot_trembl_vertebrates.dat.gz $!");
         while ($record = <DAT1>){
-           ZFINPerlModules->printWhirleyToStderr();
-           print OUTPUT "$record" if $record =~ m/OS   Danio rerio/;
+            ZFINPerlModules->printWhirleyToStderr();
+            print OUTPUT "$record" if $record =~ m/OS   Danio rerio/;
         }
         close(DAT1) ;
         print("Done processing uniprot_trembl_vertebrates.dat.gz at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n");
@@ -198,8 +326,8 @@ sub select_zebrafish {
         }
         open(DAT2, "curl -s '$SPROT_FILE_URL' $cache_tee | gunzip -c |") || die("Could not open uniprot_sprot_vertebrates.dat.gz $!");
         while ($record = <DAT2>){
-           ZFINPerlModules->printWhirleyToStderr();
-           print OUTPUT "$record" if $record =~ m/OS   Danio rerio/;
+            ZFINPerlModules->printWhirleyToStderr();
+            print OUTPUT "$record" if $record =~ m/OS   Danio rerio/;
         }
         close(DAT2) ;
         print("Done processing uniprot_sprot_vertebrates.dat.gz at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n");
@@ -209,8 +337,275 @@ sub select_zebrafish {
         close(OUTPUT) ;
     }
 
+    if (!-e "pre_zfin.dat") {
+        print "\nSomething is wrong with pre_zfin.dat. Exit.\n\n";
+        exit -1;
+    } else {
+        print "\nDone with generating pre_zfin.dat at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n\n";
+    }
+
+    if ($ENV{'SKIP_SLEEP'}) {
+        print "Skipping sleep clause 1\n";
+    } else {
+        print "\nSleeping for 8 minutes at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n\n";
+        my $sleepNumDownload1 = 500;
+        while($sleepNumDownload1--){
+            sleep(1);
+        }
+    }
+
+    system("touch pre_zfin.dat");
+
+    if ($ENV{'SKIP_SLEEP'}) {
+        print "Skipping sleep clause 2 (what is the purpose of these sleeps?)\n";
+    } else {
+        print "\nSleeping for another 8 minutes at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n\n";
+        my $sleepNumDownload2 = 500;
+        while($sleepNumDownload2--){
+            sleep(1);
+        }
+    }
 }
 
+sub processPreZfinDatFileAndGenerateZfinDatFileEtCetera {
+    ########################################################################################################
+    #
+    #  for FB case 8042 UniProt load: DR lines redundancy in the input file
+    #
+    ########################################################################################################
+
+    print "Reading pre_zfin.dat and generating zfin.dat, zfinGeneDeleted.dat, zfinGenes.dat, debugfile.dat  " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n";
+
+    my $cur;
+
+    $/ = "//\n";
+    open(PREDAT, "pre_zfin.dat") || die("Could not open pre_zfin.dat !");
+    my @blocks = <PREDAT>;
+    close(PREDAT);
+    print STDERR "Processing pre_zfin.dat\n";
+
+    open ZFINDAT, ">zfin.dat" || die("Cannot open zfin.dat !");
+    open ZFINDATDELETED, ">zfinGeneDeleted.dat" || die("Cannot open zfinGeneDeleted.dat !");
+    open ZFINGENES, ">zfinGenes.dat" || die("Cannot open zfinGenes.dat !");
+    open DBG, ">debugfile.dat" || die("Cannot open debugfile.dat !");
+
+
+    my $ttt = 0;
+    my @lines = ();
+    my %toNewInput = ();
+    my %deletes = ();
+    my $ct = 0;
+    my %ZDBgeneIDgeneAbbrevs = ();
+    my $line;
+    my $lineKey = 0;
+    my @fields = ();
+    my $ZFINgeneId;
+    my $geneAbbrev;
+    my $block;
+    my $newLineNumber;
+    my $key;
+    foreach $block (@blocks) {
+        $ttt++;
+        if ($block !~ m/OS   Danio rerio/) {
+            print "ERROR: Found non-zebrafish record! Ignoring.\n";
+            next;
+        }
+        @lines = split(/\n/, $block);
+        %toNewInput = ();
+        %deletes = ();
+        $ct = 0;
+        %ZDBgeneIDgeneAbbrevs = ();
+        foreach $line (@lines) {
+            if ($line =~ m/CC   (-------)|(Copyrighted)|(Distributed)/) {
+                #Skip copyright lines
+                next;
+            } elsif ($line =~ m/DR   ZFIN; ZDB-GENE-.*; SO:0001217./) {
+                #Skip lines that are erroneously associated with SO:0001217 as a gene abbreviation (ZFIN-8499)
+                next;
+            }
+
+            ## add 10000 to pad so that the sorting would be right
+            $lineKey = 10000 + $ct;
+            $toNewInput{$lineKey} = $line;
+            $deletes{$lineKey} = 0;
+
+            if ($line !~ m/DR   ZFIN; ZDB-GENE-/) {
+                #Skip lines that are not DR ZFIN lines
+                next;
+            }
+
+            @fields = split(/;/, $line);
+            $ZFINgeneId = trim($fields[1]);
+            $geneAbbrev = trim($fields[2]);
+            $geneAbbrev =~ s/\.$//;
+
+            ### Some Debug Statements For First 1000 Records ###
+            if ($ttt < 1000) {
+                print DBG "ZFINgeneId : $ZFINgeneId \t geneAbbrev : $geneAbbrev  \n";
+                if (exists($ZDBgeneIDgeneAbbrevs{$ZFINgeneId})) {
+                    print DBG "exists  $ZDBgeneIDgeneAbbrevs{$ZFINgeneId} \n";
+                }
+                else {
+                    print DBG "Not exists  \$ZDBgeneIDgeneAbbrevs{$ZFINgeneId} \n";
+                }
+            }
+
+            if (!exists($ZDBgeneIDgeneAbbrevs{$ZFINgeneId})) {
+                $cur = $dbh->prepare('select mrkr_abbrev from marker where mrkr_zdb_id = ?;');
+
+                $cur->execute($ZFINgeneId);
+                my ($ZFINgeneAbbrev);
+                $cur->bind_columns(\$ZFINgeneAbbrev);
+                while ($cur->fetch()) {
+                    $ZDBgeneIDgeneAbbrevs{$ZFINgeneId} = $ZFINgeneAbbrev;
+                }
+                $cur->finish();
+
+                if (!defined($ZFINgeneAbbrev)) {
+                    my ($mergedGeneId, $mergedGeneAbbrev) = getMergedGeneIdIfExists($dbh, $ZFINgeneId);
+                    if ($mergedGeneId) {
+                        print DBG "Merged '$ZFINgeneId' ($geneAbbrev) to '$mergedGeneId' ($mergedGeneAbbrev) \n";
+                        print DBG "   Old Line: $line\n";
+                        $line =~ s/$geneAbbrev/$mergedGeneAbbrev/g;
+                        $line =~ s/$ZFINgeneId/$mergedGeneId/g;
+                        print DBG "   New Line: $line\n";
+                        $ZFINgeneAbbrev = $geneAbbrev;
+
+                        if (exists($ZDBgeneIDgeneAbbrevs{$mergedGeneId})) {
+                            $deletes{$lineKey} = 1;
+                            next;
+                        }
+                    }
+                    else {
+                        print DBG "ERROR: Search for gene abbreviation failed for zdb id '$ZFINgeneId'";
+                        die("ERROR: Search for gene abbreviation failed for zdb id '$ZFINgeneId'");
+                    }
+                }
+
+                if ($geneAbbrev ne $ZFINgeneAbbrev) {
+                    my $ZFINgeneAbbrevDebug = defined($ZFINgeneAbbrev) ? $ZFINgeneAbbrev : "UNDEFINED";
+                    print DBG "Gene Abbreviation '$geneAbbrev' is not the same as ZFIN Gene Abbreviation ($ZFINgeneAbbrevDebug)! Updating. \n";
+                    $line =~ s/$geneAbbrev/$ZFINgeneAbbrev/g;
+                }
+                $toNewInput{$lineKey} = $line;
+            }
+            else {
+                # Is this ever true? It seems we would only ever get here if one record had multiple lines
+                # with the same "DR   ZFIN; ZDB-GENE-..." information
+                print DBG "Possible ERROR? Multiple lines in the same record with the same gene info: ";
+                print DBG "geneAbbrev $geneAbbrev; ZDB $ZFINgeneId; recordNum $ttt \n";
+                $deletes{$lineKey} = 1;
+            }
+            ZFINPerlModules->printWhirleyToStderr();
+        }
+        continue {
+            $ct++;
+        }
+
+        foreach $newLineNumber (sort keys %toNewInput) {
+            if ($deletes{$newLineNumber} == 0) {
+                print ZFINDAT "$toNewInput{$newLineNumber}\n";
+                $totalOnZfinDat = $totalOnZfinDat + 1;
+            }
+            else {
+                print ZFINDATDELETED "$toNewInput{$newLineNumber}\n";
+                $totalOnDeleted++;
+            }
+        }
+
+        foreach $key (sort keys %ZDBgeneIDgeneAbbrevs) {
+            print ZFINGENES "$ZDBgeneIDgeneAbbrevs{$key}\n";
+        }
+
+    }
+
+    close(ZFINDAT);
+    close(ZFINDATDELETED);
+    close(ZFINGENES);
+    close(DBG);
+
+    print "Finished generating output .dat files at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n";
+}
+
+sub generateReportOfCounts {
+    open(PRE, "pre_zfin.dat") || die("Could not open pre_zfin.dat !");
+    my @blocksPRE1 = <PRE>;
+    close(PRE);
+    my $prezfin = 0;
+    my $totalprezfin = 0;
+
+    foreach my $block (@blocksPRE1) {
+        $totalprezfin++;
+        if ($block =~ m/OS   Danio rerio/) {
+            $prezfin++;
+        }
+    }
+
+    open(ZF, "zfin.dat") || die("Could not open zfin.dat !");
+    my @blocksZF1 = <ZF>;
+    close(ZF);
+    my $zfin = 0;
+    my $totalzfin = 0;
+    foreach my $block (@blocksZF1) {
+        $totalzfin++;
+        if ($block =~ m/OS   Danio rerio/) {
+            $zfin++;
+        }
+    }
+
+    $/ = "\n";
+
+    open(PRE, "pre_zfin.dat") || die("Could not open pre_zfin.dat !");
+    my @blocksPRE2 = <PRE>;
+    close(PRE);
+    my $prezfinGene = 0;
+    my $prezfinLines = 0;
+    foreach my $block (@blocksPRE2) {
+        $prezfinLines++;
+        if ($block =~ m/DR   ZFIN; ZDB-GENE-/) {
+            $prezfinGene++;
+        }
+    }
+
+    open(ZF, "zfin.dat") || die("Could not open zfin.dat !");
+    my @blocksZF2 = <ZF>;
+    close(ZF);
+    my $zfinGene = 0;
+    my $zfinLines = 0;
+    foreach my $block (@blocksZF2) {
+        $zfinLines++;
+        if ($block =~ m/DR   ZFIN; ZDB-GENE-/) {
+            $zfinGene++;
+        }
+    }
+
+    print "totalOnZfinDat = $totalOnZfinDat\t totalOnDeleted = $totalOnDeleted\n\n\n";
+    print "prezfin = $prezfin\t";
+    print "totalprezfin = $totalprezfin\n";
+    print "zfin = $zfin\t";
+    print "totalzfin = $totalzfin\n";
+
+    print "\n\n\n";
+    print "prezfinGene = $prezfinGene\t";
+    print "prezfinLines = $prezfinLines\n";
+    print "zfinGene = $zfinGene\t";
+    print "zfinLines = $zfinLines\n";
+
+    open(REDGENERPT, ">redGeneReport.txt") || die("Could not open redGeneReport.txt !");
+    print REDGENERPT "totalOnZfinDat = $totalOnZfinDat\t totalOnDeleted = $totalOnDeleted\n\n\n";
+    print REDGENERPT "prezfin = $prezfin\t";
+    print REDGENERPT "totalprezfin = $totalprezfin\n";
+    print REDGENERPT "zfin = $zfin\t";
+    print REDGENERPT "totalzfin = $totalzfin\n";
+
+    print REDGENERPT "\n\n\n";
+    print REDGENERPT "prezfinGene = $prezfinGene\t";
+    print REDGENERPT "prezfinLines = $prezfinLines\n";
+    print REDGENERPT "zfinGene = $zfinGene\t";
+    print REDGENERPT "zfinLines = $zfinLines\n";
+
+    close REDGENERPT;
+}
 
 sub getMergedGeneIdIfExists {
     my $dbh = $_[0];
@@ -225,385 +620,35 @@ sub getMergedGeneIdIfExists {
     return ($mergedGeneId, $mergedGeneAbbrev);
 }
 
+#------------------- Download -----------
 
-#=======================================================
-#
-#   Main
-#
+sub downloadOrUseLocalFile {
+    my ($url, $outfile) = @_;
+    if ($ENV{"SKIP_DOWNLOADS"}) {
+        print("Skipping download '$url' to '$outfile'\n");
+        my $outfileWithoutGz = $outfile  =~ s/\.gz$//r;
+        if (!-e $outfile && !-e $outfileWithoutGz) {
+            print "*************************************************\n";
+            print "* ERROR: The $outfile file does not exist, but we are running with SKIP_DOWNLOADS flag\n";
+            print "*************************************************\n";
+            exit -1;
+        } elsif (!-e $outfile && -e $outfileWithoutGz) {
+            print "$outfile file missing, continuing with $outfileWithoutGz\n";
+        }
+    } else {
+        print("Downloading '$url' to '$outfile'\n");
 
-
-chdir $ENV{'ROOT_PATH'} . "/server_apps/data_transfer/SWISS-PROT/";
-
-
-#remove old files
-if ($ENV{'SKIP_CLEANUP'}) {
-    print "Skipping file cleanup\n";
-} else {
-    print "Cleaning up old files\n";
-    system("rm -f ./ccnote/*");
-    system("rmdir ./ccnote");
-    system("rm -f *.ontology");
-    system("rm -f *2go");
-    system("rm -f prob*");
-    system("rm -f okfile");
-    system("rm -f pubmed_not_in_zfin");
-    system("rm -f *.unl");
-    system("rm -f *.txt");
-    system("rm -f *.dat.gz");
-    system("mkdir ./ccnote");
-}
-
-my $dbname = $ENV{'DB_NAME'};
-my $dbhost = $ENV{'PGHOST'};
-my $username = "";
-my $password = "";
-
-########################################################################################################
-#
-#  for FB case 15015, Validate manually-added UniProt IDs attributed to the new publication, ZDB-PUB-170131-9
-#
-########################################################################################################
-
-### open a handle on the db
-my $dbh = DBI->connect ("DBI:Pg:dbname=$dbname;host=$dbhost", $username, $password)
-    or die "Cannot connect to PostgreSQL database: $DBI::errstr\n";
-
-my $sqlGetManuallyEnteredUniProtIDsWithMultGenes = "select distinct db1.dblink_acc_num from db_link db1
-                                                     where exists(select 'x' from record_attribution
-                                                                   where db1.dblink_zdb_id = recattrib_data_zdb_id
-                                                                     and recattrib_source_zdb_id = 'ZDB-PUB-170131-9')
-                                                       and exists(select 'x' from db_link db2
-                                                                   where db2.dblink_acc_num = db1.dblink_acc_num
-                                                                     and db2.dblink_linked_recid != db1.dblink_linked_recid);";
-
-my $curGetManuallyEnteredUniProtIDsWithMultGenes = $dbh->prepare_cached($sqlGetManuallyEnteredUniProtIDsWithMultGenes);
-$curGetManuallyEnteredUniProtIDsWithMultGenes->execute();
-my $manuallyEnteredUniProtIDWithMultGenes;
-$curGetManuallyEnteredUniProtIDsWithMultGenes->bind_columns(\$manuallyEnteredUniProtIDWithMultGenes);
-open MULTIPLE, ">manuallyCuratedUniProtIDsWithMultipleGenes.txt" || die ("Cannot open manuallyCuratedUniProtIDsWithMultipleGenes.txt !");
-my $ctManuallyEnteredUniProtIDsWithMultGenes = 0;
-while ($curGetManuallyEnteredUniProtIDsWithMultGenes->fetch()) {
-    print MULTIPLE "$manuallyEnteredUniProtIDWithMultGenes\n";
-    $ctManuallyEnteredUniProtIDsWithMultGenes++;
-}
-$curGetManuallyEnteredUniProtIDsWithMultGenes->finish();
-
-close(MULTIPLE);
-
-print "\nNumber of manually curated UniProt IDs with multiple genes: $ctManuallyEnteredUniProtIDsWithMultGenes at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n\n";
-
-if ($ctManuallyEnteredUniProtIDsWithMultGenes > 0) {
-  my $subject = "Auto from SWISS-PROT: manually curated UniProt IDs with multiple genes";
-  ZFINPerlModules->sendMailWithAttachedReport($ENV{'SWISSPROT_EMAIL_REPORT'},"$subject","manuallyCuratedUniProtIDsWithMultipleGenes.txt");
-#  system("cp manuallyCuratedUniProtIDsWithMultipleGenes.txt log/");
-}
-
-my $sqlGetManuallyEnteredUniProtIDs = "select dblink_acc_num from db_link
-                                        where exists(select 'x' from record_attribution
-                                                      where dblink_zdb_id = recattrib_data_zdb_id
-                                                        and recattrib_source_zdb_id = 'ZDB-PUB-170131-9');";
-
-my $curGetManuallyEnteredUniProtIDs = $dbh->prepare_cached($sqlGetManuallyEnteredUniProtIDs);
-$curGetManuallyEnteredUniProtIDs->execute();
-my $manuallyEnteredUniProtID;
-$curGetManuallyEnteredUniProtIDs->bind_columns(\$manuallyEnteredUniProtID);
-my @manuallyEnteredUniProtIDs = ();
-my $ctManuallyEnteredUniProtIDs = 0;
-open MCIDS, ">manuallyCuratedUniProtIDs.txt" || die ("Cannot open manuallyCuratedUniProtIDs.txt !");
-while ($curGetManuallyEnteredUniProtIDs->fetch()) {
-    $manuallyEnteredUniProtIDs[$ctManuallyEnteredUniProtIDs] = $manuallyEnteredUniProtID;
-    print MCIDS "$manuallyEnteredUniProtID\n";
-    $ctManuallyEnteredUniProtIDs++;
-}
-$curGetManuallyEnteredUniProtIDs->finish();
-close(MCIDS);
-
-print "\nNumber of manually curated UniProt IDs: $ctManuallyEnteredUniProtIDs at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n\n";
-
-my $uniprotId;
-my $url;
-my $uniProtURL = "https://rest.uniprot.org/uniprotkb/";
-
-if ($ENV{"SKIP_MANUAL_CHECK"}) {
-    print("Skipping check for invalid manually entered uniprot IDs\n");
-} else {
-    open INVALID, ">invalidManuallyCuratedUniProtIDs.txt" || die ("Cannot open invalidManuallyCuratedUniProtIDs.txt !");
-    my $numInvalidUniProtIDs = 0;
-
-
-    if ($ctManuallyEnteredUniProtIDs > 0) {
-      print "Checking for invalid manually entered uniprot IDs at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n";
-      foreach $uniprotId (@manuallyEnteredUniProtIDs) {
-          ZFINPerlModules->printWhirleyToStderr();
-         $url = $uniProtURL . $uniprotId;
-         my $status_code = getstore($url, "/dev/null");
-         if ($status_code != 200) {
-              print INVALID "$uniprotId\n";
-              $numInvalidUniProtIDs++;
-          }
-          undef $status_code;
-      }
-      print("\n");
-    }
-
-    close(INVALID);
-
-    print "\nNumber of Invalid Manually curated UniProt IDs: $numInvalidUniProtIDs\n\n";
-
-    if ($numInvalidUniProtIDs > 0) {
-      my $subject = "Auto from SWISS-PROT: invalid manually curated UniProt IDs";
-      ZFINPerlModules->sendMailWithAttachedReport($ENV{'SWISSPROT_EMAIL_REPORT'},"$subject","invalidManuallyCuratedUniProtIDs.txt");
-#      system("cp invalidManuallyCuratedUniProtIDs.txt log");
+        #set the number of bytes that a dot represents in wget progress bar to 10M
+        if (system("wget --progress=dot -e dotbytes=10M '$url' -O '$outfile'")) {
+            die("Failure downloading '$url' to '$outfile' with wget");
+        }
     }
 }
 
-&downloadGOtermFiles();
-
-print "Finished downloading GO term files at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n";
-
-########################################################################################################
-#
-#  for FB case 8042 UniProt load: DR lines redundancy in the input file
-#
-########################################################################################################
-
-print "Reading pre_zfin.dat and generating zfin.dat, zfinGeneDeleted.dat, zfinGenes.dat, debugfile.dat  " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n";
-
-my $cur;
-
-$/ = "//\n";
-open(PREDAT, "pre_zfin.dat") || die("Could not open pre_zfin.dat !");
-my @blocks = <PREDAT>;
-close(PREDAT);
-print STDERR "Processing pre_zfin.dat\n";
-
-open ZFINDAT, ">zfin.dat" || die ("Cannot open zfin.dat !");
-open ZFINDATDELETED, ">zfinGeneDeleted.dat" || die ("Cannot open zfinGeneDeleted.dat !");
-open ZFINGENES, ">zfinGenes.dat" || die ("Cannot open zfinGenes.dat !");
-open DBG, ">debugfile.dat" || die ("Cannot open debugfile.dat !");
-
-my $totalOnZfinDat = 0;
-my $totalOnDeleted = 0;
-my $ttt = 0;
-my @lines = ();
-my %toNewInput = ();
-my %deletes = ();
-my $ct = 0;
-my %ZDBgeneIDgeneAbbrevs = ();
-my $line;
-my $lineKey = 0;
-my @fields = ();
-my $ZFINgeneId;
-my $geneAbbrev;
-my $block;
-my $newLineNumber;
-my $key;
-foreach $block (@blocks) {
-   $ttt++;
-   if($block !~ m/OS   Danio rerio/) {
-       print "ERROR: Found non-zebrafish record! Ignoring.\n";
-       next;
-   }
-    @lines = split(/\n/, $block);
-    %toNewInput = ();
-    %deletes = ();
-    $ct = 0;
-    %ZDBgeneIDgeneAbbrevs = ();
-    foreach $line (@lines) {
-       if($line =~ m/CC   (-------)|(Copyrighted)|(Distributed)/ ) {
-           #Skip copyright lines
-           next;
-       }
-
-       ## add 10000 to pad so that the sorting would be right
-       $lineKey = 10000 + $ct;
-       $toNewInput{$lineKey} = $line;
-       $deletes{$lineKey} = 0;
-
-       if ($line !~ m/DR   ZFIN; ZDB-GENE-/) {
-           #Skip lines that are not DR ZFIN lines
-           next;
-       }
-
-       @fields = split(/;/, $line);
-       $ZFINgeneId = trim($fields[1]);
-       $geneAbbrev = trim($fields[2]);
-       $geneAbbrev =~ s/\.$//;
-
-       ### Some Debug Statements For First 1000 Records ###
-       if ($ttt < 1000) {
-           print DBG "ZFINgeneId : $ZFINgeneId \t geneAbbrev : $geneAbbrev  \n";
-           if (exists($ZDBgeneIDgeneAbbrevs{$ZFINgeneId})) {
-               print DBG "exists  $ZDBgeneIDgeneAbbrevs{$ZFINgeneId} \n";
-           } else {
-               print DBG "Not exists  \$ZDBgeneIDgeneAbbrevs{$ZFINgeneId} \n";
-           }
-       }
-
-       if (!exists($ZDBgeneIDgeneAbbrevs{$ZFINgeneId})) {
-           $cur = $dbh->prepare('select mrkr_abbrev from marker where mrkr_zdb_id = ?;');
-
-           $cur->execute($ZFINgeneId);
-           my ($ZFINgeneAbbrev);
-           $cur->bind_columns(\$ZFINgeneAbbrev);
-           while ($cur->fetch()) {
-               $ZDBgeneIDgeneAbbrevs{$ZFINgeneId} = $ZFINgeneAbbrev;
-           }
-           $cur->finish();
-
-           if (!defined($ZFINgeneAbbrev)) {
-               my ($mergedGeneId, $mergedGeneAbbrev) = getMergedGeneIdIfExists($dbh, $ZFINgeneId);
-               if ($mergedGeneId) {
-                   print DBG "Merged '$ZFINgeneId' ($geneAbbrev) to '$mergedGeneId' ($mergedGeneAbbrev) \n";
-                   print DBG "   Old Line: $line\n";
-                   $line =~ s/$geneAbbrev/$mergedGeneAbbrev/g;
-                   $line =~ s/$ZFINgeneId/$mergedGeneId/g;
-                   print DBG "   New Line: $line\n";
-                   $ZFINgeneAbbrev = $geneAbbrev;
-
-                   if (exists($ZDBgeneIDgeneAbbrevs{$mergedGeneId})) {
-                       $deletes{$lineKey} = 1;
-                       next;
-                   }
-               } else {
-                   print DBG "ERROR: Search for gene abbreviation failed for zdb id '$ZFINgeneId'";
-                   die("ERROR: Search for gene abbreviation failed for zdb id '$ZFINgeneId'");
-               }
-           }
-
-           if ($geneAbbrev ne $ZFINgeneAbbrev) {
-               my $ZFINgeneAbbrevDebug = defined($ZFINgeneAbbrev) ? $ZFINgeneAbbrev : "UNDEFINED";
-               print DBG "Gene Abbreviation '$geneAbbrev' is not the same as ZFIN Gene Abbreviation ($ZFINgeneAbbrevDebug)! Updating. \n";
-               $line =~ s/$geneAbbrev/$ZFINgeneAbbrev/g;
-           }
-           $toNewInput{$lineKey} = $line;
-       } else {
-           # Is this ever true? It seems we would only ever get here if one record had multiple lines
-           # with the same "DR   ZFIN; ZDB-GENE-..." information
-           print DBG "Possible ERROR? Multiple lines in the same record with the same gene info: ";
-           print DBG "geneAbbrev $geneAbbrev; ZDB $ZFINgeneId; recordNum $ttt \n";
-           $deletes{$lineKey} = 1;
-       }
-       ZFINPerlModules->printWhirleyToStderr();
-    } continue {
-        $ct++;
-    }
-
-    foreach $newLineNumber (sort keys %toNewInput) {
-       if ($deletes{$newLineNumber} == 0) {
-           print ZFINDAT "$toNewInput{$newLineNumber}\n";
-           $totalOnZfinDat = $totalOnZfinDat + 1;
-       } else {
-           print ZFINDATDELETED "$toNewInput{$newLineNumber}\n";
-           $totalOnDeleted++;
-       }
-    }
-
-    foreach $key (sort keys %ZDBgeneIDgeneAbbrevs) {
-           print ZFINGENES "$ZDBgeneIDgeneAbbrevs{$key}\n";
-    }
-
-}
-
-close(ZFINDAT);
-close(ZFINDATDELETED);
-close(ZFINGENES);
-close(DBG);
-
-$dbh->disconnect();
-print "Finished generating output .dat files at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n";
-
-
-open(PRE, "pre_zfin.dat") || die("Could not open pre_zfin.dat !");
-my @blocksPRE = <PRE>;
-close(PRE);
-my $prezfin = 0;
-my $totalprezfin = 0;
-
-foreach $block (@blocksPRE){
-   $totalprezfin++;
-   if($block =~ m/OS   Danio rerio/) {
-      $prezfin++;
-   }
-}
-
-open(ZF, "zfin.dat") || die("Could not open zfin.dat !");
-my @blocksZF = <ZF>;
-close(ZF);
-my $zfin = 0;
-my $totalzfin = 0;
-foreach $block (@blocksZF){
-   $totalzfin++;
-   if($block =~ m/OS   Danio rerio/) {
-      $zfin++;
-   }
-}
-
-$/ = "\n";
-
-open(PRE, "pre_zfin.dat") || die("Could not open pre_zfin.dat !");
-my @blocksPRE = <PRE>;
-close(PRE);
-my $prezfinGene = 0;
-my $prezfinLines = 0;
-foreach $block (@blocksPRE){
-   $prezfinLines++;
-   if($block =~ m/DR   ZFIN; ZDB-GENE-/) {
-      $prezfinGene++;
-   }
-}
-
-open(ZF, "zfin.dat") || die("Could not open zfin.dat !");
-my @blocksZF = <ZF>;
-close(ZF);
-my $zfinGene = 0;
-my $zfinLines = 0;
-foreach $block (@blocksZF){
-   $zfinLines++;
-   if($block =~ m/DR   ZFIN; ZDB-GENE-/) {
-      $zfinGene++;
-   }
-}
-
-print "totalOnZfinDat = $totalOnZfinDat\t totalOnDeleted = $totalOnDeleted\n\n\n";
-print "prezfin = $prezfin\t";
-print "totalprezfin = $totalprezfin\n";
-print "zfin = $zfin\t";
-print "totalzfin = $totalzfin\n";
-
-print "\n\n\n";
-print "prezfinGene = $prezfinGene\t";
-print "prezfinLines = $prezfinLines\n";
-print "zfinGene = $zfinGene\t";
-print "zfinLines = $zfinLines\n";
-
-open(REDGENERPT, ">redGeneReport.txt") || die("Could not open redGeneReport.txt !");
-print REDGENERPT "totalOnZfinDat = $totalOnZfinDat\t totalOnDeleted = $totalOnDeleted\n\n\n";
-print REDGENERPT "prezfin = $prezfin\t";
-print REDGENERPT "totalprezfin = $totalprezfin\n";
-print REDGENERPT "zfin = $zfin\t";
-print REDGENERPT "totalzfin = $totalzfin\n";
-
-print REDGENERPT "\n\n\n";
-print REDGENERPT "prezfinGene = $prezfinGene\t";
-print REDGENERPT "prezfinLines = $prezfinLines\n";
-print REDGENERPT "zfinGene = $zfinGene\t";
-print REDGENERPT "zfinLines = $zfinLines\n";
-
-close REDGENERPT;
-
-exit;
-
+main();
 # Comments on 11/22/2021 by Ryan T.
 #
-# Some small TODO items that aren't worth creating a ticket, but might be nice to clean up this file a bit:
-#
-# Emails going out from this seem to expect the files "report.txt", "checkreport.txt", "allproblems.txt",
-# "pubmed_not_in_zfin" to exist, but are not generated directly by this script. They are generated by later scripts,
-# but not sure why this script would email those artifacts.  Might be a bug?
-#
-# Structurally, it's a bit confusing. Might be nice to wrap some of the steps up into subroutines. And maybe adopt a
-# pattern like the one described here: https://stackoverflow.com/questions/6763987
+# Some remaining questions:
 #
 # Why do we sleep for 500 seconds in various places?
 # Why do we touch various files?

--- a/server_apps/data_transfer/SWISS-PROT/runUniprotPreload.sh
+++ b/server_apps/data_transfer/SWISS-PROT/runUniprotPreload.sh
@@ -20,23 +20,26 @@ set -eo pipefail
 
 main() {
 echo "#########################################################################"
-echo "run pre_loadsp.pl " $(date "+%Y-%m-%d %H:%M:%S")
 
+echo "run pre_loadsp.pl " $(date "+%Y-%m-%d %H:%M:%S")
 ./pre_loadsp.pl ;
 
-echo "run sp_check.pl " $(date "+%Y-%m-%d %H:%M:%S")
+echo "run validate_zfin_dat.pl " $(date "+%Y-%m-%d %H:%M:%S")
+./validate_zfin_dat.pl ;
 
+echo "run sp_check.pl " $(date "+%Y-%m-%d %H:%M:%S")
 ./sp_check.pl ;
 
-echo "/bin/cat prob1 prob2 prob3 prob4 prob5 prob6 prob7 prob8 > allproblems.txt " $(date "+%Y-%m-%d %H:%M:%S")
+echo "/bin/cat prob1 prob2 prob3 prob4 prob5 prob6 prob7 prob8 prob9 prob10 > allproblems.txt " $(date "+%Y-%m-%d %H:%M:%S")
 
-/bin/cat prob1 prob2 prob3 prob4 prob5 prob6 prob7 prob8 > allproblems.txt ;
+/bin/cat prob1 prob2 prob3 prob4 prob5 prob6 prob7 prob8 prob9 prob10 > allproblems.txt ;
 
 echo "run sp_match.pl manuallyCuratedUniProtIDs.txt " $(date "+%Y-%m-%d %H:%M:%S")
 
 ./sp_match.pl manuallyCuratedUniProtIDs.txt ;
 
 echo "copying generated preload files to network drive"
+echo /usr/bin/scp "$ROOT_PATH"/server_apps/data_transfer/SWISS-PROT/{okfile,ok2file,ec2go,interpro2go,spkw2go} /research/zarchive/load_files/UniProt/
 
 /usr/bin/scp "$ROOT_PATH"/server_apps/data_transfer/SWISS-PROT/{okfile,ok2file,ec2go,interpro2go,spkw2go} /research/zarchive/load_files/UniProt/
 

--- a/server_apps/data_transfer/SWISS-PROT/sp_check.pl
+++ b/server_apps/data_transfer/SWISS-PROT/sp_check.pl
@@ -1,5 +1,7 @@
 #!/opt/zfin/bin/perl 
 
+# $Id: sp_check.pl,v 1.001 2023/03/27 rtaylor $
+
 # sp_check.pl
 #
 # This script reads Swiss-Prot file(which consists of protein records),
@@ -14,6 +16,11 @@
 # are collected and divided into different problem files for biologists to 
 # look into.
 
+# TODO: If a record has an embl id, but doesn't match anything, we should try a refseq match.
+#       Currently we only try a refseq match if there is no embl id at all
+
+use strict;
+use warnings;
 use DBI;
 use POSIX;
 
@@ -22,10 +29,6 @@ use lib $ENV{'ROOT_PATH'} . "/server_apps/";
 use ZFINPerlModules qw(assertEnvironment md5File);
 assertEnvironment('PGHOST','ROOT_PATH', 'DB_NAME');
 
-# Take a SP file as input (content format restricted).
-
-# Create the output files and give them titles. 
-init_files();
 
 my $num_ok = 0;   # number of good records that are going to be loaded
 my $num_prob = 0; # number of problem records
@@ -39,238 +42,130 @@ my $password = "";
 my $dbh = DBI->connect("DBI:Pg:dbname=$dbname;host=$dbhost", $username, $password)
     or die "Cannot connect to PostgreSQL database: $DBI::errstr\n";
 
-# if PubMed number not in zfin, output to a single file
-open PUB, ">pubmed_not_in_zfin" or die "Cannot open the pubmed_not_in_zfin:$!";
-
-my $zfin_dat_hash = md5File('zfin.dat');
-print "Processing zfin.dat (md5:$zfin_dat_hash) at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n";
-
-$/ = "//\n";
-open(UNPT, "zfin.dat") || die "Cannot open zfin.dat : $!\n";
-my $record_count = 0;
-while (<UNPT>) {
-    $record_count++;
-}
-close(UNPT);
-my $one_percent_of_records = floor($record_count / 100);
-$one_percent_of_records = 1 if $one_percent_of_records == 0;
-
-print "zfin.dat has $record_count records\n";
-
-open(UNPT, "zfin.dat") || die "Cannot open zfin.dat : $!\n";
+### Globals
+### TODO: move these to local scope if possible.
+my $after_embl;
+my $count;
+my $dr_zfin;
+my $embl_ac;
+my $embl_exist;
+my $fileno;
+my $good;
+my $match;
+my $is_empty_embl_list;
+my $num_pub;
+my $one_match;
+my $probfile;
+my $qual_check;
+my $zfin_ac;
+my @EMBL;
+my @embl_nt;
+my @embl_nt_matched;
+my @pubmed;
+my @rx;
+my @zfin;
+my $last_percent = 0;
 my $progress_count = 0;
-while (<UNPT>) {
-    $progress_count++;
+my $record_count = 0;
+my $use_refseq_match = 0;
+my $is_current_record_refseq_processed = 0;
+my %refseq_hash;
+my $refseq_hash_initialized = 0;
+my %genpept_hash;
+my $genpept_hash_initialized = 0;
+my %genbank_hash;
+my $genbank_hash_initialized = 0;
 
-    #give some indication of progress (once per 1% of records)
-    if ($progress_count % $one_percent_of_records == 0) {
-        print ceil($progress_count * 100 / $record_count) . "% - " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n";
+sub main {
+    # Take a SP file as input (content format restricted).
+
+    # Create the output files and give them titles.
+    init_files();
+
+    # if PubMed number not in zfin, output to a single file
+    open PUB, ">pubmed_not_in_zfin" or die "Cannot open the pubmed_not_in_zfin:$!";
+
+    my $zfin_dat_hash = md5File('zfin.dat');
+    print "Processing zfin.dat (md5:$zfin_dat_hash) at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n";
+
+    $/ = "//\n";
+    open(UNPT, "zfin.dat") || die "Cannot open zfin.dat : $!\n";
+    $record_count = 0;
+    while (<UNPT>) {
+        $record_count++;
     }
+    close(UNPT);
+    print "zfin.dat has $record_count records\n";
 
-    init_var(); # Initialize the variables and arrays
+    open(UNPT, "zfin.dat") || die "Cannot open zfin.dat : $!\n";
 
-    # records in probfile contains AC, RX, DR EMBL lines
-    # they go to one of the prob# files for curator review. 
-    $probrecd = "prob$$.txt";
-    open PROB, ">$probrecd" or die "Cannot create the prob record file: $!";
+    while (<UNPT>) {
+        my $record = $_;
+        print_progress();
 
-    if (!/DR\s*EMBL;/) {
-        # if no EMBL line
-        open F, ">>prob7" or die "Cannot open prob7 file";
-        print F;
-        close F;
-        print PROB;
-        close PROB;
-        system("cat '$probrecd' >> problemfile");
-        unlink $probrecd;
-        $num_prob++;
-        next;
-    }
+        init_var(); # Initialize the variables and arrays
 
-    if (/DR\s*ZFIN;.*\nDR\s*ZFIN;/) {
-        # if >1 ZFIN lines
-        open F, ">>prob8" or die "Cannot open prob8 file";
-        print F;
-        close F;
-        print PROB;
-        close PROB;
-        system("cat '$probrecd' >> problemfile");
-        unlink $probrecd;
-        $num_prob++;
-        next;
-    }
+        # records in probfile contains AC, RX, DR EMBL lines
+        # they go to one of the prob# files for curator review.
+        my $problem_buffer = "";
 
-    # record in tempfile contains ID, AC, DE, GN, DR, CC, KW, 
-    # it goes to "okfile" and "problemfile". Some record from problemfile
-    # would be matched out and appended to the okfile for parsing.
+        next if handleMissingEmblAndRefSeqRecord($record);
 
-    $temprecd = "temp$$.txt";
-    open TMP, ">$temprecd" or die "Cannot create the temporary file: $!";
+        next if handleDoubleZfinRecord($record);
 
-    foreach (split /\n/) {
-        $_ = $_ . "\n";
+        # record in tempfile contains AC, GN, CC, ID, DE, DR, KW,
+        # it goes to "okfile" and "problemfile". Some record from problemfile
+        # would be matched out and appended to the okfile for parsing.
 
-        if (/^AC/ || /^GN/ || /^CC/ || /^ID/ || /^DE/) {
-            print TMP;
-        }
+        my $temp_buffer = "";
 
-        if (/^ID\s+(\w+)/) {
-            $sp_id = $1;
-            next;
-        }
-        if (/^AC/) {
-            print PROB;
-            next;
-        }
+        foreach (split /\n/) {
+            $_ = $_ . "\n";
+            my $line = $_;
 
-        if (/^RX\s+MEDLINE=\d+.*PubMed=(\d+)/) {
-            # now only PubMed in zfin
-            push @rx, $_;
-            $num_pub = 1;
-            next;
-        }
+            next if isIgnoreLine($line);
 
-        if (/^DR\s+EMBL;\s+(\w+);\s+(\w+)\./) {
-            # check for EMBL acc number, parse it
+            # if the line is a relevant line, append it to the temp buffer for future output to okfile
+            capturePassThroughLine($line, $temp_buffer);
 
-            $dr = $_;
-            chop($dr); #the '\n' appended above could only be choped, not chomped.
-            print PROB "$dr";
-            $embl_exist = 1;
-            $embl_nt = $1;
-            push @embl_nt, $embl_nt;
+            next if handleAcLine($line, $problem_buffer);
 
-            # use GenPept acc for matching, storing results in @EMBL
-            $embl_gp = $2;
-            @embl_match = Embl_Match($embl_gp, "GenPept"); # first try the polypeptide accession
-            $num_match = @embl_match;                      # record number of genes directly or indirectly associated
+            next if handleRxLine($line, $problem_buffer);
 
-            if (@embl_match) {
-                print PROB "\tGP match: @embl_match\n";
-            } else {
-                print PROB "\n";
-            }
+            next if handleMatchingAgainstEmblLines($line, $problem_buffer, $temp_buffer);
 
-            @EMBL = (@EMBL, @embl_match); # collect all the matches for each record
+            # after the EMBL lines and ZFIN line, check the GenPept matching,
+            # if GenPept matching is not sufficient, use GenBank to further sort
+            # the records.
+            # This assumes all the EMBL lines are together so the above clause gets executed all times before this clause.
+            handlePostEmblLinesMatching($line, $problem_buffer, $temp_buffer);
 
-            if ($num_match > 1) {
-                $fileno = "1";
-            } elsif (!$num_match) {
-                print TMP "$dr  GP_NO_MATCH\n";
-            } else {
-                $one_match = pop(@embl_match);
-                print TMP "$dr  GP match: $one_match\n"; # the gene id is used in the parser
-                $count++;                                # only count the one match
-            }
-            $after_embl = 1;
-            next;
-        }
+            next if handleRefSeqMatching($record, $line, $problem_buffer, $temp_buffer);
 
-        # after the EMBL lines and ZFIN line, check the GenPept matching,
-        # if GenPept matching is not sufficient, use GenBank to furthur sort
-        # the records.
-        if ($after_embl && !$qual_check) {
-            ($no, $good) = Embl_Check();
+            next if handleZfinLine($line, $problem_buffer, $temp_buffer);
 
-            if (!$no && $good) {
-                $fileno = "0";
-            } elsif (!$no && !$good) {
-                $fileno = "2"; #GenPept matching shows conflicts
-            } else {
-                #GenBank acc check
-                @EMBL = ();
-                $count = 0;
-                foreach $embl_nt (@embl_nt) {
-                    @embl_match = Embl_Match($embl_nt, "GenBank");
-                    $num_match = @embl_match;
-                    if (@embl_match) {
-                        push @embl_nt_matched, $embl_nt;
-                        print PROB "\tGB match: @embl_match\n"; #!!this line is used in the sp_parser.pl
-                    }
-                    @EMBL = (@EMBL, @embl_match); # collect all the matches for each record
-                    if ($num_match) {
-                        $count++; # count for matched ones
-                        if ($num_match == 1) {
-                            $one_match = pop(@embl_match); # record the one match in ZFIN
-                            print TMP "\t\tGB match: $one_match\n";
-                        }
-                    }
-                }
+            next if handleDrKwLine($line, $temp_buffer);
 
-                ($no, $good) = Embl_Check();
+            handleCloseRecord($line, $problem_buffer, $temp_buffer);
 
-                if ($no) {
-                    if (!$num_pub) {
-                        $fileno = "6";
-                    } else {
-                        $fileno = PubMed_Check() ? "5" : "6";
-                    }
-                } elsif (!$good) {
-                    $fileno = "3";
-                } else {
-                    $fileno = Embl_Genomic_Check() ? "4" : "0";
-                }
-            }
-            $qual_check = 1;
+        } # foreach loop for one record
 
-        }
+    } # for loop for zfin.dat file
+    close UNPT;
 
-        if (/^DR\s+ZFIN;\s+(.*);/) {
-            # check for ZFIN acc number, parse it
-            $fileno = "00" if (!$fileno && $one_match && ($1 ne $one_match));
-            print PROB;
-            print TMP;
-            next;
-        }
+    close PUB;
+    print "Finished processing zfin.dat at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n";
 
-        if (/^DR/ || /^KW/) {
-            print TMP;
-            next;
-        }
+    open CHECKREP, ">checkreport.txt" or die "Cannot open checkreport.txt:$!";
+    print CHECKREP "\nFinal report: \n";
+    print CHECKREP "\t problem records(#) : $num_prob \n";
+    print CHECKREP "\t ok records(#)  : $num_ok \n";
 
-        if (/\/\//) {
-            # end of one record
+    my $ok_percent = sprintf("%.1f", 100 - ($num_prob/($num_prob+$num_ok)*100));
 
-            print PROB "//\n";
-            close PROB;
-            print TMP "//\n";
-            close TMP;
-
-            if ($fileno eq "0") {
-                system("cat '$temprecd' >> okfile");
-                $num_ok++;
-            } elsif ($fileno eq "00") {
-                #those disagrees go to both okfile and prob0.
-                system("cat '$temprecd' >> okfile");
-                system("cat '$probrecd' >> prob0 ");
-                $num_ok++;
-            } else {
-                $probfile = "prob" . $fileno;
-                system("cat '$probrecd' >> '$probfile'");
-                system("cat '$temprecd' >> problemfile");
-                $num_prob++;
-            }
-        }
-    } # foreach loop for one record
-
-    unlink $temprecd;
-    unlink $probrecd;
-
-} # for loop for SP file
-close UNPT;
-
-close PUB;
-print "Finished processing zfin.dat at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n";
-
-open CHECKREP, ">checkreport.txt" or die "Cannot open checkreport.txt:$!";
-print CHECKREP "\nFinal report: \n";
-print CHECKREP "\t problem records(#) : $num_prob \n";
-print CHECKREP "\t ok records(#)  : $num_ok \n";
-printf CHECKREP "\t ok percentage   : %.1f\%\n", (100 - $num_prob / ($num_prob + $num_ok) * 100.0);
-close CHECKREP;
-
-#---------------------------------------------------------------------------------------
-#
+    print CHECKREP "\t ok percentage   : $ok_percent%\n";
+    close CHECKREP;
+}
 
 sub init_var() {
 
@@ -280,20 +175,20 @@ sub init_var() {
     @zfin = ();
     @embl_nt = ();
     @embl_nt_matched = ();
-    @embl_match = ();
     $embl_ac = '';
     $zfin_ac = '';
     $one_match = '';
     $dr_zfin = '';
     $num_pub = 0;
     $embl_exist = 0;
-    $num_match = 0;
     $count = 0;
-    $no = 0;
+    $is_empty_embl_list = 0;
     $good = 0;
     $fileno = 0;
     $after_embl = 0;
     $qual_check = 0;
+    $use_refseq_match = 0;
+    $is_current_record_refseq_processed = 0;
 }
 
 # Check whether at least one EMBL numbers are in ZFIN database, 
@@ -301,52 +196,76 @@ sub init_var() {
 # Return two values that denotes the checking result.   
 
 sub Embl_Match($$) {
-
     my ($embl_ac, $dbname, $sth, $geneZdbId, $sql);
     $embl_ac = $_[0];
     $dbname = $_[1];
-    @embl_match = ();
-    $sql = "";
-    if ($dbname eq "GenPept") {
-        $sql = "  select distinct dblink_linked_recid
-                  from db_link 
-                  where dblink_fdbcont_zdb_id = 'ZDB-FDBCONT-040412-42'
-                    and dblink_linked_recid like 'ZDB-GENE-%'
-                    and dblink_acc_num = ?
-                  union
-                  select mrel_mrkr_1_zdb_id 
-                    from marker_relationship,db_link
-                   where dblink_fdbcont_zdb_id = 'ZDB-FDBCONT-040412-42'  
-                     and mrel_type = 'gene encodes small segment'
-                     and mrel_mrkr_2_zdb_id=dblink_linked_recid 
-                     and dblink_acc_num= ?";
 
+    if (!$genbank_hash_initialized) {
+        initializeGenBankHash();
+        initializeGenPeptHash();
+    }
+
+    if ($dbname eq "GenPept") {
+        if (exists $genpept_hash{$embl_ac}) {
+            return @{$genpept_hash{$embl_ac}};
+        }
     }
     if ($dbname eq "GenBank") {
-        $sql = "  select distinct dblink_linked_recid
-                  from db_link 
+        if (exists $genbank_hash{$embl_ac}) {
+            return @{$genbank_hash{$embl_ac}};
+        }
+    }
+    return ();
+}
+
+sub initializeGenPeptHash() {
+    my $sth = $dbh->prepare("select distinct dblink_acc_num, dblink_linked_recid
+                  from db_link
+                  where dblink_fdbcont_zdb_id = 'ZDB-FDBCONT-040412-42'
+                    and dblink_linked_recid like 'ZDB-GENE-%'
+                  union
+                  select dblink_acc_num, mrel_mrkr_1_zdb_id
+                    from marker_relationship,db_link
+                   where dblink_fdbcont_zdb_id = 'ZDB-FDBCONT-040412-42'
+                     and mrel_type = 'gene encodes small segment'
+                     and mrel_mrkr_2_zdb_id = dblink_linked_recid ");
+    $sth->execute();
+    while (my ($acc, $zdbId) = $sth->fetchrow_array) {
+        my $tempArray = $genpept_hash{$acc};
+        if ($tempArray) {
+            push @$tempArray, $zdbId;
+        } else {
+            $tempArray = [$zdbId];
+        }
+        $genpept_hash{$acc} = $tempArray;
+    }
+    $genpept_hash_initialized = 1;
+}
+
+sub initializeGenBankHash() {
+    my $sth = $dbh->prepare("select distinct dblink_acc_num, dblink_linked_recid
+                  from db_link
                   where dblink_fdbcont_zdb_id in ('ZDB-FDBCONT-040412-36',
                                                   'ZDB-FDBCONT-040412-37')
                     and dblink_linked_recid like 'ZDB-GENE-%'
-                    and dblink_acc_num = ?
                   union
-                  select mrel_mrkr_1_zdb_id 
+                  select dblink_acc_num, mrel_mrkr_1_zdb_id
                     from marker_relationship,db_link
                    where dblink_fdbcont_zdb_id in ('ZDB-FDBCONT-040412-37',
                                                   'ZDB-FDBCONT-040412-36')
                      and mrel_type = 'gene encodes small segment'
-                     and mrel_mrkr_2_zdb_id=dblink_linked_recid 
-                     and dblink_acc_num= ?";
-    }
-    $sth = $dbh->prepare($sql);
-    $sth->execute($embl_ac, $embl_ac);
-
-    while ($geneZdbId = $sth->fetchrow_array) {
-        if ($geneZdbId =~ /ZDB-GENE/) {
-            push @embl_match, $geneZdbId;
+                     and mrel_mrkr_2_zdb_id=dblink_linked_recid ");
+    $sth->execute();
+    while (my ($acc, $zdbId) = $sth->fetchrow_array) {
+        my $tempArray = $genbank_hash{$acc};
+        if ($tempArray) {
+            push @$tempArray, $zdbId;
+        } else {
+            $tempArray = [$zdbId];
         }
+        $genbank_hash{$acc} = $tempArray;
     }
-    return (@embl_match); #matches in ZFIN db for each EMBL number
+    $genbank_hash_initialized = 1;
 }
 
 sub Embl_Genomic_Check() {
@@ -366,6 +285,98 @@ sub Embl_Genomic_Check() {
     return ($all_genomic);
 }
 
+sub RefSeq_Match {
+    my $refseq_accession = shift;
+
+    # remove version number
+    $refseq_accession =~ s/\.\d+$//;
+
+    if (!$refseq_hash_initialized) {
+        initializeRefSeqHash();
+    }
+
+    my @embl_match = ();
+
+    my $geneZdbId = $refseq_hash{$refseq_accession};
+    if ($geneZdbId) {
+        push @embl_match, $geneZdbId;
+    }
+
+    return (@embl_match); #matches in ZFIN db for each EMBL number
+}
+
+sub initializeRefSeqHash {
+    my $sth = $dbh->prepare("select distinct dblink_acc_num, dblink_linked_recid
+                             from db_link
+                             where dblink_fdbcont_zdb_id in (
+                                'ZDB-FDBCONT-040412-38',
+                                'ZDB-FDBCONT-040412-39',
+                                'ZDB-FDBCONT-040527-1',
+                                'ZDB-FDBCONT-041217-2'
+                             )
+                                and dblink_linked_recid like 'ZDB-GENE-%'");
+    $sth->execute();
+    while (my ($refseq_accession, $geneZdbId) = $sth->fetchrow_array) {
+        if ($refseq_hash{$refseq_accession}) {
+            print "ERROR: duplicate refseq accession $refseq_accession, $geneZdbId\n";
+            die;
+        }
+        $refseq_hash{$refseq_accession} = $geneZdbId;
+    }
+    $refseq_hash_initialized = 1;
+}
+
+sub handleMissingEmblAndRefSeqRecord {
+    my $record = shift;
+
+    # TODO: simplify by removing the legacy logic and retaining the elsif clause as an if clause
+    if ($ENV{"USE_LEGACY_LOGIC"} && $record !~ /DR\s*EMBL;/) {
+        # if no EMBL line
+        file_append("prob7", $record);
+        file_append("problemfile", $record);
+
+        $num_prob++;
+        return 1;
+    } elsif (!$ENV{"USE_LEGACY_LOGIC"} && $record !~ /DR\s*EMBL;/ && $record !~ /DR\s*RefSeq;/) {
+        # if no EMBL line
+        file_append("prob7", $record);
+        file_append("problemfile", $record);
+
+        $num_prob++;
+        return 1;
+    } elsif (!$ENV{"USE_LEGACY_LOGIC"} && $record !~ /DR\s*EMBL;/ && $record =~ /DR\s*RefSeq; (.*)/) {
+        $use_refseq_match = 1;
+    }
+    return 0;
+}
+
+sub handleDoubleZfinRecord {
+    my $record = shift;
+    if (/DR\s*ZFIN;.*\nDR\s*ZFIN;/) {
+        # if >1 ZFIN lines
+        file_append("prob8", $record);
+        file_append("problemfile", $record);
+
+        $num_prob++;
+        return 1;
+    }
+    return 0;
+}
+
+sub isIgnoreLine {
+    my $line = shift;
+    my $isRelevantLine = ($line =~ /^AC/ ||
+        $line =~ /^GN/ ||
+        $line =~ /^CC/ ||
+        $line =~ /^ID/ ||
+        $line =~ /^DE/ ||
+        $line =~ /^DR/ ||
+        $line =~ /^KW/ ||
+        $line =~ /^DT/ ||
+        $line =~ /\/\// ||
+        $line =~ /^RX\s+MEDLINE=\d+.*PubMed=(\d+)/);
+    return !$isRelevantLine;
+}
 
 #check whether at least one EMBL# is in ZFIN,
 #and for those have match(es), if every one has multiple matches,
@@ -374,37 +385,44 @@ sub Embl_Genomic_Check() {
 
 sub Embl_Check() {
 
-    my $none = 0; #whether at least one EMBL# matches in ZFIN
+    my $is_empty_embl_list = 0;
     my $same = 0; #whether all EMBL#s in ZFIN associated with the same marker
+    my $matches_buffer = "";
     if (!@EMBL) {
-        $none = 1;
+        $is_empty_embl_list = 1;
     } else {
         if ($one_match) {
 
             while ($match = pop @EMBL) {
+                $matches_buffer .= "$match,"; #for debugging
                 if ($match eq $one_match) { #whether the one-match appears in all the
                     $count--;               #other matches.
                 }
             }
             if (!$count) {
                 $same = 1;
+            } else {
+                file_append("spcheck.dbg.log", "DEBUG Embl_Check: one_match ($one_match) is truthy, but not all matches are the same ($matches_buffer).\n");
             }
+        } else {
+            file_append("spcheck.dbg.log", "DEBUG Embl_Check: one_match is not truthy. \@EMBL is @EMBL.\n")
         }
     }
-    return ($none, $same);
+    return ($is_empty_embl_list, $same);
 }
 
 
 # Check whether at least one PubMed number is in ZFIN db.
 # Return 0/1 that denote this result.
 sub PubMed_Check() {
+    my $prob_buffer = $_[0];
 
     my $match = 0;
     my ($sth, $pubmed, $qpubmed, $pub_match);
 
     foreach my $rx (@rx) {
         chop($rx); # the added '\n' could only be chopped not chompped.
-        print PROB "$rx";
+        $prob_buffer .= "$rx";
 
         $pubmed = $1 if ($rx =~ /^RX\s+MEDLINE=\d+.*PubMed=(\d+)/);
         $qpubmed = $dbh->quote($pubmed);
@@ -416,18 +434,356 @@ sub PubMed_Check() {
 
         if ($pub_match) {
 
-            print PROB "\t$pub_match";
+            $prob_buffer .= "\t$pub_match";
             $match = 1;
         } else {
 
             print PUB "$pubmed\n";
         }
-        print PROB "\n";
+        $prob_buffer .= "\n";
     }
 
+    $_[0] = $prob_buffer; #is this necessary in perl?
     return $match;
 }
 
+sub capturePassThroughLine {
+    my $line = shift;
+    my $temp_buffer = $_[0];
+
+    if ($line =~ /^AC/ || $line =~ /^GN/ || $line =~ /^CC/ || $line =~ /^ID/ || $line =~ /^DE/ || $line =~ /^DT/) {
+        $_[0] .= $line;
+    }
+}
+
+sub handleAcLine {
+    my $line = shift;
+    my $problem_buffer = $_[0];
+    if ($line =~ /^AC/) {
+        $problem_buffer .= $line;
+        $_[0] = $problem_buffer;
+        return 1;
+    }
+    return 0;
+}
+
+sub handleRxLine {
+    my $line = shift;
+    if ($line =~ /^RX\s+MEDLINE=\d+.*PubMed=(\d+)/) {
+        # now only PubMed in zfin
+        push @rx, $_;
+        $num_pub = 1;
+        return 1;
+    }
+    return 0;
+}
+
+sub handleZfinLine {
+    my $line = shift;
+    my $problem_buffer = $_[0];
+    my $temp_buffer = $_[1];
+
+    if (/^DR\s+ZFIN;\s+(.*);/) {
+        # check for ZFIN acc number, parse it
+        $fileno = "00" if (!$fileno && $one_match && ($1 ne $one_match));
+        $problem_buffer .= $line;
+        $temp_buffer .= $line;
+
+        $_[0] = $problem_buffer;
+        $_[1] = $temp_buffer;
+        return 1;
+    }
+    return 0;
+}
+
+sub handleDrKwLine {
+    my $line = shift;
+    my $temp_buffer = $_[0];
+    if (/^DR/ || /^KW/) {
+        $temp_buffer .= $line;
+        $_[0] = $temp_buffer;
+        return 1;
+    }
+    return 0;
+}
+
+# @EMBL is a global array that gets built up line by line with each record (then reset for the next record)
+# In the post processing subroutine, there are some checks that are done on the @EMBL array to ensure that
+# it only contains one unique ZFIN ID.
+#
+sub handleMatchingAgainstEmblLines {
+    my $line = shift;
+    my $problem_buffer = $_[0];
+    my $temp_buffer = $_[1];
+
+    if ($line =~ /^DR\s+EMBL;\s+(\w+);\s+(\w+)\./) {
+        # check for EMBL acc number, parse it
+
+        my $dr = $line;
+        chop($dr); #the '\n' appended above could only be choped, not chomped.
+        $problem_buffer .= $dr;
+        $embl_exist = 1;
+        my $embl_genbank_acc = $1;
+        push @embl_nt, $embl_genbank_acc;
+
+        # use GenPept acc for matching, storing results in @EMBL
+        my $embl_gp = $2;
+        my @embl_match = Embl_Match($embl_gp, "GenPept"); # first try the polypeptide accession
+        my $num_match = @embl_match;                      # record number of genes directly or indirectly associated
+
+        if (@embl_match) {
+            $problem_buffer .= "\tGP match: @embl_match\n";
+        }
+        else {
+            $problem_buffer .= "\n";
+        }
+
+        @EMBL = (@EMBL, @embl_match); # collect all the matches for each record
+
+        if ($num_match > 1) {
+            $fileno = "1";
+        }
+        elsif (!$num_match) {
+            $temp_buffer .= "$dr  GP_NO_MATCH\n";
+        }
+        else {
+            $one_match = pop(@embl_match);
+            $temp_buffer .= "$dr  GP match: $one_match\n"; # the gene id is used in the parser
+            $count++;                                # only count the one match
+        }
+        $after_embl = 1;
+
+        $_[0] = $problem_buffer;
+        $_[1] = $temp_buffer;
+        return 1;
+    }
+    return 0;
+}
+
+# after the EMBL lines and ZFIN line, check the GenPept matching,
+# if GenPept matching is not sufficient, use GenBank to furthur sort
+# the records.
+# This assumes all the EMBL lines are together so the above clause gets executed all times before this clause.
+sub handlePostEmblLinesMatching {
+    my $line = shift;
+    my $problem_buffer = $_[0];
+    my $temp_buffer = $_[1];
+
+    if ($after_embl && !$qual_check) {
+        ($is_empty_embl_list, $good) = Embl_Check();
+
+        if (!$is_empty_embl_list && $good) {
+            $fileno = "0";
+        }
+        elsif (!$is_empty_embl_list && !$good) {
+            $fileno = "2"; #GenPept matching shows conflicts
+        }
+        else {
+            #GenBank acc check
+            @EMBL = ();
+            $count = 0;
+            foreach my $embl_genbank_acc (@embl_nt) {
+                my @embl_match = Embl_Match($embl_genbank_acc, "GenBank");
+                my $num_match = @embl_match;
+                if (@embl_match) {
+                    push @embl_nt_matched, $embl_genbank_acc;
+                    $problem_buffer .= "\tGB match: @embl_match\n"; #!!this line is used in the sp_parser.pl
+                }
+                @EMBL = (@EMBL, @embl_match); # collect all the matches for each record
+                if ($num_match) {
+                    $count++; # count for matched ones
+                    if ($num_match == 1) {
+                        $one_match = pop(@embl_match); # record the one match in ZFIN
+                        $temp_buffer .= "\t\tGB match: $one_match\n";
+                    }
+                }
+            }
+
+            ($is_empty_embl_list, $good) = Embl_Check();
+
+            if ($is_empty_embl_list) {
+                if (!$num_pub) {
+                    $fileno = "6";
+                }
+                else {
+                    $fileno = PubMed_Check() ? "5" : "6";
+                }
+            }
+            elsif (!$good) {
+                $fileno = "3";
+            }
+            else {
+                $fileno = Embl_Genomic_Check() ? "4" : "0";
+            }
+        }
+        $qual_check = 1;
+    }
+
+    $_[0] = $problem_buffer;
+    $_[1] = $temp_buffer;
+}
+
+# If no embl lines have been found, the record is marked to process by refseq ($use_refseq_match).
+# It is run once per record as opposed to some of the other line-handling methods.
+# It matches against ALL refseq accessions in the record. If there are multiple matches, they must
+# all be the same, otherwise the record goes to problem file (using $fileno global).
+#
+sub handleRefSeqMatching {
+    my $record = shift;
+    my $line = shift;
+    my $problem_buffer = $_[0];
+    my $temp_buffer = $_[1];
+    my @refseq_matching_accessions;
+    my @refseq_accessions;
+    my $return_value = 0;
+
+    #Add line to problem buffer as passthrough line for potential output to prob9 or prob10
+    if ($line !~ /^\/\// && ($use_refseq_match || $is_current_record_refseq_processed)) {
+        $problem_buffer .= $line;
+    }
+
+    if ($use_refseq_match && $line =~ /DR   RefSeq; (.*); (.*)\./ ) {
+        if ($is_current_record_refseq_processed) {
+            $return_value = 0;
+        } else {
+            #Get all the refseq matches in the record
+            @refseq_matching_accessions = RefSeq_Accessions_With_Match_For_Record($record);
+
+            $temp_buffer .= $line;
+            #remove trailing newline from temp_buffer
+            $temp_buffer =~ s/\n$//;
+
+            if (@refseq_matching_accessions) {
+                Process_RefSeq_Accessions(\@refseq_matching_accessions, \$problem_buffer, \$temp_buffer );
+            } else {
+                #If there are no matches, then add this record to a problemfile
+                @refseq_accessions = getRefSeqAccessions($record);
+                $problem_buffer =~ s/\n$//;
+                $problem_buffer .=  "\tREFSEQ_NO_MATCH: " . "@refseq_accessions\n";
+
+                $temp_buffer .=  "\tREFSEQ_NO_MATCH: " . "@refseq_accessions\n";
+                $fileno = "10";
+            }
+
+            $is_current_record_refseq_processed = 1;
+            $return_value = 1;
+        }
+    }
+
+    $_[0] = $problem_buffer;
+    $_[1] = $temp_buffer;
+    return $return_value;
+}
+
+# This method is called by handleRefSeqMatching. It takes an array of refseq accessions for a record
+# and appends the matching gene to the first refseq line if there is a single match.
+# If there are multiple matches, they must all be the same, otherwise the record goes to problem file (using $fileno global).
+sub Process_RefSeq_Accessions {
+    my $refseq_accessions_ref = shift;
+    my $problem_buffer_ref = shift;
+    my $temp_buffer_ref = shift;
+
+    #are the entries unique
+    if(allElementsSame($refseq_accessions_ref)) {
+        my $accession = $refseq_accessions_ref->[0];
+        $$temp_buffer_ref .= "\tREFSEQ match: $accession\n";
+    } else {
+        #remove trailing newline from temp_buffer
+        $$problem_buffer_ref =~ s/\n$//;
+
+        #conflicting matches go to a problem file
+        my @unique_refseq_accessions = uniqueEntriesFromArray(@$refseq_accessions_ref);
+        $$problem_buffer_ref .= "\tREFSEQ_CONFLICTING_MATCHES: " . "@unique_refseq_accessions\n";
+        $$temp_buffer_ref .= "\tREFSEQ_CONFLICTING_MATCHES: " . "@unique_refseq_accessions\n";
+        $fileno = "9";
+    }
+}
+
+sub handleCloseRecord {
+    my $line = shift;
+    my $problem_buffer = $_[0];
+    my $temp_buffer = $_[1];
+
+    if ($line =~ /^\/\//) {
+        # end of one record
+
+        $problem_buffer .= "//\n";
+        $temp_buffer .= "//\n";
+
+        if ($fileno eq "0") {
+            #append temp_buffer to okfile
+            file_append('okfile', $temp_buffer);
+            $num_ok++;
+        }
+        elsif ($fileno eq "00") {
+            #those disagrees go to both okfile and prob0.
+            file_append('okfile', $temp_buffer);
+            file_append('prob0', $problem_buffer);
+            $num_ok++;
+        }
+        else {
+            $probfile = "prob" . $fileno;
+            file_append($probfile, $problem_buffer);
+            file_append("problemfile", $temp_buffer);
+            $num_prob++;
+        }
+    }
+}
+
+sub RefSeq_Accessions_With_Match_For_Record {
+    my $record = shift;
+
+    my @refseq_accessions = getRefSeqAccessions($record);
+    my @all_refseq_matches = ();
+
+    for my $refseq_acc (@refseq_accessions) {
+        my @refseq_matches = RefSeq_Match($refseq_acc);
+        if (@refseq_matches) {
+            push(@all_refseq_matches, @refseq_matches);
+        }
+    }
+
+    return @all_refseq_matches;
+}
+
+sub allElementsSame {
+    my @array = @{$_[0]};
+
+    my $first_element = $array[0];
+    for my $element (@array) {
+        if ($element ne $first_element) {
+            return 0;
+        }
+    }
+    return 1;
+}
+# Get all the refseq accessions from a record, first protein, then nucleotide
+sub getRefSeqAccessions {
+    my $record = shift;
+
+    #parse out relevant RefSeq lines from $record text
+    my @lines = split /\n/, $record;
+    my @matching_lines = grep { /DR   RefSeq; (.*); (.*)\./ } @lines;
+    my @refseq_accs1 = ();
+    my @refseq_accs2 = ();
+
+    #add the refseq accs to the array
+    for my $line (@matching_lines) {
+        $line =~ /DR   RefSeq; (.*); (.*)\./;
+        push(@refseq_accs1, $1);
+        push(@refseq_accs2, $2);
+    }
+
+    return (@refseq_accs1, @refseq_accs2);
+}
+
+sub uniqueEntriesFromArray {
+    my @array = @_;
+
+    my %seen;
+    my @unique = grep { ! $seen{$_} ++ } @array;
+    return @unique;
+}
 
 # Initialize the final output files for the checked SP records
 sub init_files() {
@@ -550,4 +906,53 @@ ENDDOC
 
     print FILE "$title";
     close FILE;
+
+    open FILE, ">prob9" or die "Cannot open the prob9: $!";
+    $title = <<ENDDOC;
+#--------------------------------------------
+# SP records Problem 9
+#
+#   Conflicting refseq matches
+#
+ENDDOC
+
+    print FILE "$title";
+    close FILE;
+
+    open FILE, ">prob10" or die "Cannot open the prob10: $!";
+    $title = <<ENDDOC;
+#--------------------------------------------
+# SP records Problem 10
+#
+#   No refseq matches
+#
+ENDDOC
+
+    print FILE "$title";
+    close FILE;
 }
+
+sub print_progress {
+    $progress_count++;
+
+    my $percent = int($progress_count/$record_count*100);
+
+    #only print once per percent
+    if ($percent != $last_percent) {
+        print "$progress_count/$record_count ($percent%) " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . "\n";
+        $last_percent = $percent;
+    }
+}
+
+sub file_append {
+    my $filename = shift;
+    my $content = shift;
+
+    my $mode = ">>";
+
+    open FILE, "$mode$filename" or die "Cannot open the file $filename: $!";
+    print FILE "$content";
+    close FILE;
+}
+
+main();

--- a/server_apps/data_transfer/SWISS-PROT/sp_parser.pl
+++ b/server_apps/data_transfer/SWISS-PROT/sp_parser.pl
@@ -129,6 +129,12 @@ while (<>) {
       next;
   }
 
+  #\tREFSEQ match: ZDB-GENE-*-*     #sp_check.pl write out this line
+  if (/REFSEQ match: (.*)/) {
+      $single_gene = $1;
+      next;
+  }
+
   if (/^DR\s+ZFIN;\s+(.+);\s/ ) {
       push @gene_array, $1;
       next;

--- a/server_apps/data_transfer/SWISS-PROT/validate_zfin_dat.pl
+++ b/server_apps/data_transfer/SWISS-PROT/validate_zfin_dat.pl
@@ -1,0 +1,48 @@
+#!/opt/zfin/bin/perl 
+
+# validate_zfin_dat.pl
+# quick check that in the zfin.dat file, each record has all EMBL DR lines before any RefSeq DR lines
+
+use strict;
+use warnings;
+use DBI;
+use POSIX;
+
+sub main {
+    $/ = "\/\/\n"; #custom record separator
+    open INPUT, "zfin.dat" or die "Cannot open zfin.dat";
+    foreach my $record (<INPUT>) {
+        my $embl = 0;
+        my $refseq = 0;
+        my $id = "";
+
+        #split lines by newline
+        my @lines = split /\n/, $record;
+
+        #check each line
+        foreach my $line (@lines) {
+            my $line_is_embl = 0;
+            my $line_is_refseq = 0;
+
+            #check for ID line
+            if ($line =~ /^ID\s+(.*)/) {
+                $id = $1;
+            }
+            if ($line =~ /^DR\s+EMBL/) {
+                $line_is_embl = 1;
+                $embl = 1;
+            }
+            if ($line =~ /^DR\s+RefSeq/) {
+                $line_is_refseq = 1;
+                $refseq = 1;
+            }
+            #check that embl is before refseq
+            if ($line_is_embl == 1 && $refseq == 1) {
+                print "ERROR: EMBL DR line is after RefSeq DR line in record $id: \n";
+                exit 1;
+            }
+        }
+    }
+}
+
+main();


### PR DESCRIPTION
Add the REFSEQ match from sp_check for sp_parser.
Refactor pre_loadsp.pl for readability.
Add bugfix for weird issue with SO:0001217 (see comments on ZFIN-8499) Wrap primary logic in main method.
Refactor to not use temporary files when we can just use buffer variables.
Fix match to end-of-record: the regex "/\/\//" was erroneously matching the occasional URL lines, eg: CC       URL="https://web.expasy.org/spotlight/back_issues/210/";
refactor embl matching if clause to method.
move chunks of logic into subroutines
Add some checksum info for versioning
Add better logging to problem files. refseq problem files are now prob9 and prob10.
Clean up output of REFSEQ match.
Improve performance of db lookups with cache.