### PR TITLE
ZFIN-8648: UniProt Problem File Parsing Patch

### DIFF
--- a/server_apps/data_transfer/SWISS-PROT/clean_prob_files.pl
+++ b/server_apps/data_transfer/SWISS-PROT/clean_prob_files.pl
@@ -20,13 +20,14 @@ sub main {
     my $files = [0..10];
     foreach my $file (@$files) {
         my $filename = "prob$file";
-        rearrange_problem_files($filename);
+        clean_problem_file($filename);
     }
 }
 
-sub rearrange_problem_files {
+sub clean_problem_file {
     my $filename = shift;
     my $record_count = 1;
+    my $is_reading_header = 1;
     $/ = "\/\/\n"; #custom record separator
     open INPUT, $filename or die "Cannot open $filename";
     open (OUTPUT, ">$filename.clean") ||  die "Cannot open $filename.clean : $!\n";
@@ -42,6 +43,14 @@ sub rearrange_problem_files {
 
         #check each line
         foreach my $line (@lines) {
+
+            #let the header pass through
+            if ($line =~ /^#.*/ && $is_reading_header) {
+                print OUTPUT "$line\n";
+                next;
+            }
+            $is_reading_header = 0;
+
             #check for ID line
             if ($line =~ /^AC\s+(.*)/) {
                 $ac_line = $1;

--- a/server_apps/data_transfer/SWISS-PROT/rearrange_prob_files.pl
+++ b/server_apps/data_transfer/SWISS-PROT/rearrange_prob_files.pl
@@ -46,9 +46,6 @@ sub rearrange_problem_files {
 
     $/ = "\/\/\n"; #custom record separator
     foreach my $record (<INPUT>) {
-        if ($record eq "#\n") {
-            next;
-        }
         my $ac_line;
         my @ac = ();
         my $ac_count = 0;
@@ -58,8 +55,14 @@ sub rearrange_problem_files {
         #split lines by newline
         my @lines = split /\n/, $record;
 
+        my $newRecord = "";
+
         #check each line
         foreach my $line (@lines) {
+            if ($line eq "#") {
+                next;
+            }
+
             #check for ID line
             if ($line =~ /^AC\s+(.*)/) {
                 $ac_line = $1;
@@ -74,10 +77,13 @@ sub rearrange_problem_files {
                 #check each AC line
                 $already_exists_pubs = check_ac_exists_in_database(\@ac);
             }
+            $newRecord .= "$line\n";
         }
         if (!$ac_count) {
             #print "$filename: No AC lines found in record $record_count\n";
         }
+
+        $record = $newRecord;
         $record_count++;
 
         $has_zfin_gene = check_for_zfin_gene($record);


### PR DESCRIPTION
Small tweak to the problem file post processing part.  The header parsing wasn't quite right.  The problem was that the header was included as part of the first record--so if the first record was removed, it would remove the header too.

Also added log files to keep a record of which entries are removed from the problem files (eg. prob8.removed.txt)