### PR TITLE
ZFIN-8648: Update logic for use_refseq_match 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,13 @@ task loadDatabase() {
             ignoreExitValue = true
             commandLine "bash", "-c", "echo 'vacuum (analyze)' | psql -v ON_ERROR_STOP=1 $dbname"
         }
+        exec {
+            // do an "upsert" in the developer_data table to record the time of the last loaddb
+            ignoreExitValue = true
+            commandLine "bash", "-c", "echo \$'insert into developer_data (dd_key, dd_value)" +
+                    " values (\\'loaddb completed\\', \\'$unloadPath\\') ON CONFLICT (dd_key) " +
+                    "DO UPDATE SET dd_value = EXCLUDED.dd_value;' | psql -v ON_ERROR_STOP=1 $dbname"
+        }
 
     }
 }

--- a/buildfiles/jenkins.xml
+++ b/buildfiles/jenkins.xml
@@ -450,12 +450,14 @@
             <arg value="start"/>
         </exec>
     </target>
+    <target name="jenkins-start" description="Alias for start-jenkins" depends="start-jenkins"></target>
 
     <target name="stop-jenkins" depends="create-jenkins-symlink" description="Stop Jenkins ">
         <exec executable="${jenkins}/jenkins.sh">
             <arg value="stop"/>
         </exec>
     </target>
+    <target name="jenkins-stop" description="Alias for stop-jenkins" depends="stop-jenkins"></target>
 
     <target name="kill-jenkins" depends="create-jenkins-symlink" description="Stop Jenkins ">
         <exec executable="${jenkins}/jenkins.sh">
@@ -468,6 +470,7 @@
             <arg value="restart"/>
         </exec>
     </target>
+    <target name="jenkins-restart" description="Alias for restart-jenkins" depends="restart-jenkins"></target>
 
     <target name="pid-jenkins" description="Display the PID of Jenkins server">
         <loadfile property="jenkins-pid" srcFile="${JENKINS_HOME}/jenkins.pid"/>

--- a/buildfiles/solr-ant.xml
+++ b/buildfiles/solr-ant.xml
@@ -219,6 +219,7 @@
     <target name="start-solr" description="Start up Solr"
         depends="start-solr-docker,start-solr-systemctl">
     </target>
+    <target name="solr-start" description="Alias for start-solr" depends="start-solr"></target>
 
     <target name="start-solr-docker" description="Start up Solr " if="isDocker">
         <echo message="Source: ${solr}"/>
@@ -243,6 +244,7 @@
     <target name="stop-solr" description="Stop Solr"
         depends="stop-solr-docker,stop-solr-systemctl">
     </target>
+    <target name="solr-stop" description="Alias for stop-solr" depends="stop-solr"></target>
 
     <target name="stop-solr-docker" description="Stop Solr " if="isDocker">
         <exec executable="/usr/bin/docker">
@@ -265,6 +267,7 @@
     <target name="restart-solr" description="Restart Solr"
         depends="restart-solr-docker,restart-solr-systemctl">
     </target>
+    <target name="solr-restart" description="Alias for restart-solr" depends="restart-solr"></target>
 
     <target name="restart-solr-docker" description="Restart Solr" if="isDocker">
         <exec executable="/usr/bin/docker">

--- a/buildfiles/tomcat.xml
+++ b/buildfiles/tomcat.xml
@@ -66,6 +66,9 @@
     <target name="tomcat-start" depends="mutant-tomcat-start,informix-zfishweb-tomcat-start,docker-tomcat-start"
             description="Starts tomcat by calling all tomcat stop targets"/>
 
+    <!-- Aliases for start and stop -->
+    <target name="start-tomcat" depends="tomcat-start" description="Alias"></target>
+    <target name="stop-tomcat" depends="tomcat-stop" description="Alias"></target>
 
     <target name="tomcat-debug-start" description="Starts tomcat in debug mode">
         <exec executable="${tomcat-script-mutant}">
@@ -87,6 +90,7 @@
             <arg value="${CATALINA_BASE}/logs/catalina.out"/>
         </exec>
     </target>
+    <target name="tomcat-tail" depends="tail-tomcat" description="Alias"></target>
 
     <target name="tail-connections" description="tail -f on db-connection-pool-monitor.txt file">
         <exec executable="tail">
@@ -126,6 +130,7 @@
     <target name="tomcat-debug-restart" depends="tomcat-debug-stop,tomcat-debug-start"
             description="Restarts tomcat in debug mode"/>
     <target name="restart" depends="tomcat-restart" description="Restarts tomcat for the appropriate environment"/>
+    <target name="restart-tomcat" depends="tomcat-restart" description="Alias"/>
     <target name="debug-restart" depends="tomcat-debug-restart" description="Restarts tomcat in debug mode"/>
 
     <!-- an alias to create-mutant-instance with a more explanatory name -->

