### PR TITLE
Release 1147 - ZFIN-8351: deadlock updates (combined commits)

### DIFF
--- a/lib/DB_functions/Regen_genox/regen_cleanup_renamed_tables.sql
+++ b/lib/DB_functions/Regen_genox/regen_cleanup_renamed_tables.sql
@@ -1,0 +1,41 @@
+-- call this method to clean up tables and indexes that were renamed by the regen process
+create or replace function regen_cleanup_renamed_tables(table_prefix varchar)
+    returns text as $BODY$
+DECLARE
+    table_name text;
+    index_name text;
+    result text;
+BEGIN
+
+    --if table_prefix doesn't contain _fast_search_old_ then it's not a renamed table
+    if (table_prefix not like '%_fast_search_old_%') then
+        return 'this function should only be used to clean up tables named like ..._fast_search_old_...';
+    end if;
+
+
+    result := 'indexes dropped: ';
+
+    FOR index_name in (SELECT indexname FROM pg_indexes
+                       WHERE indexname LIKE table_prefix || '%'
+                         AND schemaname = 'public')
+        LOOP
+            raise notice 'dropping index %', index_name;
+            EXECUTE 'DROP INDEX IF EXISTS ' || index_name;
+            result := result || ' ' || index_name;
+        END LOOP;
+
+    result := result || '; ';
+
+    result := result || ' ' ||  'tables dropped: ';
+    FOR table_name IN (SELECT tablename FROM pg_tables
+                       WHERE tablename LIKE table_prefix || '%'
+                         AND schemaname = 'public')
+        LOOP
+            raise notice 'dropping table %', table_name;
+            EXECUTE 'DROP TABLE IF EXISTS ' || table_name;
+            result := result || ' ' || table_name;
+        END LOOP;
+
+    RETURN result;
+END;
+$BODY$ LANGUAGE plpgsql;

--- a/lib/DB_functions/Regen_genox/regen_genofig_finish.sql
+++ b/lib/DB_functions/Regen_genox/regen_genofig_finish.sql
@@ -78,7 +78,11 @@ returns text as $regen_genofig_finish$
 
     IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'genotype_figure_fast_search' AND table_schema = 'public') THEN
         -- Set the new table name with the current timestamp
-        genotype_figure_fast_search_rename_to := 'genotype_figure_fast_search_old_' || to_char(now(), 'YYYY_MM_DD_HH24_MI_SS_MS');
+        genotype_figure_fast_search_rename_to := 'genotype_figure_fast_search_old_'  || to_char(now(), 'YYMMDDHH24MI');
+
+        -- append 4 random characters
+        genotype_figure_fast_search_rename_to := genotype_figure_fast_search_rename_to || '_' || substring(md5(random()::text), 1, 4);
+
 
         -- Use EXECUTE to run dynamic SQL
         EXECUTE 'ALTER TABLE genotype_figure_fast_search RENAME TO ' || genotype_figure_fast_search_rename_to;

--- a/lib/DB_functions/Regen_genox/regen_genox_finish_marker.sql
+++ b/lib/DB_functions/Regen_genox/regen_genox_finish_marker.sql
@@ -47,7 +47,10 @@ begin
      -- let errorHint = "drop mutant_fast_search table ";
      IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'mutant_fast_search' AND table_schema = 'public') THEN
          -- Set the new table name with the current timestamp
-         mutant_fast_search_rename_to := 'mutant_fast_search_old_' || to_char(now(), 'YYYY_MM_DD_HH24_MI_SS_MS');
+         mutant_fast_search_rename_to := 'mutant_fast_search_old_' || to_char(now(), 'YYMMDDHH24MI');
+
+         -- append 4 random characters
+         mutant_fast_search_rename_to := mutant_fast_search_rename_to || '_' || substring(md5(random()::text), 1, 4);
 
          -- Use EXECUTE to run dynamic SQL
          EXECUTE 'ALTER TABLE mutant_fast_search RENAME TO ' || mutant_fast_search_rename_to;

--- a/lib/DB_functions/Regen_genox/regen_genox_finish_marker.sql
+++ b/lib/DB_functions/Regen_genox/regen_genox_finish_marker.sql
@@ -1,6 +1,6 @@
 create or replace function regen_genox_finish_marker ()
 returns text as $regen_genox_finish_marker$
