### PR TITLE
Switch from node-sass to sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jquery.tipsy": "1.0.3",
     "masonry-layout": "^4.2.2",
     "mini-css-extract-plugin": "^2.7.2",
-    "node-sass": "^6.0.1",
+    "sass": "^1.59.3",
     "popper.js": "1.16.1",
     "postcss": "^8.4.19",
     "prop-types": "15.8.1",


### PR DESCRIPTION
We've talked about switching to this version of sass before. I think we were waiting to make sure the other npm packages we upgraded don't cause problems. Now might be a good time to switch.  It would be nice to have the pure js implementation so we don't depend on python, and C for npm installation steps.