### PR TITLE
ZFIN-8535: GenBank Accession Update

### DIFF
--- a/server_apps/data_transfer/Genbank/GenBank-Accession-Update_d.sql
+++ b/server_apps/data_transfer/Genbank/GenBank-Accession-Update_d.sql
@@ -1,7 +1,7 @@
 begin work;
 
 create temp table tmp_acc_bk (
-	tp_acc_num	     varchar(30) not null,
+	tp_acc_num	     varchar(255) not null,
 	tp_length            integer,
 	tp_fdbcont_zdb_id    varchar(50)
 	);
@@ -9,7 +9,7 @@ create temp table tmp_acc_bk (
 create unique index tmp_acc_bk_primary_key 
 	on tmp_acc_bk(tp_acc_num);
 
-\copy tmp_acc_bk from ./nc_zf_acc.unl;
+\copy tmp_acc_bk from ./nc_zf_acc.unl DELIMITER '|';
 
 update accession_bank
    set accbk_length = (select tp_length

--- a/server_apps/data_transfer/Genbank/README
+++ b/server_apps/data_transfer/Genbank/README
@@ -8,21 +8,23 @@
 OBJECTIVE
 -------------------------
 
-  Use GenBank daily update to update the accession number information 
-in ZFIN.
+  Use GenBank daily update to update the accession number information in ZFIN.
 
 -------------------------
 EXECUTION
 --------------------------
 
-   To run:	% gmake run
+  To run:	% gmake run
 
-   This will be automated run every night by cron job. 
+  This will be automated run every night by cron job.
 
 ----------------------------
 PROCEDURE
 ----------------------------
     
-    gbaccession.pl guides the process. 
-    By default, it downloads today's update file from ftp://ftp.ncbi.nlm.nih.gov/genbank/daily-nc. Or a specific date could be given in a format of MMDD as parameter. After unzip, the file is parsed by parseDaily.pl, generating nc_zf_acc.unl and a set of fasta files for BLAST db update. The nc_zf_acc.unl is used to update accession_bank and db_link tables by GenBank-Accession-Update_d.sql, and the fasta files are then passed on to embryonix/zygotix.
+  gbaccession.pl guides the process.
+  By default, it downloads today's update file from ftp://ftp.ncbi.nlm.nih.gov/genbank/daily-nc. Or a specific date
+  could be given in a format of MMDD as parameter. After unzip, the file is parsed by parseDaily.pl, generating
+  nc_zf_acc.unl and a set of fasta files for BLAST db update. The nc_zf_acc.unl is used to update accession_bank
+  and db_link tables by GenBank-Accession-Update_d.sql, and the fasta files are then passed on to embryonix/zygotix.
   

--- a/server_apps/data_transfer/Genbank/parseDaily.pl
+++ b/server_apps/data_transfer/Genbank/parseDaily.pl
@@ -87,10 +87,10 @@ while (my $gbfile = shift @ARGV) {
 	if ($organism eq 'Danio rerio'){
 
 	    if ($type eq "mRNA") {
-		print ZFACC substr($accession,0,index($accession, '.'))."|$bp|ZDB-FDBCONT-040412-37|\n";
+		print ZFACC substr($accession,0,index($accession, '.'))."|$bp|ZDB-FDBCONT-040412-37\n";
 	    }
 	    elsif ($type eq "DNA") {
-		print ZFACC substr($accession,0,index($accession, '.'))."|$bp|ZDB-FDBCONT-040412-36|\n";
+		print ZFACC substr($accession,0,index($accession, '.'))."|$bp|ZDB-FDBCONT-040412-36\n";
 	    }
 	    else {
 		print ZF ">gi|$gi|$dbsource|$accession|$locus $definition \n";

--- a/server_apps/jenkins/jobs/GenBank-Accession-Update_d/config.xml
+++ b/server_apps/jenkins/jobs/GenBank-Accession-Update_d/config.xml
@@ -24,6 +24,11 @@ original flat file are moved to /research/zblastfiles/files/daily for weekly BLA
     </hudson.tasks.Shell>
   </builders>
   <publishers>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>server_apps/data_transfer/Genbank/acc_update.report</artifacts>
+      <latestOnly>false</latestOnly>
+      <allowEmptyArchive>true</allowEmptyArchive>
+    </hudson.tasks.ArtifactArchiver>
     <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@2.35.1">
       <recipientList>${DB_OWNER}@zfin.org</recipientList>
       <configuredTriggers>


### PR DESCRIPTION
Use the artifact archiver for keeping old log files.  
Echo everything from psql file since that's where failures occur.
Fix the generation of the unload files by parseDaily.pl.