### PR TITLE
ZFIN-8937: Bugfix - fetching a FeatureTracking object without related Feature

### DIFF
--- a/source/org/zfin/feature/repository/FeatureRepository.java
+++ b/source/org/zfin/feature/repository/FeatureRepository.java
@@ -115,7 +115,7 @@ public interface FeatureRepository {
 
     List<Marker> getMarkersPresentForFeature(Feature feature);
 
-    FeatureTracking getFeatureTrackingByAbbreviation(String abbreviation);
+    boolean isExistingFeatureTrackingByAbbreviation(String abbreviation);
 
     TreeSet<String> getFeatureLG(Feature feat);
 

--- a/source/org/zfin/feature/repository/HibernateFeatureRepository.java
+++ b/source/org/zfin/feature/repository/HibernateFeatureRepository.java
@@ -536,7 +536,7 @@ public class HibernateFeatureRepository implements FeatureRepository {
      */
     private String getNextLineNumberForLabPrefixWithoutFeatureTrackingCollision(FeaturePrefix labPrefix) {
         Integer nextLine = getNextLineNumberIntegerForLabPrefix(labPrefix);
-        while(getFeatureTrackingByAbbreviation(labPrefix.getAbbreviation() + nextLine) != null) {
+        while(isExistingFeatureTrackingByAbbreviation(labPrefix.getAbbreviation() + nextLine)) {
             nextLine++;
         }
         return String.valueOf(nextLine);
@@ -798,12 +798,16 @@ public class HibernateFeatureRepository implements FeatureRepository {
         return (String) queryTracker.uniqueResult();
     }
 
+    /**
+     * Check if there exists an entry in the feature tracking table already for the given abbreviation
+     * @param abbreviation
+     * @return
+     */
     @Override
-    public FeatureTracking getFeatureTrackingByAbbreviation(String abbreviation) {
-        String hql = "from FeatureTracking where featTrackingFeatAbbrev = :abbrev";
-        Query<FeatureTracking> query = currentSession().createQuery(hql, FeatureTracking.class);
-        query.setParameter("abbrev", abbreviation);
-        return query.uniqueResult();
+    public boolean isExistingFeatureTrackingByAbbreviation(String abbreviation) {
+        String sql = "SELECT * FROM feature_tracking WHERE ft_feature_abbrev = :abbrev";
+        List results = currentSession().createNativeQuery(sql).setParameter("abbrev", abbreviation).list();
+        return !results.isEmpty();
     }
 
     public TreeSet<String> getFeatureLG(Feature feat) {

--- a/test/org/zfin/feature/FeatureTrackingTest.java
+++ b/test/org/zfin/feature/FeatureTrackingTest.java
@@ -24,8 +24,8 @@ public class FeatureTrackingTest extends AbstractDatabaseTest {
         int asNumber = Integer.parseInt(nextLine);
         assertTrue(asNumber > 3000);
 
-        FeatureTracking ft = getFeatureRepository().getFeatureTrackingByAbbreviation("zf" + nextLine);
-        assertNull(ft);
+        boolean exists = getFeatureRepository().isExistingFeatureTrackingByAbbreviation("zf" + nextLine);
+        assertFalse(exists);
     }
 
     @Test


### PR DESCRIPTION
Fixes corner case where Hibernate tries to load the FeatureTracking's related Feature but the Feature doesn't exist.