### PR TITLE
ZFIN-8545: Errors thrown on some disease term page JSP rendering

### DIFF
--- a/source/org/zfin/marker/repository/HibernateMarkerRepository.java
+++ b/source/org/zfin/marker/repository/HibernateMarkerRepository.java
@@ -3109,7 +3109,8 @@ public class HibernateMarkerRepository implements MarkerRepository {
         Session session = HibernateUtil.currentSession();
         String sql = """
             select ortho FROM Ortholog as ortho
-            join ortho.ncbiOtherSpeciesGene
+            join fetch ortho.zebrafishGene
+            join fetch ortho.ncbiOtherSpeciesGene
             WHERE ortho.organism.commonName = :organism
             """;
 


### PR DESCRIPTION
Fix issue by eager loading some relationships.

The source of the bug is logged as:

```
Caused by: javax.servlet.jsp.JspException: org.hibernate.LazyInitializationException: could not initialize proxy [org.zfin.marker.Marker#ZDB-GENE-061027-102] - no Session
	at org.apache.jsp.tag.web.toggledLinkList_tag.doTag(toggledLinkList_tag.java:248) 
...
	at org.apache.jsp.tag.web.genesAssociatedWithDisease_tag._jspx_meth_zfin2_005fsubsection_005f0(genesAssociatedWithDisease_tag.java:243) ~[?:?]
	at org.apache.jsp.tag.web.genesAssociatedWithDisease_tag.doTag(genesAssociatedWithDisease_tag.java:183) ~[?:?]
```

The JSP tag [code](https://github.com/zfin/zfin/blob/1b50d413899c61aa2985df53729641aa0ef418ee/home/WEB-INF/tags/genesAssociatedWithDisease.tag#L45-L45) is:

```
<zfin2:toggledLinkList collection="${omimGene.zfinGene}" maxNumber="3"
       commaDelimited="true"/>
```
So when omimGene.zfinGene is referenced, it throws an exception that the lazy load proxy is failing to pull in the zfin gene from the DB due to a closed session.  Tracing the omimGene variable, we can see that it is set in [OntologyTermDetailController](https://github.com/zfin/zfin/blob/1b50d413899c61aa2985df53729641aa0ef418ee/source/org/zfin/ontology/presentation/OntologyTermDetailController.java#L189-L189) when it calls [OntologyService.getOmimPhenotypeForTerm](https://github.com/zfin/zfin/blob/386c029a485f7ce2910b7f3dd8966b0192d9aec7/source/org/zfin/ontology/service/OntologyService.java#L162).

