### PR TITLE
ZFIN-8756: fix error message "files.forEach is not a function"

### DIFF
--- a/home/javascript/react/utils/file-input.js
+++ b/home/javascript/react/utils/file-input.js
@@ -25,7 +25,7 @@ function FileInput({ multiple, accept = '', onChange = () => {}, reRenderKey = '
         let errorMsg = '';
         const validType = accept.replace(/\*$/, '');
 
-        files.forEach(file => {
+        Array.from(files).forEach(file => {
             if (file.type.startsWith(validType)) {
                 validFiles.push(file);
             } else {


### PR DESCRIPTION
This fixes the console error that was complaining about "file.forEach". In this case "files" was not an Array, but a FileList so we have to convert it to an Array to use forEach.  Here are some screenshots to give context for what happens when trying to drag an image to the component:

<img width="414" alt="Screenshot 2023-10-30 at 10 23 38 AM" src="https://github.com/ZFIN/zfin/assets/90803397/a0febef5-ffd8-4a63-8edb-5a15e08ddddc">
<img width="416" alt="Screenshot 2023-10-30 at 10 24 35 AM" src="https://github.com/ZFIN/zfin/assets/90803397/918f1028-4121-44ce-87d5-84efb47edd95">
<img width="600" alt="Screenshot 2023-10-30 at 10 24 44 AM" src="https://github.com/ZFIN/zfin/assets/90803397/6868e782-b97a-4a32-a571-4ec3ef7c0de0">
<img width="923" alt="Screenshot 2023-10-30 at 10 24 10 AM" src="https://github.com/ZFIN/zfin/assets/90803397/9a020411-5d96-403a-9516-eb927d690599">
