### PR TITLE
Fix issues with noisy logger output when running gradle tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -787,7 +787,7 @@ dependencies {
     implementation files('home/WEB-INF/lib/commons-lang3-3.1.jar')
     // maven reference does not have version 1.0, so using the plain jar file
     //implementation group: 'org.nocrala.tools.texttablefmt', name: 'text-table-formatter', version: '1.2.4'
-    implementation files('lib/Java/hibernate-c3p0-5.6.5.Final.jar')
+    implementation files('home/WEB-INF/lib/hibernate-c3p0-5.6.5.Final.jar')
     implementation files('home/WEB-INF/lib/slf4j-api-1.7.26.jar')
     implementation files('home/WEB-INF/lib/jstl-1.1.jar')
     implementation files('home/WEB-INF/lib/jackson-core-2.13.0.rc1.jar')
@@ -797,9 +797,6 @@ dependencies {
     implementation files('home/WEB-INF/lib/log4j-core-2.17.1.jar')
     implementation files('home/WEB-INF/lib/log4j-web-2.17.1.jar')
     implementation files('home/WEB-INF/lib/log4j-slf4j-impl-2.13.3.jar')
-
-
-    implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.9.0'
 
     implementation group: 'net.sourceforge.htmlunit', name: 'htmlunit', version: '2.62.0'
     implementation group: 'commons-configuration', name: 'commons-configuration', version: '1.6'

--- a/home/WEB-INF/log4j2-debug.xml
+++ b/home/WEB-INF/log4j2-debug.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<Configuration>
+    <Appenders>
+        <RollingFile name="rollingFileAppender" fileName="${env:CATALINA_BASE}/logs/catalina.out"
+                     filePattern="${env:CATALINA_BASE}/logs/catalina.out.%i.log" filePermissions="rw-r--r--">
+            <PatternLayout pattern="%d [%t] %-5p %c{2} - %m%n"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="50MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d [%t] %-5p %c{2} - %m%n"/>
+        </Console>
+        <RollingFile name="rollingJSONFileAppender" fileName="${env:CATALINA_BASE}/logs/catalina.json"
+                     filePattern="${env:CATALINA_BASE}/logs/catalina.json.%i.log" filePermissions="rw-r--r--">
+            <JsonLayout complete="false" compact="false">
+                <KeyValuePair key="uri" value="$${ctx:uri:-}"/>
+                <KeyValuePair key="sessionID" value="$${ctx:sessionID:-}"/>
+                <KeyValuePair key="queryString" value="$${ctx:queryString:-}"/>
+                <KeyValuePair key="url" value="$${ctx:url:-}"/>
+                <KeyValuePair key="sessionID" value="$${ctx:sessionID:-}"/>
+                <KeyValuePair key="login" value="$${ctx:login:-}"/>
+                <KeyValuePair key="instance" value="$${env:INSTANCE:-unknown}"/>
+                <KeyValuePair key="date" value="$${date:yyyy-MM-dd HH:mm:ss}" />
+                <KeyValuePair key="cookie" value="$${ctx:cookie:-}" />
+            </JsonLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="50MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+        <!--
+                <Console name="ConsoleJSONAppender" target="SYSTEM_OUT">
+                    <JsonLayout complete="false" compact="false"/>
+                </Console>
+        -->
+    </Appenders>
+
+    <Loggers>
+        <Logger name="orm.deprecation" level="error"/>
+        <Logger name="org.hibernate" level="warn"/>
+        <Logger name="org.zfin.framework.HibernateSessionCreator" level="warn"/>
+        <Logger name="org.hibernate.SQL" level="warn"/>
+        <Logger name="org.hibernate.type" level="warn"/>
+        <Logger name="org.hibernate.orm.deprecation" level="error"/>
+        <Logger name="org.hibernate.engine.internal.StatefulPersistenceContext" level="error"/>
+        <Logger name="org.zfin" level="debug"/>
+        <Logger name="org.zfin.ontology.OntologySerializationService" level="info"/>
+        <Logger name="org.zfin.ontology.datatransfer.AbstractScriptWrapper" level="info" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Root level="warn">
+            <AppenderRef ref="rollingFileAppender"/>
+            <AppenderRef ref="rollingJSONFileAppender"/>
+            <AppenderRef ref="STDOUT"/>
+            <!--
+                        <AppenderRef ref="ConsoleJSONAppender"/>
+            -->
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
- remove redundant library log4j-slf4j-impl (2.9.0 & 2.13.3)
- fix path of hibernate-c3p0-5.6.5.Final.jar

Example log lines that are removed:

Removed via log4j2-debug.xml:
```
DEBUG framework.HibernateSessionCreator - Hibernate Mapping files being used:...
INFO  framework.HibernateSessionCreator - Loaded Annotated Class: org.zfin.publication.PublicationFileType
INFO  framework.HibernateSessionCreator - Loaded Annotated Class: org.zfin.publication.PublicationTrackingHistory
INFO  framework.HibernateSessionCreator - Loaded Annotated Class: org.zfin.publication.PublicationTrackingLocation
...
INFO  framework.HibernateSessionCreator - Loaded Annotated Class: org.zfin.zebrashare.ZebrashareEditor
```

Removed this logging by fixing issue with multiple log4j-slf4j libs: 
```
SLF4J: Class path contains multiple SLF4J bindings. SLF4J: Found binding in [jar:file:/net/ah-nas12-zfin.uoregon.edu/vol/users/rtaylor/dev/zfin/cell/zfin/home/WEB-INF/lib/log4j-slf4j-impl-2.13.3.jar!/org/slf4j/impl/StaticLoggerBinder.class] SLF4J: Found binding in [jar:file:/net/ah-nas12-zfin.uoregon.edu/vol/users/rtaylor/dev/zfin/cell/zfin/~/.gradle/caches/modules-2/files-2.1/org.apache.logging.log4j/log4j-slf4j-impl/2.9.0/1bd7f6b6ddbaf8a21d6c2b288d0cc5bc5b791cc0/log4j-slf4j-impl-2.9.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
```

Removed this logging by fixing path for c3p0 jar:
```
2023-09-05 17:43:45,039 [main] WARN  internal.ConnectionProviderInitiator - HHH000022: c3p0 properties were encountered, but the c3p0 provider class was not found on the classpath; these properties are going to be ignored. 2023-09-05 17:43:45,042 [main] WARN  connections.pooling - HHH10001002: Using Hibernate built-in connection pool (not for production use!)
```