### PR TITLE
ZFIN-8540: Fix the word wrapping of disease terms 

### DIFF
--- a/home/WEB-INF/jsp/ontology/term-view.jsp
+++ b/home/WEB-INF/jsp/ontology/term-view.jsp
@@ -18,7 +18,7 @@
 
 <c:set var="secs"/>
 
-<z:dataPage sections="${[]}" navigationMenu="${navigationMenu}">
+<z:dataPage sections="${[]}" navigationMenu="${navigationMenu}" additionalBodyClass="term-view nav-title-wrap-break-word">
 
     <jsp:attribute name="entityName">
        ${term.termName}

--- a/home/css/datapage.scss
+++ b/home/css/datapage.scss
@@ -392,6 +392,13 @@ table.lab-view-summary-table dd a, table.company-view-summary-table dd a {
     word-break: break-all; /* <-- remove for ellipses truncation */
 }
 
+/* Wrap the page title as it appears in the left navigation menu and break on word separators */
+.nav-title-wrap-break-word a.back-to-top-link {
+    display: inline;
+    white-space: normal;
+    word-break: break-word;
+}
+
 /* Set margin for figure component on publication view page */
 .publication-view #xpresimg_control_box {
     margin-top: 20px;

--- a/source/org/zfin/framework/presentation/DiseaseNavigationMenu.java
+++ b/source/org/zfin/framework/presentation/DiseaseNavigationMenu.java
@@ -3,6 +3,9 @@ package org.zfin.framework.presentation;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.zfin.framework.featureflag.FeatureFlagEnum;
+
+import static org.zfin.framework.featureflag.FeatureFlags.isFlagEnabled;
 
 @Getter
 @Setter
@@ -18,7 +21,8 @@ public class DiseaseNavigationMenu extends NavigationMenu {
             title(NavigationMenuOptions.RELATIONSHIPS).showCount(false),
             title(NavigationMenuOptions.GENES_INVOLVED).showCount(false),
             title(NavigationMenuOptions.ZEBRAFISH_MODELS).showCount(false),
-            title(NavigationMenuOptions.ALLELE).showCount(false)
+            isFlagEnabled(FeatureFlagEnum.SHOW_ALLIANCE_DATA) ?
+                title(NavigationMenuOptions.ALLELE).showCount(false) : null
         );
     }
 

--- a/source/org/zfin/framework/presentation/NavigationMenu.java
+++ b/source/org/zfin/framework/presentation/NavigationMenu.java
@@ -5,6 +5,7 @@ import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
@@ -22,14 +23,15 @@ public class NavigationMenu {
 
     public NavigationMenu(NavigationItem.NavigationItemBuilder ...navigationItemBuilders) {
         this.navigationItems = Stream.of(navigationItemBuilders)
+                .filter(Objects::nonNull)
                 .map(NavigationItem.NavigationItemBuilder::build)
                 .toList();
     }
 
     /**
      * Set the hidden attribute for the NavigationItem in this menu matching the given title
-     * @param title
-     * @param value
+     * @param title title of the item we are looking for (enum)
+     * @param value true if the item should be hidden
      */
     public void setHidden(NavigationMenuOptions title, boolean value) {
         for(NavigationItem item : navigationItems) {


### PR DESCRIPTION
Fix the word wrapping of disease terms in the top left corner. Hide navigation item for alliance data if flag is disabled.

