### PR TITLE
ZFIN-8351: deadlock updates

### DIFF
--- a/lib/DB_functions/Regen_genox/regen_genofig_finish.sql
+++ b/lib/DB_functions/Regen_genox/regen_genofig_finish.sql
@@ -1,6 +1,6 @@
 create or replace function regen_genofig_finish(vUpdate boolean, pgId int8)
 returns text as $regen_genofig_finish$
-
+ declare genotype_figure_fast_search_rename_to text;
  begin 
    if (vUpdate != 't') then
 
@@ -72,8 +72,34 @@ returns text as $regen_genofig_finish$
 
         -- Make changes public for genotype_figure_fast_search_new
       --let errorHint = "drop genotype_figure_fast_search table ";
-      
-     drop table if exists genotype_figure_fast_search;
+
+    -- if table exists, do the following
+
+
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'genotype_figure_fast_search' AND table_schema = 'public') THEN
+        -- Set the new table name with the current timestamp
+        genotype_figure_fast_search_rename_to := 'genotype_figure_fast_search_old_' || to_char(now(), 'YYYY_MM_DD_HH24_MI_SS_MS');
+
+        -- Use EXECUTE to run dynamic SQL
+        EXECUTE 'ALTER TABLE genotype_figure_fast_search RENAME TO ' || genotype_figure_fast_search_rename_to;
+        EXECUTE 'TRUNCATE ' || genotype_figure_fast_search_rename_to;
+--         EXECUTE 'DROP TABLE ' || genotype_figure_fast_search_rename_to;
+
+        execute 'alter index genotype_figure_fast_search_geno_zdb_id_foreign_key_index
+            rename to ' || genotype_figure_fast_search_rename_to || '_geno_zdb_id_foreign_key_index';
+        execute 'alter index genotype_figure_fast_search_fig_zdb_id_foreign_key_index
+            rename to ' || genotype_figure_fast_search_rename_to || '_fig_zdb_id_foreign_key_index';
+        execute 'alter index genotype_figure_fast_search_morph_zdb_id_foreign_key_index
+            rename to ' || genotype_figure_fast_search_rename_to || '_morph_zdb_id_foreign_key_index';
+        execute 'alter index genotype_figure_fast_search_fish_zdb_id_foreign_key_index
+            rename to ' || genotype_figure_fast_search_rename_to || '_fish_zdb_id_foreign_key_index';
+        execute 'alter index genotype_figure_fast_search_pg_id_foreign_key_index
+            rename to ' || genotype_figure_fast_search_rename_to || '_pg_id_foreign_key_index';
+        execute 'alter index genotype_figure_fast_search_psg_id_foreign_key_index
+            rename to ' || genotype_figure_fast_search_rename_to || '_psg_id_foreign_key_index';
+
+    END IF;
+
 
       --let errorHint = "rename table gffs";
      alter table  genotype_figure_fast_search_new rename to genotype_figure_fast_search;

--- a/lib/DB_functions/Regen_genox/regen_genofig_finish_cleanup.sql
+++ b/lib/DB_functions/Regen_genox/regen_genofig_finish_cleanup.sql
@@ -1,0 +1,33 @@
+create or replace function regen_genofig_finish_cleanup()
+returns text as $BODY$
+DECLARE
+    table_name text;
+    index_name text;
+    result text;
+BEGIN
+    result := 'indexes dropped: ';
+
+    FOR index_name in (SELECT indexname FROM pg_indexes
+                        WHERE indexname LIKE 'genotype_figure_fast_search_old_%'
+                        AND schemaname = 'public')
+    LOOP
+        raise notice 'dropping index %', index_name;
+        EXECUTE 'DROP INDEX IF EXISTS ' || index_name;
+        result := result || ' ' || index_name;
+    END LOOP;
+
+    result := result || '; ';
+
+    result := result || ' ' ||  'tables dropped: ';
+    FOR table_name IN (SELECT tablename FROM pg_tables
+                       WHERE tablename LIKE 'genotype_figure_fast_search_old_%'
+                       AND schemaname = 'public')
+    LOOP
+        raise notice 'dropping table %', table_name;
+        EXECUTE 'DROP TABLE IF EXISTS ' || table_name;
+        result := result || ' ' || table_name;
+    END LOOP;
+
+    RETURN result;
+END;
+$BODY$ LANGUAGE plpgsql;

