### PR TITLE
ZFIN-8966: BeanCompareService should ignore null->"" changes

### DIFF
--- a/source/org/zfin/profile/service/BeanCompareService.java
+++ b/source/org/zfin/profile/service/BeanCompareService.java
@@ -48,6 +48,13 @@ public class BeanCompareService {
             newField = (newField == null ? false : newField);
         }
 
+        //if both are null (or empty string), then they are equal
+        boolean oldFieldIsNull = oldField == null || (oldField instanceof String && StringUtils.isEmpty((String) oldField));
+        boolean newFieldIsNull = newField == null || (newField instanceof String && StringUtils.isEmpty((String) newField));
+        if (oldFieldIsNull && newFieldIsNull) {
+            return null;
+        }
+
         if (!Objects.equals(oldField, newField)) {
             beanFieldUpdate = new BeanFieldUpdate();
             if (oldField instanceof String oldFieldString) {


### PR DESCRIPTION
This fixes the issue we were seeing where lab PIs could not update their lab information. The reason was that they were submitting changes to their lab on the lab page. Since PIs don't have permission to change their lab prefix, the prefix field comes in as empty string (""). The BeanCompareService was comparing the old prefix field (null) to the new prefix field ("") and since they are different, it flagged the change.  However, since ZFIN-8946 added a step to transform the "to" field to null if it was an empty string, the BeanCompareService was returning an update object saying that prefix should change from null to null. That's already a bit weird, but you would expect it to result in a no-op down the line. However, the prefix handler in ProfileService does not expect a null value in the to field (see: https://github.com/zfin/zfin/blob/release-1150/source/org/zfin/profile/service/ProfileService.java#L215-L215 -- `beanFieldUpdate.getTo().toString`) and it threw a Null Pointer Exception.