### PR TITLE
ZFIN-8517: Update to the NCBI One Way Matches report

### DIFF
--- a/source/org/zfin/sequence/repository/HibernateSequenceRepository.java
+++ b/source/org/zfin/sequence/repository/HibernateSequenceRepository.java
@@ -932,17 +932,17 @@ public class HibernateSequenceRepository implements SequenceRepository {
     @Override
     public List<RelatedMarkerDBLinkDisplay> getDBLinksForFirstRelatedMarker(Marker marker, DisplayGroup.GroupName groupName, MarkerRelationship.Type... markerRelationshipTypes) {
 
-        String hql = " select distinct dbl, mr " +
-                " from DBLink dbl, DisplayGroup dg, ReferenceDatabase ref,  " +
-                " MarkerRelationship  mr  " +
-                " where dg.groupName = :displayGroup " +
-                " and dbl.referenceDatabase=ref " +
-                " and dg in elements(ref.displayGroups) " +
-                " and mr.secondMarker.zdbID=dbl.dataZdbID " +
-                " and mr.markerRelationshipType.name in (:types) " +
-                " and mr.firstMarker.zdbID = :markerZdbId " +
-                " ";
-
+        String hql = """
+                select distinct dbl, mr 
+                from DBLink dbl, DisplayGroup dg, ReferenceDatabase ref,  
+                MarkerRelationship  mr  
+                where dg.groupName = :displayGroup 
+                and dbl.referenceDatabase=ref 
+                and dg in elements(ref.displayGroups) 
+                and mr.secondMarker.zdbID=dbl.dataZdbID 
+                and mr.markerRelationshipType.name in (:types) 
+                and mr.firstMarker.zdbID = :markerZdbId 
+            """;
         Set<String> types = new HashSet<>();
         if (markerRelationshipTypes.length != 0) {
             for (MarkerRelationship.Type type : markerRelationshipTypes) {
@@ -952,7 +952,6 @@ public class HibernateSequenceRepository implements SequenceRepository {
             for (MarkerRelationship.Type type : MarkerRelationship.Type.values()) {
                 types.add(type.toString());
             }
-
         }
         Query query = HibernateUtil.currentSession().createQuery(hql)
                 .setParameter("markerZdbId", marker.getZdbID())

--- a/source/org/zfin/uniprot/NcbiMatchReportRow.java
+++ b/source/org/zfin/uniprot/NcbiMatchReportRow.java
@@ -1,0 +1,31 @@
+package org.zfin.uniprot;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class NcbiMatchReportRow {
+    private String ncbiId;
+    private String zdbId;
+    private String ensemblId;
+    private String symbol;
+    private String dblinks;
+    private String publications;
+    private String rnaAccessions;
+
+    public List<String> toList() {
+        return List.of(
+                ncbiId == null ? "" : ncbiId,
+                zdbId == null ? "" : zdbId,
+                ensemblId == null ? "" : ensemblId,
+                symbol == null ? "" : symbol,
+                dblinks == null ? "" : dblinks,
+                publications == null ? "" : publications,
+                rnaAccessions == null ? "" : rnaAccessions
+        );
+    }
+}

--- a/source/org/zfin/uniprot/NcbiMatchThroughEnsemblTask.java
+++ b/source/org/zfin/uniprot/NcbiMatchThroughEnsemblTask.java
@@ -255,7 +255,7 @@ public class NcbiMatchThroughEnsemblTask extends AbstractScriptWrapper {
                     ensembl_id,
                     symbol,
                     string_agg(dbl2.dblink_zdb_id, ', ') AS dblinks,
-                    string_agg(ra.recattrib_source_zdb_id, ', ') AS pubs
+                    string_agg(ra.recattrib_source_zdb_id, ', ') AS publications
                     INTO TEMP TABLE ncbi_match_report
                 FROM
                     tmp_ncbi2zfin n2z
@@ -282,7 +282,7 @@ public class NcbiMatchThroughEnsemblTask extends AbstractScriptWrapper {
          left join (select dblink_linked_recid, dblink_acc_num from
         						db_link left join foreign_db_contains on dblink_fdbcont_zdb_id = fdbcont_zdb_id where fdbcont_fdbdt_id = 3) subq
         						on subq.dblink_linked_recid = nmr.zdb_id
-         group by ncbi_id, zdb_id, ensembl_id, symbol, db_links, publications
+         group by ncbi_id, zdb_id, ensembl_id, symbol, dblinks, publications
             """;
         List<Object[]> results = session.createSQLQuery(query).list();
 
@@ -301,7 +301,7 @@ public class NcbiMatchThroughEnsemblTask extends AbstractScriptWrapper {
     private void writeResultsToCsv(List<Object[]> results) {
         try (Writer writer = Files.newBufferedWriter(Paths.get(CSV_FILE));
              CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT
-                     .withHeader("ncbi_id", "zdb_id", "ensembl_id", "symbol", "db_links", "publications"))) {
+                     .withHeader("ncbi_id", "zdb_id", "ensembl_id", "symbol", "dblinks", "publications", "rna_accessions"))) {
             for (Object[] result : results) {
                 csvPrinter.printRecord(result);
             }


### PR DESCRIPTION
Ken requested the related RNA sequences for this report. We have somewhat complex logic for retrieving RNA sequences per marker from the gene page.  Instead of re-inventing that logic through SQL queries, I use the existing logic and iterate over each row to get the related RNA sequences.  It's slow, but it works.