### PR TITLE
ZFIN-8625: NCBI patch: Fix reference to undefined value

### DIFF
--- a/server_apps/data_transfer/NCBIGENE/NCBI_gene_load.pl
+++ b/server_apps/data_transfer/NCBIGENE/NCBI_gene_load.pl
@@ -3368,7 +3368,15 @@ sub reportAllLoadStatistics {
     $ctGenPeptWithMultipleZDBgeneAfterLoad = 0;
     foreach $GenPept (sort keys %GenPeptWithMultipleZDBgeneAfterLoad) {
         $ref_arrayZDBgeneIds = $GenPeptWithMultipleZDBgeneAfterLoad{$GenPept};
-        print STATS "$GenPept\t$GenPeptsToLoad{$GenPept}\t@$ref_arrayZDBgeneIds\n";
+
+        my $genPeptToLoad = "";
+        if(exists($GenPeptsToLoad{$GenPept})) {
+            $genPeptToLoad = $GenPeptsToLoad{$GenPept};
+        } else {
+            $genPeptToLoad = "[not in GenPeptsToLoad hash]";
+            print "ERROR - GenPept $GenPept not in GenPeptsToLoad hash\n";
+        }
+        print STATS "$GenPept\t$genPeptToLoad\t@$ref_arrayZDBgeneIds\n";
         $ctGenPeptWithMultipleZDBgeneAfterLoad++;
     }
     print STATS "-----------------------------------------\nTotal: $ctGenPeptWithMultipleZDBgeneAfterLoad\n\n\n";


### PR DESCRIPTION
On trunk, was generating an error due to an undefined value in $GenPeptsToLoad{$GenPept} (ERROR - GenPept ABC43274 not in GenPeptsToLoad hash)