### PR TITLE
ZFIN-8720: fix superscript issue in safari

### DIFF
--- a/home/css/zfin.css
+++ b/home/css/zfin.css
@@ -866,11 +866,11 @@ ul.comma-separated {
 }
 
 .comma-separated > li:last-child::after {
-    content: "";
+    content: " ";
 }
 
 .comma-separated > li.no-comma::after {
-    content: "";
+    content: " ";
 }
 
 .list-unstyled {


### PR DESCRIPTION
Fix for issue with safari (and only some versions of safari) occasionally superscripting (or appearing to superscript) the last element of a comma separated list.