### PR TITLE
ZFIN-9017: Keep orgID when creating person fails due to validation error

### DIFF
--- a/home/WEB-INF/jsp/profile/create-person.jsp
+++ b/home/WEB-INF/jsp/profile/create-person.jsp
@@ -21,11 +21,12 @@
                         <zfin2:errors errorResult="${errors}" path="putativeLoginName"/>
                         <br>
                         <form:label path="email">Email:</form:label>
-                        <form:input size="50" path="email"/>
+                        <form:input size="50" path="email" required="true"/>
                         <zfin2:errors errorResult="${errors}" path="email"/>
                         <br>
                         <form:label path="pass1">Password:</form:label>
                         <form:input size="50" path="pass1" cssClass="fill-with-generated-password"
+                                    required="true"
                                     onkeyup="testPassword(document.getElementById('pass1').value,'passwordScore','passwordVerdict');"/>
                         <zfin2:errors errorResult="${errors}" path="pass1"/>
                         <br>
@@ -34,10 +35,10 @@
                        <div> Password Strength:<strong><span id="passwordVerdict"></span></strong></div>
                         <br>
                         <form:label path="firstName">First Name:</form:label>
-                        <form:input size="50" path="firstName"/>
+                        <form:input size="50" path="firstName" required="true"/>
                         <zfin2:errors errorResult="${errors}" path="firstName"/>
                         <br>
-                        <form:label path="lastName">Last Name:</form:label>
+                        <form:label path="lastName" required="true">Last Name:</form:label>
                         <form:input size="50" path="lastName"/>
                         <zfin2:errors errorResult="${errors}" path="lastName"/>
                         <br>
@@ -53,7 +54,7 @@
                             Position:
                             <c:forEach var="position" items="${positions}">
                                 <div style="text-indent: 2em;">
-                                    <form:radiobutton path="position" id="position-${position.id}" value="${position.id}"/>
+                                    <form:radiobutton path="position" id="position-${position.id}" value="${position.id}" required="true"/>
                                     <label for="position-${position.id}">${position.name}</label>
                                 </div>
                             </c:forEach>

--- a/source/org/zfin/profile/presentation/PersonController.java
+++ b/source/org/zfin/profile/presentation/PersonController.java
@@ -378,6 +378,12 @@ public class PersonController {
 
         logger.debug("passed in an organization");
 
+        setupPersonCreationModelForOrganization(organizationZdbID, model);
+
+        return "profile/create-person";
+    }
+
+    private void setupPersonCreationModelForOrganization(String organizationZdbID, Model model) {
         //todo: this is probably a little over-duplicated, I only care about the org type
         //for the sake of which position list to get...
         if (organizationZdbID != null && organizationZdbID.startsWith("ZDB-LAB")) {
@@ -393,10 +399,7 @@ public class PersonController {
                 model.addAttribute("organization", company);
                 model.addAttribute("positions", profileRepository.getCompanyPositions());
             }
-
         }
-
-        return "profile/create-person";
     }
 
 
@@ -407,6 +410,9 @@ public class PersonController {
         createPersonValidator.validate(person, errors);
         if (errors.hasErrors()) {
             model.addAttribute(LookupStrings.ERRORS, errors);
+            if (!StringUtils.isEmpty(person.getOrganizationZdbId())) {
+                setupPersonCreationModelForOrganization(person.getOrganizationZdbId(), model);
+            }
             return "profile/create-person";
         }
 


### PR DESCRIPTION
Fix case where admin creates a person from the lab page, but forgets to fill in required field, then gets redirected to page with validation errors and thus loses the organization information.