### PR TITLE
ExternalNote hotfix: Looks like these external_notes are used after all

### DIFF
--- a/source/org/zfin/db/postGmakePostloaddb/1150/ZFIN-8797.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1150/ZFIN-8797.sql
@@ -14,9 +14,9 @@
 -- END COMMENTED OUT SECTION
 
 -- DELETE external notes instead
-DELETE FROM external_note
- WHERE extnote_source_zdb_id = 'ZDB-PUB-230615-71'
-   AND extnote_note_type IS NULL;
+-- DELETE FROM external_note
+--  WHERE extnote_source_zdb_id = 'ZDB-PUB-230615-71'
+--    AND extnote_note_type IS NULL;
 
 -- clean up ncbi loaded refseqs for uniprot release:
 -- these refseqs were moved to ZDB-GENE-100922-192


### PR DESCRIPTION
The GetGeneProducts method uses them. Deleting the external_notes loaded by UniProt load caused the MarkerRepositoryTest.getGeneProducts test to fail.

<img width="1506" alt="Screenshot 2023-12-18 at 11 20 18 AM" src="https://github.com/ZFIN/zfin/assets/90803397/815a788f-9e12-4c8f-b70f-7a0bad6c7416">

<img width="1503" alt="Screenshot 2023-12-18 at 11 20 32 AM" src="https://github.com/ZFIN/zfin/assets/90803397/baf5ef87-b2f4-45ca-94e0-24dd4db3d510">