--- a/server_apps/DB_maintenance/build.xml
+++ b/server_apps/DB_maintenance/build.xml
@@ -268,6 +268,12 @@
     </target>
 
     <target name="regenerate-webhost-curated-databases" description="">
+        <echo message="Regenerate webhost curated databases"/>
+        <echo message="main class: org.zfin.sequence.blast.RegenerateWebHostCuratedDatabasesJob"/>
+        <echo message="arg1: ${web-inf.dir}/zfin.properties"/>
+        <echo message="arg2: ${validateData}/report_data"/>
+        <echo message="arg3: ${jobName}"/>
+
         <java classname="org.zfin.sequence.blast.RegenerateWebHostCuratedDatabasesJob" fork="yes"
               classpathref="extended.classpath"
               failonerror="true">

--- a/server_apps/data_transfer/SWISS-PROT/ProblemFileUtil.pm
+++ b/server_apps/data_transfer/SWISS-PROT/ProblemFileUtil.pm
@@ -1,0 +1,70 @@
+#!/opt/zfin/bin/perl
+package ProblemFileUtil;
+
+use strict;
+use MIME::Lite;
+use DBI;
+use Exporter 'import';
+
+our @EXPORT_OK = qw(getAllExistingUniprotRecordsByAccession);
+
+my %global_cache = ();
+
+sub cache_uniprot_entries {
+    if (%global_cache) {
+        return;
+    }
+
+    my $dbname = $ENV{'DB_NAME'};
+    my $dbhost = $ENV{'PGHOST'};
+    my $username = "";
+    my $password = "";
+
+    ### open a handle on the db
+    my $dbh = DBI->connect("DBI:Pg:dbname=$dbname;host=$dbhost", $username, $password)
+        or die "Cannot connect to PostgreSQL database: $DBI::errstr\n";
+
+    #($pub_id, $gene_id, $dblink_id, $title, $marker, $accession, $dblink_info, $fdb_name)
+    my $sql = "WITH fullreport as (SELECT
+	recattrib_source_zdb_id as pub_id,
+	dblink_linked_recid as gene_id,
+	dl.dblink_zdb_id as dblink_id,
+	title as publication,
+	mrkr_abbrev as gene_abbrev,
+	dblink_acc_num as accession,
+	dblink_info,
+	fdb_db_name
+FROM
+	record_attribution ra
+	LEFT JOIN db_link dl ON ra.recattrib_data_zdb_id = dl.dblink_zdb_id
+	left join foreign_db_contains fc on dl.dblink_fdbcont_zdb_id = fc.fdbcont_zdb_id
+	left join foreign_db fdb on fc.fdbcont_fdb_db_id = fdb.fdb_db_pk_id
+	left join publication p on p.zdb_id = recattrib_source_zdb_id
+	left join marker m on dl.dblink_linked_recid = m.mrkr_zdb_id
+WHERE
+	fdb.fdb_db_name = 'UniProtKB')
+select count(pub_id) as pub_count, count(gene_id) as gene_count, string_agg(pub_id, ';') as pub_ids, string_agg(gene_id, ';') as gene_ids, string_agg(dblink_id, ';') as dblink_ids, string_agg(publication, ';') as pub_names, string_agg(gene_abbrev, ';') as gene_abbrevs, accession, string_agg(COALESCE(dblink_info,''), ';') as dblink_infos, fdb_db_name from fullreport
+group by accession, fdb_db_name
+order by count(gene_id) desc, count(pub_id) desc";
+
+    my $sth = $dbh->prepare($sql);
+    $sth->execute();
+    while (my @row = $sth->fetchrow_array) {
+        my $acc = $row[7];
+
+        #check for array in cache
+        if (!exists($global_cache{$acc})) {
+            $global_cache{$acc} = \@row;
+        } else {
+            print "Second entry for $acc\n";
+            die;
+        }
+    }
+}
+
+sub getAllExistingUniprotRecordsByAccession {
+    cache_uniprot_entries();
+    return \%global_cache;
+}
+
+1;

--- a/server_apps/data_transfer/SWISS-PROT/README
+++ b/server_apps/data_transfer/SWISS-PROT/README
@@ -203,8 +203,8 @@ publication record the explains SWISS-PROT to GO translation table file
 ("ZDB-PUB-020723-1") or InterPro to GO translation table file 
 ("ZDB-PUB-020724-1"). All the other loaded records are attributed to an 
 internal publication record ("ZDB-PUB-020723-2") that explains the 
-SWISS-PROT loading process. These attribution facts are stored in the 
-record_attribution table.
+SWISS-PROT loading process -- replaced with (ZDB-PUB-230615-71).
+These attribution facts are stored in the record_attribution table.
   The reloading also need to take care of the information that are in the 
 unloading file, but already recorded in zfin. The unique zdb id of those
 records will be put into a temp table. The conflict loading will be avoid, 

