### PR TITLE
ZFIN-8722 patch: COLLATE issue

### DIFF
--- a/source/org/zfin/uniprot/NcbiMatchThroughEnsemblTask.java
+++ b/source/org/zfin/uniprot/NcbiMatchThroughEnsemblTask.java
@@ -354,13 +354,13 @@ public class NcbiMatchThroughEnsemblTask extends AbstractScriptWrapper {
                 dblinks,
                 publications
             ORDER BY
-                4 COLLATE "C" ASC, -- because some systems don't sort the same based on locale (examples: dre-mir-21-2 and dre-mir-212, see: https://stackoverflow.com/questions/22534484)
-                1,
-                2,
-                3,
-                5,
-                6,
-                7
+                symbol COLLATE "C" ASC, -- because some systems don't sort the same based on locale (examples: dre-mir-21-2 and dre-mir-212, see: https://stackoverflow.com/questions/22534484)
+                ncbi_id,
+                zdb_id,
+                ensembl_id,
+                dblinks,
+                publications,
+                rna_accessions
             """;
         List<Object[]> results = session.createSQLQuery(query).list();
 


### PR DESCRIPTION
on trunk, postgresql did not like using column numbers in the order by clause in combination with "COLLATE".
on cell, this did work.