### PR TITLE
ZFIN-8986: Update marker relationships when renaming construct

### DIFF
--- a/home/WEB-INF/jsp/construct/construct-rename.jsp
+++ b/home/WEB-INF/jsp/construct/construct-rename.jsp
@@ -68,7 +68,14 @@
             "constructType": "Tg",
             "constructPrefix": "",
             "constructStoredName": "pth2#:TagRFP#Cassette#,#cryaa#:mCherry"
-        }
+        },
+        {
+            "constructID": "ZDB-TGCONSTRCT-190812-12",
+            "pubZdbID": "ZDB-PUB-190209-17",
+            "constructType": "Tg",
+            "constructPrefix": "BAC",
+            "constructStoredName": "cdh1#:cdh1#-#TagRFP#Cassette#,#cryaa#:Cerulean"
+        },
     ];
 
     changes.forEach(change => {

--- a/source/org/zfin/construct/ConstructComponent.java
+++ b/source/org/zfin/construct/ConstructComponent.java
@@ -39,7 +39,11 @@ public class ConstructComponent {
         TEXT_COMPONENT("text component"),
         TEXT_COMPONENT_("text component "),
         UNKNOWN_COMPONENT("unknown component"),
-        CODING_COMPONENT("coding component");
+        CODING_COMPONENT("coding component"),
+        PROMOTER_COMPONENT("promoter component"),
+        CODING_SEQUENCE_COMPONENT("coding sequence component"),
+        CASSETTE_DELIMITER("cassette delimiter"),
+        CONSTRUCT_WRAPPER_COMPONENT("construct wrapper component");
 
         private final String value;
 
@@ -50,6 +54,22 @@ public class ConstructComponent {
         public String toString() {
             return this.value;
         }
+
+
+        public static Type fromString(String text) {
+            if (text != null) {
+                for (Type b : Type.values()) {
+                    if (text.equals(b.value)) {
+                        return b;
+                    }
+                }
+            }
+            return UNKNOWN_COMPONENT; // Or null, based on how you want to handle unknown cases
+        }
+    }
+
+    public Type getComponentCategoryEnum() {
+        return Type.fromString(componentCategory);
     }
 
 }

--- a/source/org/zfin/construct/name/Cassette.java
+++ b/source/org/zfin/construct/name/Cassette.java
@@ -4,14 +4,17 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang.StringUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Data
 @NoArgsConstructor
 public class Cassette {
     public static final String COMPONENT_SEPARATOR = ":";
     private static final String STORED_COMPONENT_SEPARATOR = "#";
 
-    private Promoter promoter;
-    private Coding coding;
+    private Promoter promoter = new Promoter();
+    private Coding coding = new Coding();
     private int cassetteNumber;
 
     public Cassette (Promoter promoter, Coding coding) {
@@ -34,8 +37,13 @@ public class Cassette {
     }
 
     public String toString() {
-        return promoter.toString() +
-                COMPONENT_SEPARATOR +
-                coding.toString();
+        List<String> nameParts = new ArrayList<>();
+        if (StringUtils.isNotEmpty(promoter.toString())) {
+            nameParts.add(promoter.toString());
+        }
+        if (StringUtils.isNotEmpty(coding.toString())) {
+            nameParts.add(coding.toString());
+        }
+        return String.join(COMPONENT_SEPARATOR, nameParts);
     }
 }

--- a/source/org/zfin/construct/name/CassettesDiff.java
+++ b/source/org/zfin/construct/name/CassettesDiff.java
@@ -1,0 +1,45 @@
+ package org.zfin.construct.name;
+
+import lombok.Data;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class CassettesDiff {
+    private List<String> promoterMarkersAdded = new ArrayList<>();
+    private List<String> promoterMarkersRemoved = new ArrayList<>();
+    private List<String> codingMarkersAdded = new ArrayList<>();
+    private List<String> codingMarkersRemoved = new ArrayList<>();
+
+    public static CassettesDiff calculate(Cassettes before, Cassettes after) {
+        List<String> beforePromoterParts = new ArrayList<>();
+        before.getCassettes().forEach(cassette -> {
+            beforePromoterParts.addAll(cassette.getPromoter().getPromoterParts());
+        });
+
+        List<String> afterPromoterParts = new ArrayList<>();
+        after.getCassettes().forEach(cassette -> {
+            afterPromoterParts.addAll(cassette.getPromoter().getPromoterParts());
+        });
+
+        CassettesDiff diff = new CassettesDiff();
+        CollectionUtils.subtract(afterPromoterParts, beforePromoterParts).forEach(diff.getPromoterMarkersAdded()::add);
+        CollectionUtils.subtract(beforePromoterParts, afterPromoterParts).forEach(diff.getPromoterMarkersRemoved()::add);
+
+        List<String> beforeCodingParts = new ArrayList<>();
+        before.getCassettes().forEach(cassette -> {
+            beforeCodingParts.addAll(cassette.getCoding().getCodingParts());
+        });
+
+        List<String> afterCodingParts = new ArrayList<>();
+        after.getCassettes().forEach(cassette -> {
+            afterCodingParts.addAll(cassette.getCoding().getCodingParts());
+        });
+
+        CollectionUtils.subtract(afterCodingParts, beforeCodingParts).forEach(diff.getCodingMarkersAdded()::add);
+        CollectionUtils.subtract(beforeCodingParts, afterCodingParts).forEach(diff.getCodingMarkersRemoved()::add);
+        return diff;
+    }
+}

--- a/source/org/zfin/construct/name/Coding.java
+++ b/source/org/zfin/construct/name/Coding.java
@@ -37,4 +37,8 @@ public class Coding {
     public int size() {
         return codingParts.size();
     }
+
+    public void addCodingPart(String componentValue) {
+        codingParts.add(componentValue);
+    }
 }

--- a/source/org/zfin/construct/name/ConstructName.java
+++ b/source/org/zfin/construct/name/ConstructName.java
@@ -51,9 +51,9 @@ import static org.zfin.construct.presentation.ConstructComponentService.getTypeA
 @NoArgsConstructor
 public class ConstructName {
     private Marker.Type type;
-    private String prefix;
+    private String prefix = "";
 
-    private Cassettes cassettes;
+    private Cassettes cassettes = new Cassettes();
 
     public ConstructName(String typeAbbreviation, String prefix) {
         getConstructTypeEnumByConstructName(typeAbbreviation).ifPresent(this::setType);
@@ -88,12 +88,24 @@ public class ConstructName {
         return typeAbbr.get();
     }
 
+    public String getTypeAbbreviationOrEmpty() {
+        Optional<String> typeAbbr = getTypeAbbreviationFromType(type);
+        if (typeAbbr.isEmpty()) {
+            return "";
+        }
+        return typeAbbr.get();
+    }
+
     public String toString() {
-        return getTypeAbbreviation() +
+        return getTypeAbbreviationOrEmpty() +
                 prefix +
                 "(" +
                 cassettes.toString() +
                 ")";
+    }
+
+    public void addCassette(Cassette cassette) {
+        cassettes.add(cassette);
     }
 
     public void addCassette(Promoter promoter, Coding coding) {
@@ -102,5 +114,9 @@ public class ConstructName {
 
     public void setCassettesFromStoredName(String storedName) {
         cassettes = Cassettes.fromStoredName(storedName);
+    }
+
+    public void setTypeByAbbreviation(String componentValue) {
+        getConstructTypeEnumByConstructName(componentValue).ifPresent(this::setType);
     }
 }

--- a/source/org/zfin/construct/name/Promoter.java
+++ b/source/org/zfin/construct/name/Promoter.java
@@ -37,4 +37,8 @@ public class Promoter {
     public int size() {
         return promoterParts.size();
     }
+
+    public void addPromoterPart(String componentValue) {
+        promoterParts.add(componentValue);
+    }
 }

--- a/source/org/zfin/construct/repository/ConstructRepository.java
+++ b/source/org/zfin/construct/repository/ConstructRepository.java
@@ -21,6 +21,7 @@ public interface ConstructRepository {
     ConstructRelationship getConstructRelationshipByID(String zdbID);
     ConstructRelationship getConstructRelationship(ConstructCuration marker1, Marker marker2, ConstructRelationship.Type type);
     void addConstructRelationships(Set<Marker> promMarker, Set<Marker> codingMarker, ConstructCuration construct, String pubID);
+    void removeConstructRelationships(Set<Marker> promMarker, Set<Marker> codingMarker, ConstructCuration construct, String pubID);
     ConstructCuration getConstructByID(String zdbID);
     ConstructCuration getConstructByName(String conName);
     void createConstruct(ConstructCuration construct, Publication publication, Person loggedInUser);

--- a/test/org/zfin/sequence/blast/smoketest/BlastSmokeTest.java
+++ b/test/org/zfin/sequence/blast/smoketest/BlastSmokeTest.java
@@ -3,6 +3,7 @@ package org.zfin.sequence.blast.smoketest;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.*;
 import lombok.extern.log4j.Log4j2;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -45,6 +46,7 @@ public class BlastSmokeTest extends AbstractSmokeTest {
      * Get a recent crispr STR from the database. Query the blast form with the sequence of the STR.
      * Make sure it returns a results page that contains the STR in the results.
      */
+    @Ignore //This fails on TRUNK -> TODO: write a jenkins job to replace this test
     @Test
     public void testRecentSTR() {
         SequenceTargetingReagent str = getRecentCrisprSTR();

--- a/test/org/zfin/sequence/blast/smoketest/BlastSmokeTest.java
+++ b/test/org/zfin/sequence/blast/smoketest/BlastSmokeTest.java
@@ -3,7 +3,6 @@ package org.zfin.sequence.blast.smoketest;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.*;
 import lombok.extern.log4j.Log4j2;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -46,7 +45,7 @@ public class BlastSmokeTest extends AbstractSmokeTest {
      * Get a recent crispr STR from the database. Query the blast form with the sequence of the STR.
      * Make sure it returns a results page that contains the STR in the results.
      */
-    @Ignore //This fails on TRUNK -> TODO: write a jenkins job to replace this test
+    @org.junit.Ignore //This fails on TRUNK -> TODO: write a jenkins job to replace this test
     @Test
     public void testRecentSTR() {
         SequenceTargetingReagent str = getRecentCrisprSTR();


### PR DESCRIPTION
- Add ability to generate a ConstructName object by fetching the ConstructComponent objects from the DB.
- When renaming a construct, make sure to add to marker_relationship and construct_marker_relationship (and delete).
- Add new construct change: ZDB-TGCONSTRCT-190812-12
