### PR TITLE
ZFIN-9030: GenesInvolvedIndexer load with stateful session

### DIFF
--- a/source/org/zfin/indexer/GenesInvolvedIndexer.java
+++ b/source/org/zfin/indexer/GenesInvolvedIndexer.java
@@ -1,8 +1,6 @@
 package org.zfin.indexer;
 
 import lombok.extern.log4j.Log4j2;
-import org.hibernate.Session;
-import org.zfin.framework.HibernateUtil;
 import org.zfin.framework.api.Pagination;
 import org.zfin.ontology.GenericTerm;
 import org.zfin.ontology.OmimPhenotypeDisplay;
@@ -11,13 +9,9 @@ import org.zfin.ontology.service.OntologyService;
 import javax.persistence.JoinTable;
 import javax.persistence.Table;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
-import static org.zfin.repository.RepositoryFactory.getDiseasePageRepository;
 import static org.zfin.repository.RepositoryFactory.getOntologyRepository;
 
 @Log4j2
@@ -49,6 +43,4 @@ public class GenesInvolvedIndexer extends UiIndexer<OmimPhenotypeDisplay> {
             throw new RuntimeException(e);
         }
     }
-
-
 }

--- a/source/org/zfin/indexer/UiIndexer.java
+++ b/source/org/zfin/indexer/UiIndexer.java
@@ -45,9 +45,9 @@ public abstract class UiIndexer<Entity> extends Thread {
         return "[" + indexerConfig.getTypeName() + "]";
     }
 
