### PR TITLE
ZFIN-8676: Fix issue from switching from setString to setParameter on hql queries.

### DIFF
--- a/source/org/zfin/construct/repository/HibernateConstructRepository.java
+++ b/source/org/zfin/construct/repository/HibernateConstructRepository.java
@@ -197,8 +197,7 @@ public class HibernateConstructRepository implements ConstructRepository {
         types.add(Marker.Type.ETCONSTRCT.name());
 
 
-        String hql = "select m from Marker m " +
-                " where m.markerType.name in (:types) ";
+        String hql = "select m from Marker m  where m.markerType.name in (:types) ";
         Query query = HibernateUtil.currentSession().createQuery(hql);
         query.setParameterList("types", types);
         return (List<Marker>) query.list();

--- a/source/org/zfin/feature/repository/HibernateFeatureRepository.java
+++ b/source/org/zfin/feature/repository/HibernateFeatureRepository.java
@@ -934,6 +934,7 @@ public class HibernateFeatureRepository implements FeatureRepository {
         query.setString("feat", feature.getZdbID());
 
 
+        //SEE ZFIN-8676 before uncommenting?
         //query.setString("type", Marker.Type.GENE.toString());
 
         return (List<Marker>) query.list();

--- a/source/org/zfin/mutant/repository/HibernateMutantRepository.java
+++ b/source/org/zfin/mutant/repository/HibernateMutantRepository.java
@@ -915,49 +915,21 @@ public class HibernateMutantRepository implements MutantRepository {
         return basicPhenos;
     }
 
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public List<STRMarkerSequence> getSequenceTargetingReagentsWithMarkerRelationships() {
-
-        // using this type of query for both speed (an explicit join)
-        // and because createSQLQuery had trouble binding the lvarchar of s.sequence
-        final String queryString = "select m.zdbID ,m.abbreviation, s.sequence   from SequenceTargetingReagent m  " +
-            "inner join m.sequence s " +
-            "inner join m.firstMarkerRelationships  " +
-            "where m.markerType in  (:moType, :crisprType, :talenType) ";
-
-        final Query<Tuple> query = currentSession().createQuery(queryString, Tuple.class);
-        query.setParameter("moType", Marker.Type.MRPHLNO.toString());
-        query.setParameter("crisprType", Marker.Type.CRISPR.toString());
-        query.setParameter("talenType", Marker.Type.TALEN.toString());
-
-        List<Tuple> sequences = query.list();
-
-        List<STRMarkerSequence> strSequences = new ArrayList<STRMarkerSequence>();
-        for (Tuple seqObjects : sequences) {
-            STRMarkerSequence strSequence = new STRMarkerSequence();
-            strSequence.setZdbID(seqObjects.get(0).toString());
-            strSequence.setName(seqObjects.get(1).toString());
-            strSequence.setSequence(seqObjects.get(2).toString());
-            strSequences.add(strSequence);
-        }
-        return strSequences;
-    }
-
     @SuppressWarnings("unchecked")
     @Override
     public List<STRMarkerSequence> getMorpholinosWithMarkerRelationships() {
 
         // using this type of query for both speed (an explicit join)
         // and because createSQLQuery had trouble binding the lvarchar of s.sequence
-        final String queryString = "select m.zdbID ,m.abbreviation, s.sequence   from SequenceTargetingReagent m  " +
-            "inner join m.sequence s " +
-            "inner join m.firstMarkerRelationships  " +
-            "where m.markerType in  (:moType) ";
+        final String queryString = """ 
+            select m.zdbID, m.abbreviation, s.sequence from SequenceTargetingReagent m  
+            inner join m.sequence s 
+            inner join m.firstMarkerRelationships 
+            where m.markerType.name = :markerTypeName 
+            """;
 
         final Query<Tuple> query = currentSession().createQuery(queryString, Tuple.class);
-        query.setParameter("moType", Marker.Type.MRPHLNO.toString());
+        query.setParameter("markerTypeName", Marker.Type.MRPHLNO.name());
 
         List<Tuple> sequences = query.list();
 
@@ -978,13 +950,14 @@ public class HibernateMutantRepository implements MutantRepository {
 
         // using this type of query for both speed (an explicit join)
         // and because createSQLQuery had trouble binding the lvarchar of s.sequence
-        final String queryString = "select m.zdbID ,m.abbreviation, s.sequence   from SequenceTargetingReagent m  " +
-            "inner join m.sequence s " +
-            "inner join m.firstMarkerRelationships  " +
-            "where m.markerType in  (:crisprType) ";
-
+        final String queryString = """
+            select m.zdbID, m.abbreviation, s.sequence from SequenceTargetingReagent m 
+            inner join m.sequence s
+            inner join m.firstMarkerRelationships 
+            where m.markerType.name = :markerTypeName 
+            """;
         final Query<Tuple> query = currentSession().createQuery(queryString, Tuple.class);
-        query.setParameter("crisprType", Marker.Type.CRISPR.toString());
+        query.setParameter("markerTypeName", Marker.Type.CRISPR.name());
 
         List<Tuple> sequences = query.list();
 
@@ -1006,13 +979,15 @@ public class HibernateMutantRepository implements MutantRepository {
 
         // using this type of query for both speed (an explicit join)
         // and because createSQLQuery had trouble binding the lvarchar of s.sequence
-        final String queryString = "select m.zdbID ,m.abbreviation, s.sequence   from SequenceTargetingReagent m  " +
-            "inner join m.sequence s " +
-            "inner join m.firstMarkerRelationships  " +
-            "where m.markerType in  (:talenType) ";
+        final String queryString = """
+            select m.zdbID, m.abbreviation, s.sequence from SequenceTargetingReagent m
+            inner join m.sequence s
+            inner join m.firstMarkerRelationships
+            where m.markerType.name = :markerTypeName
+            """;
 
         final Query<Tuple> query = currentSession().createQuery(queryString, Tuple.class);
-        query.setParameter("talenType", Marker.Type.TALEN.toString());
+        query.setParameter("markerTypeName", Marker.Type.TALEN.name());
 
         List<Tuple> sequences = query.list();
 

--- a/source/org/zfin/mutant/repository/MutantRepository.java
+++ b/source/org/zfin/mutant/repository/MutantRepository.java
@@ -160,8 +160,6 @@ public interface MutantRepository {
 
     List<BasicPhenotypeDTO> getBasicPhenotypeDTOObjects();
 
-    List<STRMarkerSequence> getSequenceTargetingReagentsWithMarkerRelationships();
-
     List<STRMarkerSequence> getMorpholinosWithMarkerRelationships();
 
     List<STRMarkerSequence> getCrisprsWithMarkerRelationships();

--- a/source/org/zfin/sequence/repository/HibernateSequenceRepository.java
+++ b/source/org/zfin/sequence/repository/HibernateSequenceRepository.java
@@ -566,7 +566,7 @@ public class HibernateSequenceRepository implements SequenceRepository {
         query.setString("markerZdbID", marker.getZdbID());
         query.setString("superType", "sequence");
         query.setString("type", referenceDatabaseType.name());
-        query.setString("markerType", Marker.Type.GENE.name());
+        query.setString("markerType", Marker.Type.GENE.name()); //if using setParameter, change hql to use "...markerType.name = :markerType..."
         // todo: and marker_relation type = .....
 //        query.setString("markerRelationshipType", MarkerRelationship.Type.GENE_ENCODES_SMALL_SEGMENT.name()) ;
         dbLinks.addAll(query.list());

--- a/test/org/zfin/mutant/repository/MutantRepositoryTest.java
+++ b/test/org/zfin/mutant/repository/MutantRepositoryTest.java
@@ -188,15 +188,6 @@ public class MutantRepositoryTest {
     }
 
     @Test
-    public void getSTRsWithMarkerRelationships() {
-        List<STRMarkerSequence> sequenceTargetingReagents = mutantRepository.getSequenceTargetingReagentsWithMarkerRelationships();
-        assertThat(sequenceTargetingReagents, notNullValue());
-        LOG.info("# of sequence targeting reagents: " + sequenceTargetingReagents.size());
-        assertThat(sequenceTargetingReagents, hasSize(greaterThan(3000)));
-        assertThat(sequenceTargetingReagents.get(0).getSequence(), notNullValue());
-    }
-
-    @Test
     public void phenotypesWithObsoleteTerms() {
         List<PhenotypeStatement> phenotypes = mutantRepository.getPhenotypesOnObsoletedTerms();
         assertThat(phenotypes, notNullValue());


### PR DESCRIPTION
For example, we had to change queries like this:

```
hql = "...where m.markerType = :markerTypeName";
...
query.setString("markerTypeName", Marker.Type.MRPHLNO.name());
```

to

```
hql = "...where m.markerType.name = :markerTypeName";
...
query.setParameter("markerTypeName", Marker.Type.MRPHLNO.name());
```