-
+declare mutant_fast_search_rename_to text;
 begin
      insert into mutant_fast_search_new 
         ( mfs_data_zdb_id, mfs_genox_zdb_id )
@@ -45,7 +45,28 @@ begin
    
 
      -- let errorHint = "drop mutant_fast_search table ";
-      drop table mutant_fast_search;
+     IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'mutant_fast_search' AND table_schema = 'public') THEN
+         -- Set the new table name with the current timestamp
+         mutant_fast_search_rename_to := 'mutant_fast_search_old_' || to_char(now(), 'YYYY_MM_DD_HH24_MI_SS_MS');
+
+         -- Use EXECUTE to run dynamic SQL
+         EXECUTE 'ALTER TABLE mutant_fast_search RENAME TO ' || mutant_fast_search_rename_to;
+         EXECUTE 'TRUNCATE ' || mutant_fast_search_rename_to;
+--         EXECUTE 'DROP TABLE ' || mutant_fast_search_rename_to;
+
+        execute 'alter index mutant_fast_search_genox_zdb_id_foreign_key_index
+            rename to ' || mutant_fast_search_rename_to || '_genox_zdb_id_foreign_key_index';
+
+        execute 'alter index mutant_fast_search_data_zdb_id_foreign_key_index
+            rename to ' || mutant_fast_search_rename_to || '_data_zdb_id_foreign_key_index';
+
+        execute 'alter index mutant_fast_search_primary_key_index
+            rename to ' || mutant_fast_search_rename_to || '_primary_key_index';
+
+
+     END IF;
+
+
 
      -- let errorHint = "rename table ";
       alter table  mutant_fast_search_new rename to mutant_fast_search;

--- a/lib/DB_functions/regen_clean_expression/regen_clean_expression.sql
+++ b/lib/DB_functions/regen_clean_expression/regen_clean_expression.sql
@@ -105,7 +105,11 @@ DECLARE clean_expression_fast_search_rename_to text;
  
     IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'clean_expression_fast_search' AND table_schema = 'public') THEN
         -- Set the new table name with the current timestamp
-        clean_expression_fast_search_rename_to := 'clean_expression_fast_search_old_' || to_char(now(), 'YYYY_MM_DD_HH24_MI_SS_MS');
+        clean_expression_fast_search_rename_to := 'clean_expression_fast_search_old_' || to_char(now(), 'YYMMDDHH24MI');
+
+        -- append 4 random characters
+        clean_expression_fast_search_rename_to := clean_expression_fast_search_rename_to || '_' || substring(md5(random()::text), 1, 4);
+
 
         -- Use EXECUTE to run dynamic SQL
         EXECUTE 'ALTER TABLE clean_expression_fast_search RENAME TO ' || clean_expression_fast_search_rename_to;

--- a/server_apps/DB_maintenance/warehouse/regenPhenotypeMartCleanup.sh
+++ b/server_apps/DB_maintenance/warehouse/regenPhenotypeMartCleanup.sh
@@ -1,11 +1,16 @@
-#!/bin/tcsh
+#!/bin/bash
 
-echo "start regen_genofig_finish_cleanup()";
-echo "select regen_genofig_finish_cleanup();" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DBNAME;
-if ($? != 0) then
-   echo "regen_genofig_finish_cleanup failed";
-exit 1;
-endif
+echo "Dropping tables that were renamed earlier";
+for i in clean_expression mutant genotype_figure
+do
+    TABLE=${i}_fast_search_old_
+    echo "Cleaning $TABLE";
+    echo "regen_cleanup_renamed_tables('$TABLE')" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DBNAME;
+    if [ $? -ne 0 ]; then
+        echo "regen_cleanup_renamed_tables('$TABLE') failed";
+        exit 1;
+    fi
+done
 
 date;
-echo "done with regen_genofig_finish_cleanup()";
+echo "done with regen finish cleanup";


### PR DESCRIPTION
Since the deadlock always occurs upon trying to delete one of:

- genotype_figure_fast_search
- mutant_fast_search
- clean_expression_fast_search (actually, haven't seen this one cause deadlock yet)

this code avoids dropping the tables and instead renames them and their indexes. The renamed version of the table/indexes is later be deleted by regenPhenotypeMartCleanup.sh