### PR TITLE
ZFIN-8534: Fix relative path to log4j config file.

### DIFF
--- a/server_apps/DB_maintenance/build.xml
+++ b/server_apps/DB_maintenance/build.xml
@@ -8,7 +8,7 @@
     <property name="lib" value="${basedir}/lib/Java"/>
     <property name="web.lib" value="${web-inf.dir}/lib"/>
     <property name="validateData" value="${basedir}/server_apps/DB_maintenance"/>
-    <property name="jvm.arg.log4j" value="-Dlog4j.configurationFile=./home/WEB-INF/conf/log4j2.xml"/>
+    <property name="jvm.arg.log4j" value="-Dlog4j.configurationFile=${web-inf.dir}/conf/log4j2.xml"/>
 
     <property environment="env"/>
 

--- a/server_apps/data_transfer/RNACentral/build.xml
+++ b/server_apps/data_transfer/RNACentral/build.xml
@@ -10,7 +10,7 @@
     <property name="web.lib" value="${web-inf.dir}/lib"/>
     <property name="log.dir" value="${basedir}/logs"/>
     <property name="jvm.mem" value="-Xmx4g"/>
-    <property name="jvm.arg.log4j" value="-Dlog4j.configurationFile=./home/WEB-INF/conf/log4j2.xml"/>
+    <property name="jvm.arg.log4j" value="-Dlog4j.configurationFile=${web-inf.dir}/conf/log4j2.xml"/>
 
 
     <property environment="env"/>


### PR DESCRIPTION
There were some errors when running Dump-RNACentral-File_w.

Here's a sample of the output:
```
create-transcript-info-file:
     [echo] Check entity changes
     [echo] /opt/zfin/www_homes/trunk/server_apps/data_transfer/RNACentral/../../../
     [java] ERROR StatusLogger Reconfiguration failed: No configuration found for '67424e82' at 'null' in 'null'
     [java] 1029
     [java] 1
```

https://trunk.zfin.org/jobs/job/Dump-RNACentral-File_w/32/console