### PR TITLE
ZFIN-8950: Bugfix: Report summary fails on dry run

### DIFF
--- a/home/uniprot/secondary-load-report.html
+++ b/home/uniprot/secondary-load-report.html
@@ -403,6 +403,14 @@
                 `;
             }
 
+
+            if (!reportSummary) {
+                return html`<h2>Dry Run</h2>
+                <p>This report was generated as part of a dry-run. The before/after summary data is not captured for
+                dry runs.</p>
+                `;
+            }
+
             return html`
                     <h2>Summary</h2>
                     <p>Summary of the changes that will be made to the database (or have been made).</p>


### PR DESCRIPTION
Report summary fails when we do a dry run -- because we can't do a direct DB comparison of before and after. I added a check for this.