--- a/server_apps/data_transfer/SWISS-PROT/clean_prob_files.pl
+++ b/server_apps/data_transfer/SWISS-PROT/clean_prob_files.pl
@@ -1,7 +1,9 @@
 #!/opt/zfin/bin/perl 
 
-# validate_prob_files.pl
-# quick check on prob files to see if the records already exist in our DB with other references
+# clean_prob_files.pl
+# Reduce clutter in problem files by removing entries that already
+# exist in the database with attribution to ZDB-PUB-220705-2.
+# Those have already been manually checked and are not problems.
 
 use strict;
 use warnings;
@@ -15,28 +17,25 @@ use ProblemFileUtil;
 my %global_cache = %{ProblemFileUtil->getAllExistingUniprotRecordsByAccession()};
 
 sub main {
-    open CSVOUT, ">validate_prob_files.csv" or die "Cannot open validate_prob_files.csv";
-    #print header
-    print CSVOUT "file,record,accession,exists already,pub_count,gene_count,pub_ids,gene_ids,dblink_ids,pub_names,gene_abbrevs,accession,dblink_infos,fdb_db_name\n";
-
     my $files = [1..10];
     foreach my $file (@$files) {
         my $filename = "prob$file";
-        validate_problem_files($filename);
+        rearrange_problem_files($filename);
     }
-
-    close CSVOUT;
 }
 
-sub validate_problem_files {
+sub rearrange_problem_files {
     my $filename = shift;
     my $record_count = 1;
     $/ = "\/\/\n"; #custom record separator
     open INPUT, $filename or die "Cannot open $filename";
+    open (OUTPUT, ">$filename.clean") ||  die "Cannot open $filename.clean : $!\n";
+
     foreach my $record (<INPUT>) {
         my $ac_line;
         my @ac = ();
         my $ac_count = 0;
+        my $ignore_record = 0;
 
         #split lines by newline
         my @lines = split /\n/, $record;
@@ -55,33 +54,49 @@ sub validate_problem_files {
 
                 $ac_count = @ac;
                 #check each AC line
-                check_acs(\@ac, $filename, $record_count);
+                $ignore_record = check_ac_exists_with_manual_curation(\@ac);
             }
         }
         if (!$ac_count) {
             #print "$filename: No AC lines found in record $record_count\n";
         }
         $record_count++;
+        if (!$ignore_record) {
+            print OUTPUT $record;
+        }
     }
+    close INPUT;
+    close OUTPUT;
+
+    #rename original file
+    rename $filename, "$filename.orig";
+    #rename clean file to original name
+    rename "$filename.clean", $filename;
+    #delete original file
+    unlink "$filename.orig";
 }
 