-    private IndexerInfo indexerInfo;
-    private IndexerInfoDAO infoDAO = new IndexerInfoDAO();
-    private IndexerTaskDAO taskDAO = new IndexerTaskDAO();
+    private final IndexerInfo indexerInfo;
+    private final IndexerInfoDAO infoDAO = new IndexerInfoDAO();
+    private final IndexerTaskDAO taskDAO = new IndexerTaskDAO();
 
     public void runIndex() {
         try {
@@ -221,7 +221,7 @@ public abstract class UiIndexer<Entity> extends Thread {
         IndexerRunDAO indexerRunDAO = new IndexerRunDAO();
         IndexerRun indexerRun = new IndexerRun();
         logRunIndexer(indexerRun, indexerRunDAO, true);
-        boolean isThreadedExecution = false;
+        boolean isThreadedExecution = false; //is this always false?
         for (String type : indexers.keySet()) {
             if (argumentSet.size() == 0 || argumentSet.contains(type)) {
                 if (isThreadedExecution) {

--- a/source/org/zfin/indexer/UiIndexer.java
+++ b/source/org/zfin/indexer/UiIndexer.java
@@ -150,7 +150,8 @@ public abstract class UiIndexer<Entity> extends Thread {
     protected void saveRecords(Collection<List<Entity>> batchedList) {
         if(this.getClass().equals(UiIndexerConfig.PublicationExpressionIndexer.getIndexClazz()) ||
            this.getClass().equals(UiIndexerConfig.TermPhenotypeIndexer.getIndexClazz()) ||
-           this.getClass().equals(UiIndexerConfig.ChebiPhenotypeIndexer.getIndexClazz())) {
+           this.getClass().equals(UiIndexerConfig.ChebiPhenotypeIndexer.getIndexClazz()) ||
+           this.getClass().equals(UiIndexerConfig.GenesInvolvedIndexer.getIndexClazz())) {
             saveWithStatefulSession(batchedList);
         } else {
             saveWithStatelessSession(batchedList);

--- a/source/org/zfin/mutant/OmimPhenotype.java
+++ b/source/org/zfin/mutant/OmimPhenotype.java
@@ -54,20 +54,12 @@ public class OmimPhenotype implements Comparable<OmimPhenotype>, Serializable {
         }
     }
 
-    public String getHumanGeneMimNumber() {
-        return humanGeneMimNumber;
-    }
-
-    public void setHumanGeneMimNumber(String humanGeneMimNumber) {
-        this.humanGeneMimNumber = humanGeneMimNumber;
-    }
-
     @Override
     public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
         if (o instanceof OmimPhenotype anotherOmimPhenotype) {
-            if (anotherOmimPhenotype == null) {
-                return false;
-            }
 
             if(Long.valueOf(anotherOmimPhenotype.getId()) != null && Long.valueOf(id) != null && anotherOmimPhenotype.getId() == id) {
                 return true;

--- a/source/org/zfin/ontology/TermExternalReference.java
+++ b/source/org/zfin/ontology/TermExternalReference.java
@@ -1,5 +1,7 @@
 package org.zfin.ontology;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.zfin.mutant.OmimPhenotype;
 import org.zfin.sequence.ForeignDB;
 
@@ -10,6 +12,8 @@ import java.util.Set;
 /**
  * Term definition reference.
  */
+@Setter
+@Getter
 @Entity
 @Table(name = "term_xref")
 public class TermExternalReference implements Comparable, Serializable {
@@ -18,18 +22,24 @@ public class TermExternalReference implements Comparable, Serializable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "tx_pk_id")
     private long ID;
+
     @ManyToOne
     @JoinColumn(name = "tx_term_zdb_id")
     private GenericTerm term;
+
     @ManyToOne
     @JoinColumn(name = "tx_fdb_db_id")
     private ForeignDB foreignDB;
+
     @Column(name = "tx_full_accession")
     private String fullAccession;
+
     @Column(name = "tx_prefix")
     private String prefix;
+
     @Column(name = "tx_accession")
     private String accessionNumber;
+
     @ManyToMany()
     @JoinTable(name = "omimp_termxref_mapping", joinColumns = {
             @JoinColumn(name = "otm_tx_id", nullable = false, updatable = false)},
@@ -37,71 +47,13 @@ public class TermExternalReference implements Comparable, Serializable {
                     nullable = false, updatable = false)})
     private Set<OmimPhenotype> omimPhenotypes;
 
-
-    public String getFullAccession() {
-        return fullAccession;
-    }
-
-    public void setFullAccession(String fullAccession) {
-        this.fullAccession = fullAccession;
-    }
-
-    public String getPrefix() {
-        return prefix;
-    }
-
-    public void setPrefix(String prefix) {
-        this.prefix = prefix;
-    }
-
-    public String getAccessionNumber() {
-        return accessionNumber;
-    }
-
-    public void setAccessionNumber(String accessionNumber) {
-        this.accessionNumber = accessionNumber;
-    }
-
-    public long getID() {
-        return ID;
-    }
-
-    public void setID(long ID) {
-        this.ID = ID;
-    }
-
-    public ForeignDB getForeignDB() {
-        return foreignDB;
-    }
-
-    public void setForeignDB(ForeignDB foreignDB) {
-        this.foreignDB = foreignDB;
-    }
-
     public String getXrefUrl() {
         if (foreignDB == null)
             return null;
         return foreignDB.getDbUrlPrefix() + accessionNumber;
     }
 
-    public GenericTerm getTerm() {
-        return term;
-    }
-
-    public void setTerm(GenericTerm term) {
-        this.term = term;
-    }
-
     public int compareTo(Object otherTermExRef) {
         return fullAccession.compareTo(((TermExternalReference) otherTermExRef).getFullAccession());
-    }
-
-
-    public Set<OmimPhenotype> getOmimPhenotypes() {
-        return omimPhenotypes;
-    }
-
-    public void setOmimPhenotypes(Set<OmimPhenotype> omimPhenotypes) {
-        this.omimPhenotypes = omimPhenotypes;
     }
 }

--- a/source/org/zfin/ontology/presentation/DiseaseDisplay.java
+++ b/source/org/zfin/ontology/presentation/DiseaseDisplay.java
@@ -1,37 +1,27 @@
 package org.zfin.ontology.presentation;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.zfin.mutant.OmimPhenotype;
 import org.zfin.ontology.Term;
 
+@Setter
+@Getter
 public class DiseaseDisplay implements Comparable<DiseaseDisplay> {
+
     private Term diseaseTerm;
+
     private OmimPhenotype omimPhenotype;
 
     public DiseaseDisplay() {
     }
 
-    public Term getDiseaseTerm() {
-        return diseaseTerm;
-    }
-
-    public void setDiseaseTerm(Term diseaseTerm) {
-        this.diseaseTerm = diseaseTerm;
-    }
-
-    public OmimPhenotype getOmimPhenotype() {
-        return omimPhenotype;
-    }
-
-    public void setOmimPhenotype(OmimPhenotype omimPhenotype) {
-        this.omimPhenotype = omimPhenotype;
-    }
-
     @Override
     public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
         if (o instanceof DiseaseDisplay anotherDiseaseDisplay) {
-            if (anotherDiseaseDisplay == null) {
-                return false;
-            }
             if (anotherDiseaseDisplay.getDiseaseTerm() == null) {
                 return anotherDiseaseDisplay.getOmimPhenotype().equals(this.omimPhenotype);
             }

--- a/source/org/zfin/ontology/presentation/OntologyTermDetailController.java
+++ b/source/org/zfin/ontology/presentation/OntologyTermDetailController.java
@@ -126,6 +126,7 @@ public class OntologyTermDetailController {
         return histogram;
     }
 
+    //TODO: remove this method when we are ready to get rid of the old term pages
     @RequestMapping("/term-detail/{termID}")
     protected String termDetailPage(@PathVariable String termID,
                                     @ModelAttribute("formBean") OntologyBean form,

--- a/source/org/zfin/orthology/Ortholog.java
+++ b/source/org/zfin/orthology/Ortholog.java
@@ -1,7 +1,8 @@
 package org.zfin.orthology;
 
 import com.fasterxml.jackson.annotation.JsonView;
-import org.zfin.Species;
+import lombok.Getter;
+import lombok.Setter;
 import org.zfin.framework.api.View;
 import org.zfin.marker.Marker;
 
@@ -9,6 +10,8 @@ import java.io.Serializable;
 import java.util.Set;
 import java.util.SortedSet;
 
+@Setter
+@Getter
 public class Ortholog implements Comparable, Serializable {
 
     @JsonView(View.OrthologyAPI.class)
@@ -29,90 +32,10 @@ public class Ortholog implements Comparable, Serializable {
     private org.zfin.Species organism;
     private boolean obsolete;
 
-    public NcbiOtherSpeciesGene getNcbiOtherSpeciesGene() {
-        return ncbiOtherSpeciesGene;
-    }
-
-    public void setNcbiOtherSpeciesGene(NcbiOtherSpeciesGene ncbiGene) {
-        this.ncbiOtherSpeciesGene = ncbiGene;
-    }
-
-    public String getZdbID() {
-        return zdbID;
-    }
-
-    public void setZdbID(String zdbID) {
-        this.zdbID = zdbID;
-    }
-
-    public Marker getZebrafishGene() {
-        return zebrafishGene;
-    }
-
-    public void setZebrafishGene(Marker gene) {
-        this.zebrafishGene = gene;
-    }
-
-
-    public SortedSet<OrthologExternalReference> getExternalReferenceList() {
-        return externalReferenceList;
-    }
-
-    public void setExternalReferenceList(SortedSet<OrthologExternalReference> externalReferenceList) {
-        this.externalReferenceList = externalReferenceList;
-    }
-
-    public String getChromosome() {
-        return chromosome;
-    }
-
-    public void setChromosome(String chromosome) {
-        this.chromosome = chromosome;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public boolean isObsolete() {
-        return obsolete;
-    }
-
-    public void setObsolete(boolean obsolete) {
-        this.obsolete = obsolete;
-    }
-
-    public String getSymbol() {
-        return symbol;
-    }
-
-    public void setSymbol(String symbol) {
-        this.symbol = symbol;
-    }
-
-    public org.zfin.Species getOrganism() {
-        return organism;
-    }
-
-    public void setOrganism(Species organism) {
-        this.organism = organism;
-    }
 
     public int compareTo(Object o) {
         //todo: ordering method doesn't use a zero padded attribute
         return getNcbiOtherSpeciesGene().getAbbreviation().compareTo(((Ortholog) o).getNcbiOtherSpeciesGene().getAbbreviation());
-    }
-
-    public Set<OrthologEvidence> getEvidenceSet() {
-        return evidenceSet;
-    }
-
-    public void setEvidenceSet(Set<OrthologEvidence> evidenceSet) {
-        this.evidenceSet = evidenceSet;
     }
 
     public String toString() {


### PR DESCRIPTION
GenesInvolvedIndexer load needs to use stateful session in order to pull in related tables.
Also, some general cleanup.