### PR TITLE
UniProt-Diff-Load bugfix: $WORKSPACE is wrong

### DIFF
--- a/server_apps/jenkins/jobs/UniProt-Diff-Load/config.xml
+++ b/server_apps/jenkins/jobs/UniProt-Diff-Load/config.xml
@@ -37,11 +37,12 @@
       <command>
         <![CDATA[
 echo "WORKSPACE=$WORKSPACE"
+echo "PWD=$PWD"
 echo "UNIPROT_COMMIT_CHANGES=$UNIPROT_COMMIT_CHANGES"
-rm -f $WORKSPACE/uniprot_load_report.html $WORKSPACE/uniprot_context.json
+rm -f $PWD/uniprot_load_report.html $PWD/uniprot_context.json
+export UNIPROT_OUTPUT_REPORT_FILE="$PWD/uniprot_load_report.html"
+export UNIPROT_CONTEXT_FILE="$PWD/uniprot_context.json"
 cd $SOURCEROOT
-export UNIPROT_OUTPUT_REPORT_FILE="$WORKSPACE/uniprot_load_report.html"
-export UNIPROT_CONTEXT_FILE="$WORKSPACE/uniprot_context.json"
 gradle uniprotLoadTask
         ]]>
       </command>


### PR DESCRIPTION
On trunk, I discovered that the value we get from the $WORKSPACE variable does not match the actual workspace that jenkins is using.

This is apparent when viewing the console log:
```
Building in workspace /opt/zfin/www_homes/trunk/server_apps/jenkins/jenkins-home/jobs/UniProt-Diff-Load/workspace
[workspace] $ /bin/sh -xe /tmp/jenkins13438737710530707733.sh
+ echo WORKSPACE=/opt/zfin/source_roots/trunk/ZFIN_WWW
WORKSPACE=/opt/zfin/source_roots/trunk/ZFIN_WWW
```

Taken from: https://trunk.zfin.org/jobs/job/UniProt-Diff-Load/7/console