-sub check_acs {
+#check if any of the AC lines in the record already exist in the database
+#return 1 if any of the AC lines already exist (associated with a manually curated entry -- ZDB-PUB-220705-2)
+sub check_ac_exists_with_manual_curation {
 
     my @ac = @{$_[0]};
-    my $filename = $_[1];
-    my $record_count = $_[2];
 
+    # print "  $filename: '@ac' \n";
     foreach my $ac (@ac) {
         my $cache_hit_ref = $global_cache{$ac};
         if (!$cache_hit_ref) {
-            print CSVOUT "$filename,$record_count,$ac,NOT EXISTS\n";
             next;
         }
         my @cache_hit = @$cache_hit_ref;
-        #join array into string
-        my $line = join ',', @cache_hit;
-        print CSVOUT "$filename,$record_count,$ac,EXISTS,$line\n";
+        my $pub_ids = $cache_hit[2];
+
+        if ($pub_ids =~ /ZDB-PUB-220705-2/) {
+            # print "  $filename,$record_count,$ac,ALREADY EXISTS\n";
+            return 1;
+        }
     }
+    return 0;
 }
 
 main();

--- a/server_apps/data_transfer/SWISS-PROT/move_prob_files.pl
+++ b/server_apps/data_transfer/SWISS-PROT/move_prob_files.pl
@@ -1,0 +1,19 @@
+#!/opt/zfin/bin/perl 
+
+# move_prob_files.pl
+# Just rename the prob files to add .txt
+
+use strict;
+use warnings;
+
+sub main {
+    my $files = [1..10];
+    foreach my $file (@$files) {
+        my $filename = "prob$file";
+        my $dest = $filename . ".txt";
+        print "renaming $filename to $dest\n";
+        rename($filename, $dest);
+    }
+}
+
+main();

--- a/server_apps/data_transfer/SWISS-PROT/rearrange_prob_files.pl
+++ b/server_apps/data_transfer/SWISS-PROT/rearrange_prob_files.pl
@@ -1,0 +1,161 @@
+#!/opt/zfin/bin/perl 
+
+# rearrange_prob_files.pl
+# Put higher priority records at the top of the file
+# 1.  records that already exist in our DB
+# 2.  records with a ZFIN gene ID
+
+use strict;
+use warnings;
+use DBI;
+use POSIX;
+use FindBin;
+
+#import from package in this directory:
+use lib "$FindBin::Bin/";
+use ProblemFileUtil;
+my %global_cache = %{ProblemFileUtil->getAllExistingUniprotRecordsByAccession()};
+
+sub main {
+    my $files = [1..10];
+    foreach my $file (@$files) {
+        my $filename = "prob$file";
+        print "$filename\n";
+        rearrange_problem_files($filename);
+    }
+}
+
+sub rearrange_problem_files {
+    my $filename = shift;
+    my $record_count = 1;
+    open INPUT, $filename or die "Cannot open $filename";
+    open (OUTPUT, ">$filename.rclean") ||  die "Cannot open $filename.rclean : $!\n";
+
+    my @high_priority = (); #records that already exist in our DB and have a ZFIN gene ID
+    my @medium_high_priority = (); #records that already exist in our DB without a ZFIN gene ID
+    my @medium_priority = (); #records with a ZFIN gene ID
+    my @low_priority = (); #records without a ZFIN gene ID
+
+    # read the first five lines (header) into high priority queue
+    $/ = "\n";
+    for (my $i = 0; $i < 5; $i++) {
+        my $line = <INPUT>;
+        push @high_priority, $line;
+    }
+    push @high_priority, "#--------------------------------------------\n";
+
+    $/ = "\/\/\n"; #custom record separator
+    foreach my $record (<INPUT>) {
+        if ($record eq "#\n") {
+            next;
+        }
+        my $ac_line;
+        my @ac = ();
+        my $ac_count = 0;
+        my $already_exists_pubs = 0;
+        my $has_zfin_gene = 0;
+
+        #split lines by newline
+        my @lines = split /\n/, $record;
+
+        #check each line
+        foreach my $line (@lines) {
+            #check for ID line
+            if ($line =~ /^AC\s+(.*)/) {
+                $ac_line = $1;
+                @ac = split /;\s+/, $ac_line;
+
+                #remove trailing semicolon
+                foreach (@ac) {
+                    $_ =~ s/;$//;
+                }
+
+                $ac_count = @ac;
+                #check each AC line
+                $already_exists_pubs = check_ac_exists_in_database(\@ac);
+            }
+        }
+        if (!$ac_count) {
+            #print "$filename: No AC lines found in record $record_count\n";
+        }
+        $record_count++;
+
+        $has_zfin_gene = check_for_zfin_gene($record);
+        if ($has_zfin_gene || $already_exists_pubs) {
+            my $header = "     # ";
+            if ($has_zfin_gene) {
+                $header .= "HAS_ZDB_ID ($has_zfin_gene) ";
+            }
+            if ($already_exists_pubs) {
+                $header .= "ALREADY_EXISTS ($already_exists_pubs) ";
+            }
+            my @lines = split /\n/, $record;
+            my $line1 = shift(@lines);
+            $line1 =~ s/^\s+//;
+            $line1 .= $header;
+            unshift(@lines, $line1);
+            $record = join("\n", @lines) . "\n";
+        }
+
+        if ($already_exists_pubs && $has_zfin_gene) {
+            push @high_priority, $record;
+        } elsif ($already_exists_pubs) {
+            push @medium_high_priority, $record;
+        } elsif ($has_zfin_gene) {
+            push @medium_priority, $record;
+        } else {
+            push @low_priority, $record;
+        }
+    }
+
+    foreach my $record (@high_priority) {
+        print OUTPUT $record;
+    }
+    foreach my $record (@medium_high_priority) {
+        print OUTPUT $record;
+    }
+    foreach my $record (@medium_priority) {
+        print OUTPUT $record;
+    }
+    foreach my $record (@low_priority) {
+        print OUTPUT $record;
+    }
+
+    close INPUT;
+    close OUTPUT;
+
+    #rename original file
+    rename $filename, "$filename.rorig";
+    #rename clean file to original name
+    rename "$filename.rclean", $filename;
+    #delete original file
+    unlink "$filename.rorig";
+}
+
+#check if any of the AC lines in the record already exist in the database
+#return 1 if any of the AC lines already exist (associated with a manually curated entry -- ZDB-PUB-220705-2)
+sub check_ac_exists_in_database {
+
+    my @ac = @{$_[0]};
+
+    foreach my $ac (@ac) {
+        my $cache_hit_ref = $global_cache{$ac};
+        if (!$cache_hit_ref) {
+            next;
+        }
+        my @cache_hit = @$cache_hit_ref;
+        my $pub_ids = $cache_hit[2];
+        return $pub_ids;
+    }
+    return 0;
+}
+
+sub check_for_zfin_gene {
+    my $record = $_[0];
+    if ($record =~ /DR   ZFIN; (ZDB-.*)$/m) {
+        return $1;
+    }
+    return 0;
+}
+
+main();

--- a/server_apps/data_transfer/SWISS-PROT/runUniprotPreload.sh
+++ b/server_apps/data_transfer/SWISS-PROT/runUniprotPreload.sh
@@ -6,6 +6,8 @@
 # Use environment variable "SKIP_SLEEP" to not to sleep for 500 seconds at various parts
 # Use environment variable "ARCHIVE_ARTIFACTS" to to save a copy of all generated artifacts in subdirectory called archives/$TIMESTAMP
 # Use environment variable "SKIP_PRE_ZFIN_GEN" to skip the step of building pre_zfin.dat. Useful for troubleshooting if a pre_zfin.dat file is already in place.
+# Use environment variable "USE_LEGACY_LOGIC" to tell sp_check.pl to use the pre-refseq logic for matching
+
 # Flags are useful for being a good citizen and not putting too much strain on servers.
 #
 # Can run with those env vars in tcsh like so: (https://stackoverflow.com/questions/5946736/)

--- a/server_apps/data_transfer/SWISS-PROT/runUniprotPreload.sh
+++ b/server_apps/data_transfer/SWISS-PROT/runUniprotPreload.sh
@@ -36,6 +36,12 @@ echo "/bin/cat prob1 prob2 prob3 prob4 prob5 prob6 prob7 prob8 prob9 prob10 > al
 
 /bin/cat prob1 prob2 prob3 prob4 prob5 prob6 prob7 prob8 prob9 prob10 > allproblems.txt ;
 
+echo "problem files post processing " $(date "+%Y-%m-%d %H:%M:%S")
+./validate_prob_files.pl
+./clean_prob_files.pl
+./rearrange_prob_files.pl
+./move_prob_files.pl
+
 echo "run sp_match.pl manuallyCuratedUniProtIDs.txt " $(date "+%Y-%m-%d %H:%M:%S")
 
 ./sp_match.pl manuallyCuratedUniProtIDs.txt ;

--- a/server_apps/data_transfer/SWISS-PROT/sp_check.pl
+++ b/server_apps/data_transfer/SWISS-PROT/sp_check.pl
@@ -19,6 +19,11 @@
 # TODO: If a record has an embl id, but doesn't match anything, we should try a refseq match.
 #       Currently we only try a refseq match if there is no embl id at all
 
+# There are flags available to control the behavior of the script:
+#  USE_LEGACY_LOGIC - If set, use older logic without RefSeq matching, default is false
+# example usage:
+# ( setenv USE_LEGACY_LOGIC 1 ; perl sp_check.pl )
+
 use strict;
 use warnings;
 use DBI;
@@ -337,14 +342,13 @@ sub handleMissingEmblAndRefSeqRecord {
 
         $num_prob++;
         return 1;
-    } elsif (!$ENV{"USE_LEGACY_LOGIC"} && $record !~ /DR\s*EMBL;/ && $record !~ /DR\s*RefSeq;/) {
+    } elsif (!$ENV{"USE_LEGACY_LOGIC"} && $record !~ /DR\s+EMBL;\s+(\w+);\s+(\w+)\./ && $record !~ /DR\s*RefSeq;/) {
         # if no EMBL line
         file_append("prob7", $record);
         file_append("problemfile", $record);
-
         $num_prob++;
         return 1;
-    } elsif (!$ENV{"USE_LEGACY_LOGIC"} && $record !~ /DR\s*EMBL;/ && $record =~ /DR\s*RefSeq; (.*)/) {
+    } elsif (!$ENV{"USE_LEGACY_LOGIC"} && $record !~ /DR\s+EMBL;\s+(\w+);\s+(\w+)\./ && $record =~ /DR\s*RefSeq; (.*)/) {
         $use_refseq_match = 1;
     }
     return 0;

--- a/server_apps/data_transfer/SWISS-PROT/sp_delete.sql
+++ b/server_apps/data_transfer/SWISS-PROT/sp_delete.sql
@@ -12,13 +12,13 @@ begin work;
 	insert into pre_delete
 		select recattrib_data_zdb_id from record_attribution
 		where recattrib_source_zdb_id in 
-		   ('ZDB-PUB-020723-2','ZDB-PUB-020723-1','ZDB-PUB-020724-1','ZDB-PUB-031118-3');
+		   ('ZDB-PUB-230615-71','ZDB-PUB-020723-2','ZDB-PUB-020723-1','ZDB-PUB-020724-1','ZDB-PUB-031118-3');
 
 
 --!echo '//Delete from record_attribution records from SP load'
 	delete from record_attribution
 		where recattrib_source_zdb_id in 
-		  ('ZDB-PUB-020723-2','ZDB-PUB-020723-1','ZDB-PUB-020724-1','ZDB-PUB-031118-3');
+		  ('ZDB-PUB-230615-71','ZDB-PUB-020723-2','ZDB-PUB-020723-1','ZDB-PUB-020724-1','ZDB-PUB-031118-3');
 		  
 --!echo '//Take the records that have other sources from the delete list' 
 

--- a/server_apps/data_transfer/SWISS-PROT/sp_load.sql
+++ b/server_apps/data_transfer/SWISS-PROT/sp_load.sql
@@ -125,7 +125,7 @@ alter table tmp_uniprot_db_link_with_dups
 
 --!echo 'Attribute db links to the internal pub record'
 	insert into record_attribution (recattrib_data_zdb_id, recattrib_source_zdb_id)
-		select dblink_zdb_id, 'ZDB-PUB-020723-2'
+		select dblink_zdb_id, 'ZDB-PUB-230615-71'
 		  from tmp_uniprot_pre_db_link;
 --!echo '		into record_attribution'
 
@@ -465,7 +465,7 @@ and exists (Select 'x' from pre_marker_go_term_evidence
         );
         
         insert into tmp_uniprot_pre_external_note (p_extnote_note,p_extnote_data_zdb_id, p_extnote_source_zdb_id)
-                select nondupl_cc_note, dblink_zdb_id, 'ZDB-PUB-020723-2'
+                select nondupl_cc_note, dblink_zdb_id, 'ZDB-PUB-230615-71'
 	          from temporary_nondupl_mrkr_cc, db_link
 		 where nondupl_gene_zdb_id = dblink_linked_recid
 		   and nondupl_sp_acc_num  = dblink_acc_num

--- a/server_apps/data_transfer/SWISS-PROT/sp_load.sql
+++ b/server_apps/data_transfer/SWISS-PROT/sp_load.sql
@@ -15,6 +15,10 @@
 
 begin work;
 
+\echo 'Deleting from reference_protein';
+delete from reference_protein;
+
+
 --set pdqpriority 50;
 
 --the unloaded record if already in, only add zdb_id into record_attribution with SWISS_PROT source

--- a/server_apps/data_transfer/SWISS-PROT/validate_prob_files.pl
+++ b/server_apps/data_transfer/SWISS-PROT/validate_prob_files.pl
@@ -1,0 +1,137 @@
+#!/opt/zfin/bin/perl 
+
+# validate_prob_files.pl
+# quick check on prob files to see if the records already exist in our DB with other references
+
+use strict;
+use warnings;
+use DBI;
+use POSIX;
+
+my $dbname = $ENV{'DB_NAME'};
+my $dbhost = $ENV{'PGHOST'};
+my $username = "";
+my $password = "";
+
+### open a handle on the db
+my $dbh = DBI->connect("DBI:Pg:dbname=$dbname;host=$dbhost", $username, $password)
+    or die "Cannot connect to PostgreSQL database: $DBI::errstr\n";
+
+my %global_cache = ();
+
+sub main {
+
+    #print header
+    print "file,record,exists already,pub_count,gene_count,pub_ids,gene_ids,dblink_ids,pub_names,gene_abbrevs,accession,dblink_infos,fdb_db_name\n";
+
+    my $files = [1..10];
+    foreach my $file (@$files) {
+        my $filename = "prob$file";
+        # print "$filename\n";
+        check_file($filename);
+    }
+}
+
+sub check_file {
+    my $filename = shift;
+    my $record_count = 1;
+    $/ = "\/\/\n"; #custom record separator
+    open INPUT, $filename or die "Cannot open $filename";
+    foreach my $record (<INPUT>) {
+        my $ac_line;
+        my @ac = ();
+        my $ac_count = 0;
+
+        #split lines by newline
+        my @lines = split /\n/, $record;
+
+        #check each line
+        foreach my $line (@lines) {
+            #check for ID line
+            if ($line =~ /^AC\s+(.*)/) {
+                $ac_line = $1;
+                @ac = split /;\s+/, $ac_line;
+
+                #remove trailing semicolon
+                foreach (@ac) {
+                    $_ =~ s/;$//;
+                }
+
+                $ac_count = @ac;
+                #check each AC line
+                check_acs(\@ac, $filename, $record_count);
+            }
+        }
+        if (!$ac_count) {
+            #print "$filename: No AC lines found in record $record_count\n";
+        }
+        $record_count++;
+    }
+}
+
+sub cache_uniprot_entries {
+    if (%global_cache) {
+        return;
+    }
+
+    #($pub_id, $gene_id, $dblink_id, $title, $marker, $accession, $dblink_info, $fdb_name)
+    my $sql = "WITH fullreport as (SELECT
+	recattrib_source_zdb_id as pub_id,
+	dblink_linked_recid as gene_id,
+	dl.dblink_zdb_id as dblink_id,
+	title as publication,
+	mrkr_abbrev as gene_abbrev,
+	dblink_acc_num as accession,
+	dblink_info,
+	fdb_db_name
+FROM
+	record_attribution ra
+	LEFT JOIN db_link dl ON ra.recattrib_data_zdb_id = dl.dblink_zdb_id
+	left join foreign_db_contains fc on dl.dblink_fdbcont_zdb_id = fc.fdbcont_zdb_id
+	left join foreign_db fdb on fc.fdbcont_fdb_db_id = fdb.fdb_db_pk_id
+	left join publication p on p.zdb_id = recattrib_source_zdb_id
+	left join marker m on dl.dblink_linked_recid = m.mrkr_zdb_id
+WHERE
+	fdb.fdb_db_name = 'UniProtKB')
+select count(pub_id) as pub_count, count(gene_id) as gene_count, string_agg(pub_id, ';') as pub_ids, string_agg(gene_id, ';') as gene_ids, string_agg(dblink_id, ';') as dblink_ids, string_agg(publication, ';') as pub_names, string_agg(gene_abbrev, ';') as gene_abbrevs, accession, string_agg(COALESCE(dblink_info,''), ';') as dblink_infos, fdb_db_name from fullreport
+group by accession, fdb_db_name
+order by count(gene_id) desc, count(pub_id) desc";
+
+    my $sth = $dbh->prepare($sql);
+    $sth->execute();
+    while (my @row = $sth->fetchrow_array) {
+        my $acc = $row[7];
+
+        #check for array in cache
+        if (!exists($global_cache{$acc})) {
+            $global_cache{$acc} = \@row;
+        } else {
+            print "Second entry for $acc\n";
+            die;
+        }
+    }
+
+}
+
+sub check_acs {
+    cache_uniprot_entries();
+
+    my @ac = @{$_[0]};
+    my $filename = $_[1];
+    my $record_count = $_[2];
+
+    # print "  $filename: '@ac' \n";
+    foreach my $ac (@ac) {
+        my $cache_hit_ref = $global_cache{$ac};
+        if (!$cache_hit_ref) {
+            print "  $filename,$record_count,$ac,NOT EXISTS\n";
+            next;
+        }
+        my @cache_hit = @$cache_hit_ref;
+        #join array into string
+        my $line = join ',', @cache_hit;
+        print "  $filename,$record_count,$ac,EXISTS,$line\n";
+    }
+}
+
+main();

