### PR TITLE
ZFIN-8537: Feedback 

### DIFF
--- a/home/javascript/react/components/entity/EntityAbbreviation.js
+++ b/home/javascript/react/components/entity/EntityAbbreviation.js
@@ -51,7 +51,7 @@ const EntityAbbreviation = ({entity}) => {
         linktext = entity.abbreviation || '';
     }
 
-    return <span className={className}>{linktext}</span>;
+    return <span className={className} dangerouslySetInnerHTML={{__html: linktext}}/>;
 };
 
 EntityAbbreviation.propTypes = {


### PR DESCRIPTION
fish names were rendered as the literal string 'ptk7a<sup>hsc9/hsc9</sup>' (for example) instead of with hsc9 in the superscript.