### PR TITLE
ZFIN-8623: Fix image thumbnails

### DIFF
--- a/console.gradle
+++ b/console.gradle
@@ -73,3 +73,9 @@ task runChebiPhenotypeIndexer(type: JavaExec) {
     args 'ChebiPhenotype'
 }
 
+task imageThumbnailFixTask(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'org.zfin.figure.service.ImageThumbnailFixTask'
+    systemProperty "runImageFixes", System.getProperty("runImageFixes", null)
+}
+

--- a/source/org/zfin/figure/repository/FigureRepository.java
+++ b/source/org/zfin/figure/repository/FigureRepository.java
@@ -18,5 +18,7 @@ public interface FigureRepository {
 
     List<Image> getImages(List<String> imageIDs);
 
+    List<Image> getAllImagesWithFigures();
+
     List<Image> getRecentlyCuratedImages();
 }

--- a/source/org/zfin/figure/repository/HibernateFigureRepository.java
+++ b/source/org/zfin/figure/repository/HibernateFigureRepository.java
@@ -27,13 +27,14 @@ import static org.zfin.framework.HibernateUtil.currentSession;
 public class HibernateFigureRepository implements FigureRepository {
     private static Logger logger = LogManager.getLogger(HibernateFigureRepository.class);
 
+    @Override
     public Figure getFigure(String zdbID) {
         Session session = currentSession();
         return session.get(Figure.class, zdbID);
     }
 
     /*  for multi-object hql transformations, check out HibernateExpressionRepository.getExperimentFigureStagesByGeneAndFish2 */
-
+    @Override
     public List<Person> getSubmitters(Publication publication, Clone probe) {
         List<Person> submitters = new ArrayList<>();
 
@@ -77,6 +78,7 @@ public class HibernateFigureRepository implements FigureRepository {
     }
 
 
+    @Override
     public List<Figure> getFiguresForDirectSubmissionPublication(Publication publication, Clone probe) {
         CriteriaBuilder criteriaBuilder = currentSession().getCriteriaBuilder();
         CriteriaQuery<Figure> query = criteriaBuilder.createQuery(Figure.class);
@@ -100,6 +102,7 @@ public class HibernateFigureRepository implements FigureRepository {
     }
 
 
+    @Override
     public List<Image> getImages(List<String> zdbIDs) {
         CriteriaBuilder criteriaBuilder = currentSession().getCriteriaBuilder();
         CriteriaQuery<Image> query = criteriaBuilder.createQuery(Image.class);
@@ -114,6 +117,22 @@ public class HibernateFigureRepository implements FigureRepository {
                 .toList();
     }
 
+    @Override
+    public List<Image> getAllImagesWithFigures() {
+        CriteriaBuilder criteriaBuilder = currentSession().getCriteriaBuilder();
+        CriteriaQuery<Image> query = criteriaBuilder.createQuery(Image.class);
+        Root<Image> imageRoot = query.from(Image.class);
+
+        Join<Image, Figure> figureJoin = imageRoot.join("figure");
+
+        query.orderBy(criteriaBuilder.desc(imageRoot.get("zdbID")));
+
+        List<Image> images = currentSession().createQuery(query).getResultList();
+
+        return images;
+    }
+
+    @Override
     public List<Image> getRecentlyCuratedImages() {
         String hql = """
                 select distinct image 

--- a/source/org/zfin/figure/service/ImageThumbnailFixTask.java
+++ b/source/org/zfin/figure/service/ImageThumbnailFixTask.java
@@ -1,0 +1,108 @@
+package org.zfin.figure.service;
+
+
+import org.apache.commons.lang3.StringUtils;
+import org.zfin.expression.Image;
+import org.zfin.figure.repository.FigureRepository;
+import org.zfin.ontology.datatransfer.AbstractScriptWrapper;
+import org.zfin.properties.ZfinPropertiesEnum;
+import org.zfin.repository.RepositoryFactory;
+
+import java.io.*;
+import java.util.*;
+
+public class ImageThumbnailFixTask extends AbstractScriptWrapper {
+    private boolean dryRun = true;
+    private int imageCount = 0;
+    private int imageMissingOriginalCount = 0;
+    private int imageMissingThumbnailCount = 0;
+    private int imageMissingMediumCount = 0;
+
+
+    public static void main(String[] args) throws IOException {
+        ImageThumbnailFixTask task = new ImageThumbnailFixTask();
+        task.runTask();
+        System.exit(0);
+    }
+
+    public void runTask() throws IOException {
+        initAll();
+        initDryRun();
+
+        if (dryRun) {
+            System.out.println("Dry run.  No changes will be made. Set RUN_IMAGE_FIXES environment variable, or runImageFixes property to run.");
+        } else {
+            System.out.println("Executing changes with imagemagick.");
+        }
+
+        FigureRepository figureRepository = RepositoryFactory.getFigureRepository();
+        List<Image> images = figureRepository.getAllImagesWithFigures();
+
+        LOG.info("Found " + images.size() + " images with figures.");
+        imageCount = images.size();
+
+        runFixesForImagesMissingThumbnails(images);
+        printResults();
+
+    }
+
+    private void initDryRun() {
+        String RUN_IMAGE_FIXES = System.getenv("RUN_IMAGE_FIXES");
+        if (StringUtils.isNotEmpty(RUN_IMAGE_FIXES)) {
+            dryRun = false;
+        }
+        if (StringUtils.isNotEmpty(System.getProperty("runImageFixes"))) {
+            dryRun = false;
+        }
+    }
+
+    private void runFixesForImagesMissingThumbnails(List<Image> images) throws IOException {
+        for (Image image : images) {
+            String thumbnail = image.getThumbnail();
+            String fullSizeImagePath = ZfinPropertiesEnum.LOADUP_FULL_PATH + File.separator + image.getImageFilename();
+
+            boolean fullImageExists = new File(fullSizeImagePath).exists();
+            if (!fullImageExists) {
+                System.out.println("Full size image does not exist: " + fullSizeImagePath);
+                imageMissingOriginalCount++;
+                continue;
+            }
+
+            //thumbnail
+            String destinationPath = ZfinPropertiesEnum.LOADUP_FULL_PATH + File.separator + thumbnail;
+            boolean fileExists = new File(destinationPath).exists();
+            if (!fileExists) {
+                String cmd = ImageService.convertImageToThumbnail(fullSizeImagePath, destinationPath, dryRun);
+                imageMissingThumbnailCount++;
+                if (dryRun) {
+                    System.out.println("Preview command: " + cmd);
+                } else {
+                    System.out.println("Ran command: " + cmd);
+                }
+            }
+
+            //medium
+            String medium = image.getMedium();
+            destinationPath = ZfinPropertiesEnum.LOADUP_FULL_PATH + File.separator + medium;
+            fileExists = new File(destinationPath).exists();
+            if (!fileExists) {
+                String cmd = ImageService.convertImageToMedium(fullSizeImagePath, destinationPath, dryRun);
+                imageMissingMediumCount++;
+                if (dryRun) {
+                    System.out.println("Preview command: " + cmd);
+                } else {
+                    System.out.println("Ran command: " + cmd);
+                }
+            }
+        }
+    }
+
+    private void printResults() {
+        System.out.println("Image count: " + imageCount);
+        System.out.println("Image missing original count: " + imageMissingOriginalCount);
+        System.out.println("Image missing thumbnail count: " + imageMissingThumbnailCount);
+        System.out.println("Image missing medium count: " + imageMissingMediumCount);
+    }
+
+}
+


### PR DESCRIPTION
Add a gradle task that fixes missing image thumbnails by converting full-size images to thumbnails and medium images. It retrieves a list of all images associated with figures, checks for missing thumbnails and mediums, and performs the necessary imagemagick command if required.