--- a/server_apps/DB_maintenance/facetedSearchIndexerRegenWrapper.sh
+++ b/server_apps/DB_maintenance/facetedSearchIndexerRegenWrapper.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+set -u
+set -x
+set -o pipefail
+
+main() {
+  cd $TARGETROOT/server_apps/DB_maintenance/warehouse && ./regenPhenotypeMart.sh
+  cd $TARGETROOT/server_apps/DB_maintenance/warehouse && ./regenExpressionMart.sh
+  cd $TARGETROOT/server_apps/DB_maintenance && ./regen.sh
+}
+
+# Set up a trap to catch errors and exit
+handle_error() {
+    echo "PROBLEM ENCOUNTERED"
+    echo "TODO: Add error handling here if we need any"
+}
+trap handle_error EXIT
+
+# Call the main function
+main
+
+# Reset the trap so it won't trigger on a normal exit
+trap - EXIT

--- a/server_apps/DB_maintenance/warehouse/regenPhenotypeMartCleanup.sh
+++ b/server_apps/DB_maintenance/warehouse/regenPhenotypeMartCleanup.sh
@@ -1,0 +1,11 @@
+#!/bin/tcsh
+
+echo "start regen_genofig_finish_cleanup()";
+echo "select regen_genofig_finish_cleanup();" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DBNAME;
+if ($? != 0) then
+   echo "regen_genofig_finish_cleanup failed";
+exit 1;
+endif
+
+date;
+echo "done with regen_genofig_finish_cleanup()";

--- a/server_apps/jenkins/jobs/Index-Faceted-Search_d/config.xml
+++ b/server_apps/jenkins/jobs/Index-Faceted-Search_d/config.xml
@@ -17,15 +17,9 @@
   <concurrentBuild>false</concurrentBuild>
   <customWorkspace>$SOURCEROOT</customWorkspace>
   <builders>
-     <hudson.tasks.Shell>
-      <command>cd $TARGETROOT/server_apps/DB_maintenance/warehouse &amp;&amp; ./regenPhenotypeMart.sh </command>
-    </hudson.tasks.Shell>
     <hudson.tasks.Shell>
-      <command>cd $TARGETROOT/server_apps/DB_maintenance/warehouse &amp;&amp; ./regenExpressionMart.sh </command>
+      <command>cd $TARGETROOT/server_apps/DB_maintenance &amp;&amp; ./facetedSearchIndexerRegenWrapper.sh </command>
     </hudson.tasks.Shell>
-  <hudson.tasks.Shell>
-      <command>cd $TARGETROOT/server_apps/DB_maintenance &amp;&amp; ./regen.sh </command>
- </hudson.tasks.Shell>
     <hudson.tasks.Shell>
       <command>cd $SOURCEROOT</command>
     </hudson.tasks.Shell>
@@ -37,6 +31,9 @@
       <targets>cleanup-solr-backup-files</targets>
       <buildFile>$SOURCEROOT/build.xml</buildFile>
     </hudson.tasks.Ant>
+    <hudson.tasks.Shell>
+      <command>cd $TARGETROOT/server_apps/DB_maintenance/warehouse &amp;&amp; ./regenPhenotypeMartCleanup.sh</command>
+    </hudson.tasks.Shell>
   </builders>
   <publishers>
     <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@2.35.1">


### PR DESCRIPTION
Since the deadlock always occurs upon trying to delete genotype_figure_fast_search, this code avoids dropping the table and instead renames it and its indexes.

The renamed version of the table is later be deleted by regenPhenotypeMartCleanup.sh