--- a/server_apps/jenkins/jobs/NCBI-Gene-Load_w/config.xml
+++ b/server_apps/jenkins/jobs/NCBI-Gene-Load_w/config.xml
@@ -3,7 +3,20 @@
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
-  <properties/>
+
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.BooleanParameterDefinition>
+          <name>LOAD_NCBI_ONE_WAY_GENES</name>
+          <description>Enable this flag to additionally add NCBI genes that have a link to ZFIN without an equivalent link back from ZFIN to NCBI.
+          These are validated by having a shared ensembl id.  See ZFIN-8517 for details.</description>
+          <defaultValue>false</defaultValue>
+        </hudson.model.BooleanParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+
   <scm class="hudson.scm.NullSCM"/>
   <canRoam>true</canRoam>
   <disabled>false</disabled>
@@ -23,7 +36,7 @@
   </builders>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>server_apps/data_transfer/NCBIGENE/report*,server_apps/data_transfer/NCBIGENE/log*,server_apps/data_transfer/NCBIGENE/*.unl,server_apps/data_transfer/NCBIGENE/*Log*,server_apps/data_transfer/NCBIGENE/debug*</artifacts>
+      <artifacts>server_apps/data_transfer/NCBIGENE/report*,server_apps/data_transfer/NCBIGENE/log*,server_apps/data_transfer/NCBIGENE/*.unl,server_apps/data_transfer/NCBIGENE/*Log*,server_apps/data_transfer/NCBIGENE/debug*,server_apps/data_transfer/NCBIGENE/*csv</artifacts>
       <latestOnly>false</latestOnly>
       <allowEmptyArchive>true</allowEmptyArchive>
     </hudson.tasks.ArtifactArchiver>

--- a/server_apps/jenkins/jobs/Uniprot-Preload/config.xml
+++ b/server_apps/jenkins/jobs/Uniprot-Preload/config.xml
@@ -50,7 +50,7 @@ SKIP_PRE_ZFIN_GEN=
     </builders>
     <publishers>
         <hudson.tasks.ArtifactArchiver>
-            <artifacts>server_apps/data_transfer/SWISS-PROT/ccnote,server_apps/data_transfer/SWISS-PROT/*.ontology,server_apps/data_transfer/SWISS-PROT/*2go,server_apps/data_transfer/SWISS-PROT/prob*,server_apps/data_transfer/SWISS-PROT/okfile,server_apps/data_transfer/SWISS-PROT/ok2file,server_apps/data_transfer/SWISS-PROT/pubmed_not_in_zfin,server_apps/data_transfer/SWISS-PROT/*.unl,server_apps/data_transfer/SWISS-PROT/*.txt,server_apps/data_transfer/SWISS-PROT/*.dat</artifacts>
+            <artifacts>server_apps/data_transfer/SWISS-PROT/ccnote,server_apps/data_transfer/SWISS-PROT/*.ontology,server_apps/data_transfer/SWISS-PROT/*2go,server_apps/data_transfer/SWISS-PROT/prob*,server_apps/data_transfer/SWISS-PROT/okfile,server_apps/data_transfer/SWISS-PROT/ok2file,server_apps/data_transfer/SWISS-PROT/pubmed_not_in_zfin,server_apps/data_transfer/SWISS-PROT/*.unl,server_apps/data_transfer/SWISS-PROT/*.txt,server_apps/data_transfer/SWISS-PROT/*.dat,server_apps/data_transfer/SWISS-PROT/*.csv</artifacts>
             <allowEmptyArchive>false</allowEmptyArchive>
             <onlyIfSuccessful>false</onlyIfSuccessful>
             <fingerprint>false</fingerprint>

--- a/server_apps/jenkins/jobs/Uniprot-Production-Load/config.xml
+++ b/server_apps/jenkins/jobs/Uniprot-Production-Load/config.xml
@@ -39,6 +39,15 @@ turn uses those files to copy to production !!</description>
       <latestOnly>false</latestOnly>
       <allowEmptyArchive>false</allowEmptyArchive>
     </hudson.tasks.ArtifactArchiver>
+    <hudson.tasks.BuildTrigger>
+      <childProjects>Load-Reference-Proteome</childProjects>
+      <threshold>
+        <name>FAILURE</name>
+        <ordinal>2</ordinal>
+        <color>RED</color>
+        <completeBuild>true</completeBuild>
+      </threshold>
+    </hudson.tasks.BuildTrigger>
     <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@2.35.1">
       <recipientList>${DB_OWNER}@zfin.org</recipientList>
       <configuredTriggers>

--- a/source/org/zfin/db/postGmakePostloaddb/1145/ZFIN-8625.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1145/ZFIN-8625.sql
@@ -17,12 +17,12 @@ ALTER TABLE public.developer_data ADD CONSTRAINT dd_key_unique UNIQUE (dd_key);
 
 -- last modified trigger function
 CREATE OR REPLACE FUNCTION developer_data_sync_modified_at()
-    RETURNS trigger AS $BODY$
+    RETURNS trigger AS '
 BEGIN
     NEW.dd_modified_at := NOW();
     RETURN NEW;
 END;
-$BODY$ LANGUAGE plpgsql;
+' LANGUAGE plpgsql;
 
 -- last modified trigger
 DROP TRIGGER IF EXISTS developer_data_sync_modified_at_trigger on developer_data;

--- a/source/org/zfin/db/postGmakePostloaddb/1145/ZFIN-8625.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1145/ZFIN-8625.sql
@@ -1,0 +1,35 @@
+--liquibase formatted sql
+--changeset rtaylor:ZFIN-8625.sql
+
+DROP TABLE IF EXISTS public.developer_data;
+
+CREATE TABLE public.developer_data (
+   dd_pk_id serial,
+   dd_key text,
+   dd_value text,
+   dd_created_at timestamp DEFAULT now(),
+   dd_modified_at timestamp DEFAULT now()
+);
+
+COMMENT ON TABLE public.developer_data IS 'This table is for keeping data that is useful for developers';
+ALTER TABLE public.developer_data ADD CONSTRAINT dd_key_unique UNIQUE (dd_key);
+
+
+-- last modified trigger function
+CREATE OR REPLACE FUNCTION developer_data_sync_modified_at()
+    RETURNS trigger AS $BODY$
+BEGIN
+    NEW.dd_modified_at := NOW();
+    RETURN NEW;
+END;
+$BODY$ LANGUAGE plpgsql;
+
+-- last modified trigger
+DROP TRIGGER IF EXISTS developer_data_sync_modified_at_trigger on developer_data;
+
+CREATE TRIGGER
+    developer_data_sync_modified_at_trigger
+    BEFORE UPDATE ON
+    developer_data
+    FOR EACH ROW EXECUTE PROCEDURE
+    developer_data_sync_modified_at();

--- a/source/org/zfin/db/postGmakePostloaddb/1145/db.changelog.master.xml
+++ b/source/org/zfin/db/postGmakePostloaddb/1145/db.changelog.master.xml
@@ -5,4 +5,5 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <include file="source/org/zfin/db/postGmakePostloaddb/1145/ZFIN-8522.sql" />
+    <include file="source/org/zfin/db/postGmakePostloaddb/1145/ZFIN-8625.sql" />
 </databaseChangeLog>


### PR DESCRIPTION
Update logic for use_refseq_match to account for lines like the following that do not match the regex for EMBL lines /^DR\s+EMBL;\s+(\w+);\s+(\w+)\./.

DR   EMBL; CABZ01117703; -; NOT_ANNOTATED_CDS; Genomic_DNA.

as opposed to the expected format:

DR   EMBL; BC063239; AAH63239.1; -; mRNA.

This seems like it was likely also a bug in the legacy code.

This was discovered as a result of Doug's testing here: https://zfin.atlassian.net/browse/ZFIN-8604?focusedCommentId=151827