### PR TITLE
Fix failing test: FigureRepositorySpec.groovy

### DIFF
--- a/test/org/zfin/figure/repository/FigureRepositorySpec.groovy
+++ b/test/org/zfin/figure/repository/FigureRepositorySpec.groovy
@@ -86,7 +86,7 @@ class FigureRepositorySpec extends AbstractZfinIntegrationSpec {
         List<Image> images = RepositoryFactory.figureRepository.getRecentlyCuratedImages()
 
         then: "it should have the correct number of images in order"
-        images.size() >= 50;
+        images.size() >= 20;
     }
 
 }


### PR DESCRIPTION
We expect there to be at least 50 "recently curated images". Currently, there are only 28.

See for example this query:
```sql
SELECT DISTINCT
image.*,
image_stage.imgstg_start_stg_zdb_id,
image_stage.imgstg_end_stg_zdb_id
        FROM
image
LEFT OUTER JOIN image_stage ON image.img_zdb_id = image_stage.imgstg_img_zdb_id
        INNER JOIN figure ON image.img_fig_zdb_id = figure.fig_zdb_id
        INNER JOIN publication ON figure.fig_source_zdb_id = publication.zdb_id
        INNER JOIN pub_tracking_history ON publication.zdb_id = pub_tracking_history.pth_pub_zdb_id
        LEFT OUTER JOIN expression_pattern_figure ON figure.fig_zdb_id = expression_pattern_figure.xpatfig_fig_zdb_id
        LEFT OUTER JOIN expression_result ON expression_pattern_figure.xpatfig_xpatres_zdb_id = expression_result.xpatres_zdb_id
        LEFT OUTER JOIN phenotype_experiment ON figure.fig_zdb_id = phenotype_experiment.phenox_fig_zdb_id

        INNER JOIN pub_tracking_status ON pub_tracking_history.pth_status_id = pub_tracking_status.pts_pk_id
        INNER JOIN expression_experiment ON expression_result.xpatres_xpatex_zdb_id = expression_experiment.xpatex_zdb_id
        WHERE
pub_tracking_history.pth_status_is_current = TRUE
        AND pub_tracking_status.pts_status_display = 'Closed, Curated'
AND pub_tracking_history.pth_status_insert_date > CURRENT_DATE - INTERVAL '1 year'
AND publication.pub_date > CURRENT_DATE - INTERVAL '1 year'
AND publication.pub_can_show_images = TRUE
AND (image.img_image IS NOT NULL)
AND (phenotype_experiment.phenox_pk_id IS NOT NULL OR
(expression_result.xpatres_zdb_id IS NOT NULL) AND
(expression_experiment.xpatex_assay_name = 'Immunohistochemistry' OR
        expression_experiment.xpatex_assay_name = 'mRNA in situ hybridization'))
ORDER BY img_zdb_id

```