### PR TITLE
ZFIN-9044 & ZFIN-9085: Fix ZDB ID lookup by uniprot accession & improve efficiency

### DIFF
--- a/source/org/zfin/uniprot/persistence/BatchInserter.java
+++ b/source/org/zfin/uniprot/persistence/BatchInserter.java
@@ -1,0 +1,174 @@
+package org.zfin.uniprot.persistence;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.collections4.ListUtils;
+import org.hibernate.query.NativeQuery;
+import org.zfin.framework.HibernateUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.zfin.framework.HibernateUtil.currentSession;
+
+/**
+ * This class is used to bulk load data into a table.
+ * It will insert the data in batches of 100.
+ */
+@Log4j2
+@Getter
+@Setter
+public class BatchInserter {
+
+    private static final String TEMP_TABLE_PREFIX = "temp_bulk_load_";
+    private static final int BATCH_SIZE = 100;
+    private final String baseTableName;
+    private String tempTableOverride;
+    private final List<Map<String, Object>> rowsOfKeyValuePairsToInsert;
+
+    //use this to access column names to make sure we get the same order each time
+    private final List<String> columnNames;
+
+    /**
+     *
+     * @param baseTableName The table that will be bulk loaded into.  (eg. db_link)
+     * @param rowsOfKeyValuePairsToInsert The data to be inserted.  Each row is a list of key-value pairs.
+     *                                    The key is the column name, the value is the value to be inserted.
+     */
+    public BatchInserter(String baseTableName,
+                          List<Map<String, Object>> rowsOfKeyValuePairsToInsert) {
+        this.baseTableName = baseTableName;
+        this.rowsOfKeyValuePairsToInsert = rowsOfKeyValuePairsToInsert;
+        this.columnNames = new ArrayList<>(rowsOfKeyValuePairsToInsert.get(0).keySet());
+    }
+
+    public static void bulkLoadActiveDataZdbIDs(List<String> uniprotIds) {
+        String sqlFormat = """
+                INSERT INTO zdb_active_data
+                (zactvd_zdb_id) VALUES
+                ('%s')
+                ON CONFLICT (zactvd_zdb_id)
+                DO NOTHING
+                """;
+
+        List<List<String>> batches = ListUtils.partition(uniprotIds, BATCH_SIZE);
+        for(List<String> batch : batches) {
+            String combinedUniprotIDs = String.join("'), ('", batch);
+            String sql = String.format(sqlFormat, combinedUniprotIDs);
+            currentSession().createSQLQuery(sql).executeUpdate();
+        }
+    }
+
+    public static void bulkInsert(String tableName, List<Map<String, Object>> tuples) {
+        BatchInserter inserter = new BatchInserter(tableName, tuples);
+        inserter.setTempTableOverride(tableName);
+        inserter.loadBatchData();
+    }
+
+    public final void execute() {
+        log.info("creating temp table for bulk load: " + tempTable());
+        createTempTable();
+
+        log.info("loading data into temp table for bulk load: " + tempTable());
+        loadBatchData();
+
+        log.info("inserting data from temp table into base table: " + baseTableName);
+        insertFromTempTable();
+
+        log.info("dropping temp table: " + tempTable());
+        dropTempTable();
+    }
+
+    private void createTempTable() {
+        String sql = String.format(
+                "create temp table %s as select * from %s where false",
+                tempTable(),
+                baseTableName);
+        log.info("create temp table sql: " + sql);
+        HibernateUtil.currentSession().createSQLQuery(sql).executeUpdate();
+    }
+
+    public void loadBatchData() {
+        ListUtils.partition(rowsOfKeyValuePairsToInsert, BATCH_SIZE)
+                .forEach(this::loadSingleBatchOfDBLinksToBulkTable);
+    }
+
+    /**
+     * Generates SQL like:
+     * insert into temp_bulk_load_dblink
+     * (
+     * dblink_acc_num,
+     * dblink_linked_recid,
+     * )
+     * VALUES
+     * (?, ?),
+     * (?, ?),
+     * ...
+     * (?, ?)
+     *
+     * @param rows The data to be inserted.  Each row is a list of key-value pairs that represent a column name and the value for that column.
+     */
+    private void loadSingleBatchOfDBLinksToBulkTable(List<Map<String, Object>> rows) {
+        String sqlOuterTemplate = String.format("""
+                insert into %s
+                  (
+                  %s
+                  ) VALUES
+                """, tempTable(), getCommaSeparatedColumnNames());
+
+        List<String> sqlInnerTemplates = new ArrayList<>();
+
+        //create rows of '?',
+        // eg. (?, ?, ?, ?, ?, ?),
+        //     (?, ?, ?, ?, ?, ?),
+        //     ...
+        String singleRowOfValuesPlaceholder = "(" + getColumnNames().stream().map(c -> "?").collect(Collectors.joining(", ")) + ")";
+        rows.forEach(a -> sqlInnerTemplates.add(singleRowOfValuesPlaceholder));
+        String sql = sqlOuterTemplate + String.join(",\n", sqlInnerTemplates);
+
+        NativeQuery query = currentSession().createSQLQuery(sql);
+
+        int i = 1;
+        for(Map<String, Object> row : rows) {
+            for(String columnKey : this.getColumnNames()) {
+                query.setParameter(i++, row.get(columnKey));
+            }
+        }
+        query.executeUpdate();
+    }
+
+    private void insertFromTempTable() {
+        String sql = String.format("""
+                insert into %s (%s)
+                select %s from %s
+                """, baseTableName, getCommaSeparatedColumnNames(), getCommaSeparatedColumnNames(), tempTable());
+        currentSession().createSQLQuery(sql).executeUpdate();
+    }
+
+    private void dropTempTable() {
+        String sql = String.format("""
+                drop table %s
+                """, tempTable());
+        currentSession().createSQLQuery(sql).executeUpdate();
+    }
+
+
+    // Template method
+    private String tempTable() {
+        if (tempTableOverride != null) {
+            return tempTableOverride;
+        }
+        return TEMP_TABLE_PREFIX + baseTableName;
+    }
+
+    private String getCommaSeparatedColumnNames() {
+        return String.join(", ", getColumnNames());
+    }
+
+    private List<String> getColumnNames() {
+        return columnNames;
+    }
+}

--- a/source/org/zfin/uniprot/secondary/SecondaryLoadContext.java
+++ b/source/org/zfin/uniprot/secondary/SecondaryLoadContext.java
@@ -345,8 +345,16 @@ public class SecondaryLoadContext {
                 uniprotDbLinksByGeneZdbID.get(dataZdbID);
     }
 
-    public List<DBLinkSlimDTO> getGeneByUniprot(String dataZdbID) {
+    public List<DBLinkSlimDTO> getGenesByUniprot(String dataZdbID) {
         return this.uniprotDbLinks.get(dataZdbID);
+    }
+
+    public List<String> getGeneZdbIDsByUniprot(String uniprotAccession) {
+        List<DBLinkSlimDTO> dblinks = this.uniprotDbLinks.get(uniprotAccession);
+        if(dblinks == null) {
+            return Collections.emptyList();
+        }
+        return dblinks.stream().map(DBLinkSlimDTO::getDataZdbID).toList();
     }
 
     public boolean hasAnyUniprotGeneAssociation(String uniprotAccession, List<String> geneZdbIDs) {

--- a/source/org/zfin/uniprot/secondary/SecondaryTermLoadPipeline.java
+++ b/source/org/zfin/uniprot/secondary/SecondaryTermLoadPipeline.java
@@ -135,11 +135,11 @@ public class SecondaryTermLoadPipeline {
 
         for(SecondaryTermLoadAction.SubType subType : orderedSubTypes) {
             List<SecondaryTermLoadAction> subTypeActions = groupedBySubType.get(subType);
-            processLoadActionsBySubType(subType, subTypeActions);
+            processLoadActionsBySubType(type, subType, subTypeActions);
         }
     }
 
-    private static void processLoadActionsBySubType(SecondaryTermLoadAction.SubType subType, List<SecondaryTermLoadAction> subTypeActions) {
+    private static void processLoadActionsBySubType(SecondaryTermLoadAction.Type type, SecondaryTermLoadAction.SubType subType, List<SecondaryTermLoadAction> subTypeActions) {
         Class handlerClass = subTypeActions.get(0).getHandlerClass();
         ActionProcessor handler = getHandler(handlerClass);
         if (handler.isSubTypeHandlerFor() != subType) {
@@ -147,7 +147,7 @@ public class SecondaryTermLoadPipeline {
         }
         log.info("Processing " + subTypeActions.size() + " actions for " + subType + " using handler " + handlerClass);
         Date timestamp = new Date();
-        handler.processActions(subTypeActions);
+        handler.processActions(subTypeActions, type);
         long timeElapsed = new Date().getTime() - timestamp.getTime();
         long secondsElapsed = timeElapsed / 1000;
         log.info("Finished processing " + subTypeActions.size() + " actions in " + secondsElapsed + " seconds for " + subType + " using handler " + handlerClass);

--- a/source/org/zfin/uniprot/secondary/handlers/ActionProcessor.java
+++ b/source/org/zfin/uniprot/secondary/handlers/ActionProcessor.java
@@ -9,9 +9,11 @@ public interface ActionProcessor {
     /**
      * After all the actions have been created, the actions are processed.
      * This is where the database is updated.
+     *
      * @param actions list of actions to process
+     * @param type
      */
-    void processActions(List<SecondaryTermLoadAction> actions);
+    void processActions(List<SecondaryTermLoadAction> actions, SecondaryTermLoadAction.Type type);
 
     /**
      * Sanity check to make sure the actions are for the correct sub-type

--- a/source/org/zfin/uniprot/secondary/handlers/AddNewDBLinksFromUniProtsActionCreator.java
+++ b/source/org/zfin/uniprot/secondary/handlers/AddNewDBLinksFromUniProtsActionCreator.java
@@ -59,7 +59,7 @@ public class AddNewDBLinksFromUniProtsActionCreator implements ActionCreator {
             RichSequenceAdapter uniprot = uniprotEntry.getValue();
             String uniprotAccession = uniprot.getAccession();
 
-            List<DBLinkSlimDTO> dbls = context.getGeneByUniprot(uniprotAccession);
+            List<DBLinkSlimDTO> dbls = context.getGenesByUniprot(uniprotAccession);
             if(CollectionUtils.isEmpty(dbls)) {
                 continue;
             }

--- a/source/org/zfin/uniprot/secondary/handlers/AddNewDBLinksFromUniProtsActionProcessor.java
+++ b/source/org/zfin/uniprot/secondary/handlers/AddNewDBLinksFromUniProtsActionProcessor.java
@@ -33,7 +33,7 @@ public class AddNewDBLinksFromUniProtsActionProcessor implements ActionProcessor
     }
 
     @Override
-    public void processActions(List<SecondaryTermLoadAction> actions) {
+    public void processActions(List<SecondaryTermLoadAction> actions, SecondaryTermLoadAction.Type type) {
         List<MarkerDBLink> dblinks = new ArrayList<>();
 
         for(SecondaryTermLoadAction action : actions) {

--- a/source/org/zfin/uniprot/secondary/handlers/AddNewSpKeywordTermToGoActionCreator.java
+++ b/source/org/zfin/uniprot/secondary/handlers/AddNewSpKeywordTermToGoActionCreator.java
@@ -69,7 +69,7 @@ public class AddNewSpKeywordTermToGoActionCreator extends MarkerGoTermEvidenceAc
             if (keywords == null || keywords.isEmpty()) {
                 continue;
             }
-            List<DBLinkSlimDTO> matchingGeneDBLinks = context.getGeneByUniprot(key);
+            List<DBLinkSlimDTO> matchingGeneDBLinks = context.getGenesByUniprot(key);
             if (matchingGeneDBLinks == null || matchingGeneDBLinks.isEmpty()) {
 //                log.info("No matching gene for " + key + " with " + keywords.size() + " keywords");
                 unmatchedGeneCount++;

--- a/source/org/zfin/uniprot/secondary/handlers/AddNewSpKeywordTermToGoActionProcessor.java
+++ b/source/org/zfin/uniprot/secondary/handlers/AddNewSpKeywordTermToGoActionProcessor.java
@@ -18,7 +18,7 @@ public class AddNewSpKeywordTermToGoActionProcessor implements ActionProcessor {
     }
 
     @Override
-    public void processActions(List<SecondaryTermLoadAction> actions) {
-        (new MarkerGoTermEvidenceActionProcessor()).processActions(actions);
+    public void processActions(List<SecondaryTermLoadAction> actions, SecondaryTermLoadAction.Type type) {
+        (new MarkerGoTermEvidenceActionProcessor()).processActions(actions, type);
     }
 }

--- a/source/org/zfin/uniprot/secondary/handlers/InterproDomainActionProcessor.java
+++ b/source/org/zfin/uniprot/secondary/handlers/InterproDomainActionProcessor.java
@@ -24,7 +24,7 @@ public class InterproDomainActionProcessor implements ActionProcessor {
     }
 
     @Override
-    public void processActions(List<SecondaryTermLoadAction> actions) {
+    public void processActions(List<SecondaryTermLoadAction> actions, SecondaryTermLoadAction.Type type) {
         for (SecondaryTermLoadAction action : actions) {
             InterProProteinDTO iprDTO = InterProProteinDTO.fromMap(action.getRelatedEntityFields());
             InterProProtein ipr = iprDTO.toInterProProtein();

--- a/source/org/zfin/uniprot/secondary/handlers/InterproMarkerToProteinActionCreator.java
+++ b/source/org/zfin/uniprot/secondary/handlers/InterproMarkerToProteinActionCreator.java
@@ -37,7 +37,7 @@ public class InterproMarkerToProteinActionCreator implements ActionCreator {
         //create new records
         for(String uniprotKey : uniProtRecords.getAccessions()) {
             RichSequenceAdapter richSequenceAdapter = uniProtRecords.getByAccession(uniprotKey);
-            List<String> uniprotRecordZdbIDs = richSequenceAdapter.getCrossRefIDsByDatabase(ZFIN);
+            List<String> uniprotRecordZdbIDs = context.getGeneZdbIDsByUniprot(uniprotKey);
             for (String zdbID : uniprotRecordZdbIDs) {
                 MarkerToProteinDTO newRecord = new MarkerToProteinDTO(zdbID, uniprotKey);
 

--- a/source/org/zfin/uniprot/secondary/handlers/InterproProteinActionCreator.java
+++ b/source/org/zfin/uniprot/secondary/handlers/InterproProteinActionCreator.java
@@ -38,7 +38,7 @@ public class InterproProteinActionCreator implements ActionCreator {
 
         for(String uniprotKey : uniProtRecords.getAccessions()) {
             RichSequenceAdapter richSequenceAdapter = uniProtRecords.getByAccession(uniprotKey);
-            List<String> zdbIDs = richSequenceAdapter.getCrossRefIDsByDatabase(RichSequenceAdapter.DatabaseSource.ZFIN);
+            List<String> zdbIDs = context.getGeneZdbIDsByUniprot(uniprotKey);
             if (zdbIDs.isEmpty()) {
                 continue;
             }
@@ -75,7 +75,7 @@ public class InterproProteinActionCreator implements ActionCreator {
             return Optional.empty();
         }
 
-        List<DBLinkSlimDTO> existingDbLinks = context.getGeneByUniprot(accession);
+        List<DBLinkSlimDTO> existingDbLinks = context.getGenesByUniprot(accession);
         Optional<DBLinkSlimDTO> autoCuratedDbLinks = existingDbLinks
                 .stream()
 //                .filter(dblink -> dblink.getPublicationIDs().contains(AUTOMATED_CURATION_OF_UNIPROT_DATABASE_LINKS)) //do we need this?

--- a/source/org/zfin/uniprot/secondary/handlers/InterproProteinActionProcessor.java
+++ b/source/org/zfin/uniprot/secondary/handlers/InterproProteinActionProcessor.java
@@ -1,12 +1,14 @@
 package org.zfin.uniprot.secondary.handlers;
 
 import lombok.extern.log4j.Log4j2;
+import org.jooq.lambda.tuple.Tuple2;
+import org.zfin.uniprot.persistence.BatchInserter;
 import org.zfin.uniprot.secondary.SecondaryTermLoadAction;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.zfin.framework.HibernateUtil.currentSession;
-import static org.zfin.repository.RepositoryFactory.getInfrastructureRepository;
 
 /**
  * Creates actions for adding and deleting protein domain information (replaces part of protein_domain_info_load.pl)
@@ -24,34 +26,72 @@ public class InterproProteinActionProcessor implements ActionProcessor {
     private static final String FDBCONTID = "ZDB-FDBCONT-040412-47";
 
     @Override
-    public void processActions(List<SecondaryTermLoadAction> actions) {
-        processInsertQueries(actions);
-        processDeleteQueries(actions);
+    public void processActions(List<SecondaryTermLoadAction> actions, SecondaryTermLoadAction.Type type) {
+        if (type.equals(SecondaryTermLoadAction.Type.LOAD)) {
+            processInsertQueries(actions);
+        } else if (type.equals(SecondaryTermLoadAction.Type.DELETE)) {
+            processDeleteQueries(actions);
+        }
         currentSession().flush();
     }
 
     private static void processInsertQueries(List<SecondaryTermLoadAction> actions) {
-        for(SecondaryTermLoadAction action : actions) {
-            getInfrastructureRepository().insertActiveDataWithoutValidationIgnoreConflict(action.getAccession());
+        List<Tuple2<String, Integer>> tuples = actions.stream()
+                .map(action -> new Tuple2<>(
+                        action.getAccession(),
+                        action.getLength()))
+                .toList();
+        processInsertsFromTuples(tuples);
+    }
 
-            currentSession().createSQLQuery("""
-            INSERT INTO protein (up_uniprot_id, up_fdbcont_zdb_id, up_length) VALUES (:uniprot, :fdbcont, :length)
-            ON CONFLICT (up_uniprot_id) 
-            DO UPDATE SET up_length = EXCLUDED.up_length
-            """).setParameter("uniprot", action.getAccession())
-                    .setParameter("fdbcont", FDBCONTID)
-                    .setParameter("length", action.getLength())
-                    .executeUpdate();
-        }
+    public static void processInsertsFromTuples(List<Tuple2<String, Integer>> tuples) {
+        List<String> uniprotIds = tuples.stream()
+                .map(Tuple2::v1)
+                .toList();
+
+        log.info("Inserting Active Data ZDB IDs for protein table");
+        BatchInserter.bulkLoadActiveDataZdbIDs(uniprotIds);
+
+        log.info("Bulk loading protein records into temp table");
+        currentSession().createSQLQuery("""
+                CREATE TEMP TABLE temp_protein
+                as SELECT * FROM protein WHERE false
+                """).executeUpdate();
+
+        List<Map<String, Object>> insertionRows = tuples.stream()
+                .map(action -> Map.of(
+                        "up_uniprot_id", (Object) action.v1(),
+                        "up_fdbcont_zdb_id", FDBCONTID,
+                        "up_length", action.v2()))
+                .toList();
+        BatchInserter.bulkInsert("temp_protein", insertionRows);
+
+        log.info("Updating protein records");
+        currentSession().createSQLQuery("""
+                UPDATE protein
+                SET up_length = temp_protein.up_length
+                FROM temp_protein
+                WHERE protein.up_uniprot_id = temp_protein.up_uniprot_id
+                """).executeUpdate();
+
+        int numDeleted = currentSession().createSQLQuery("""
+                DELETE FROM temp_protein
+                WHERE up_uniprot_id IN (SELECT up_uniprot_id FROM PROTEIN)
+                """).executeUpdate();
+        log.info(numDeleted + " records from temp_protein already existed in protein table");
+
+        log.info("Inserting protein records");
+        currentSession().createSQLQuery("""
+                INSERT INTO protein 
+                SELECT * FROM temp_protein
+                """).executeUpdate();
     }
 
     private static void processDeleteQueries(List<SecondaryTermLoadAction> actions) {
         for(SecondaryTermLoadAction action: actions) {
-            if (action.getType().equals(SecondaryTermLoadAction.Type.DELETE)) {
                 currentSession().createSQLQuery("DELETE FROM protein WHERE up_uniprot_id = :uniprot")
                         .setParameter("uniprot", action.getAccession())
                         .executeUpdate();
-            }
         }
     }
 

--- a/source/org/zfin/uniprot/secondary/handlers/MarkerGoTermEvidenceActionProcessor.java
+++ b/source/org/zfin/uniprot/secondary/handlers/MarkerGoTermEvidenceActionProcessor.java
@@ -40,7 +40,7 @@ public class MarkerGoTermEvidenceActionProcessor implements ActionProcessor {
     public static final String SPKW_MRKRGOEV_PUBLICATION_ATTRIBUTION_ID = "ZDB-PUB-020723-1";
 
     @Override
-    public void processActions(List<SecondaryTermLoadAction> subTypeActions) {
+    public void processActions(List<SecondaryTermLoadAction> subTypeActions, SecondaryTermLoadAction.Type type) {
 
         //group by subtype
         Map<SecondaryTermLoadAction.Type, List<SecondaryTermLoadAction>> groupedActions = subTypeActions.stream()

--- a/source/org/zfin/uniprot/secondary/handlers/PDBActionProcessor.java
+++ b/source/org/zfin/uniprot/secondary/handlers/PDBActionProcessor.java
@@ -23,7 +23,7 @@ public class PDBActionProcessor implements ActionProcessor {
     }
 
     @Override
-    public void processActions(List<SecondaryTermLoadAction> actions) {
+    public void processActions(List<SecondaryTermLoadAction> actions, SecondaryTermLoadAction.Type type) {
         processInserts(actions);
         processDeletes(actions);
         currentSession().flush();

--- a/source/org/zfin/uniprot/secondary/handlers/ProteinToInterproActionCreator.java
+++ b/source/org/zfin/uniprot/secondary/handlers/ProteinToInterproActionCreator.java
@@ -33,6 +33,11 @@ public class ProteinToInterproActionCreator implements ActionCreator {
         for(String uniprotKey : uniProtRecords.getAccessions()) {
             RichSequenceAdapter richSequenceAdapter = uniProtRecords.getByAccession(uniprotKey);
             List<String> zdbIDs = context.getGeneZdbIDsByUniprot(uniprotKey);
+            if (zdbIDs.isEmpty()) {
+                //technically this case is handled by the clause below, but this is more clear
+                log.debug("No gene associations found for " + uniprotKey);
+                continue;
+            }
             if (!context.hasAnyUniprotGeneAssociation(uniprotKey, zdbIDs)) {
                 log.info("Is this line ever reached? " + uniprotKey + " : " + String.join(",", zdbIDs) );
                 continue;

--- a/source/org/zfin/uniprot/secondary/handlers/ProteinToInterproActionCreator.java
+++ b/source/org/zfin/uniprot/secondary/handlers/ProteinToInterproActionCreator.java
@@ -32,8 +32,9 @@ public class ProteinToInterproActionCreator implements ActionCreator {
 
         for(String uniprotKey : uniProtRecords.getAccessions()) {
             RichSequenceAdapter richSequenceAdapter = uniProtRecords.getByAccession(uniprotKey);
-            List<String> zdbIDs = richSequenceAdapter.getCrossRefIDsByDatabase(RichSequenceAdapter.DatabaseSource.ZFIN);
+            List<String> zdbIDs = context.getGeneZdbIDsByUniprot(uniprotKey);
             if (!context.hasAnyUniprotGeneAssociation(uniprotKey, zdbIDs)) {
+                log.info("Is this line ever reached? " + uniprotKey + " : " + String.join(",", zdbIDs) );
                 continue;
             }
 

--- a/source/org/zfin/uniprot/secondary/handlers/ProteinToInterproActionProcessor.java
+++ b/source/org/zfin/uniprot/secondary/handlers/ProteinToInterproActionProcessor.java
@@ -1,10 +1,14 @@
 package org.zfin.uniprot.secondary.handlers;
 
 import lombok.extern.log4j.Log4j2;
+import org.jooq.lambda.tuple.Tuple2;
 import org.zfin.uniprot.dto.ProteinToInterproDTO;
+import org.zfin.uniprot.persistence.BatchInserter;
 import org.zfin.uniprot.secondary.SecondaryTermLoadAction;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.zfin.framework.HibernateUtil.currentSession;
 
@@ -22,23 +26,61 @@ public class ProteinToInterproActionProcessor implements ActionProcessor {
     }
 
     @Override
-    public void processActions(List<SecondaryTermLoadAction> actions) {
-        for(SecondaryTermLoadAction action : actions) {
-            if (action.getType() == SecondaryTermLoadAction.Type.LOAD) {
-                processInsert(action);
-            } else if (action.getType() == SecondaryTermLoadAction.Type.DELETE) {
-                processDelete(action);
-            }
+    public void processActions(List<SecondaryTermLoadAction> actions, SecondaryTermLoadAction.Type type) {
+        if (type == SecondaryTermLoadAction.Type.LOAD) {
+            processInserts(actions);
+        } else if (type == SecondaryTermLoadAction.Type.DELETE) {
+            processDeletes(actions);
         }
         currentSession().flush();
     }
 
-    private void processInsert(SecondaryTermLoadAction action) {
+    private void processInserts(List<SecondaryTermLoadAction> actions) {
+        //collect the tuples to insert using the library
+        List<Tuple2<String, String>> tuples = actions.stream()
+                .map(action -> ProteinToInterproDTO.fromMap(action.getRelatedEntityFields()))
+                .map(proteinToInterproDTO -> new Tuple2<>(proteinToInterproDTO.uniprot(), proteinToInterproDTO.interpro()))
+                .toList();
+
+        processInsertsFromTuples(tuples);
+    }
+
+    /**
+     * This method is used to insert protein_to_interpro records in bulk.
+     * It will insert the data in batches of 100.
+     * The data to be inserted is a list of tuples. Each tuple is a pair of uniprot and interpro.
+     * @param tuples
+     */
+    public void processInsertsFromTuples(List<Tuple2<String, String>> tuples) {
+        log.info("Inserting protein_to_interpro records, count: " + tuples.size());
+
+        //optimize for batch processing -> remove tuples if they don't have corresponding interpro_protein or protein
+        String sqlQueryForProteins = "select up_uniprot_id from protein where up_uniprot_id in ('" +
+                tuples.stream().map(Tuple2::v1).distinct().collect(Collectors.joining("', '")) + "')";
+        List<String> uniprots = currentSession().createNativeQuery(sqlQueryForProteins).list().stream().map(Object::toString).toList();
+
+        String sqlQueryForInterproProteins = "select ip_interpro_id from interpro_protein where ip_interpro_id in ('" +
+                tuples.stream().map(Tuple2::v2).distinct().collect(Collectors.joining("', '")) + "')";
+        List<String> interpros = currentSession().createNativeQuery(sqlQueryForInterproProteins).list().stream().map(Object::toString).toList();
+
+        tuples = tuples.stream()
+                .filter(tuple -> uniprots.contains(tuple.v1()) && interpros.contains(tuple.v2()))
+                .toList();
+
+        List<Map<String, Object>> tuplesAsMapEntriesList = tuples.stream().map(
+                tuple -> Map.of("pti_uniprot_id", (Object)tuple.v1(), "pti_interpro_id", tuple.v2())
+        ).toList();
+
+        log.info("Filtered down to " + tuples.size() + " records");
+        BatchInserter inserter = new BatchInserter("protein_to_interpro", tuplesAsMapEntriesList);
+        inserter.execute();
+    }
+
+    private void processInsertIndividually(SecondaryTermLoadAction action) {
         ProteinToInterproDTO proteinToInterproDTO = ProteinToInterproDTO.fromMap(action.getRelatedEntityFields());
-        log.info("inserting protein to interpro record: " + proteinToInterproDTO.uniprot() + "/" + proteinToInterproDTO.interpro());
         String sqlQuery = """
                 insert into protein_to_interpro (pti_uniprot_id, pti_interpro_id)
-                select :uniprot, :interpro 
+                select :uniprot, :interpro
                 where exists (select 1 from interpro_protein where ip_interpro_id = :interpro) 
                 and exists (select 1 from protein where up_uniprot_id = :uniprot)
                 """;
@@ -46,6 +88,12 @@ public class ProteinToInterproActionProcessor implements ActionProcessor {
                 .setParameter("uniprot", proteinToInterproDTO.uniprot())
                 .setParameter("interpro", proteinToInterproDTO.interpro())
                 .executeUpdate();
+    }
+
+    private void processDeletes(List<SecondaryTermLoadAction> actions) {
+        for(SecondaryTermLoadAction action : actions) {
+            processDelete(action);
+        }
     }
 
     private void processDelete(SecondaryTermLoadAction action) {

--- a/source/org/zfin/uniprot/secondary/handlers/RemoveFromLostUniProtsActionProcessor.java
+++ b/source/org/zfin/uniprot/secondary/handlers/RemoveFromLostUniProtsActionProcessor.java
@@ -24,7 +24,7 @@ public class RemoveFromLostUniProtsActionProcessor implements ActionProcessor {
     }
 
     @Override
-    public void processActions(List<SecondaryTermLoadAction> actions) {
+    public void processActions(List<SecondaryTermLoadAction> actions, SecondaryTermLoadAction.Type type) {
         List<DBLink> dblinksToDelete = new ArrayList<>();
         for(SecondaryTermLoadAction action : actions) {
             DBLink dblink = getSequenceRepository().getDBLinkByReferenceDatabaseID(action.getGeneZdbID(), action.getAccession(), getReferenceDatabaseIDForAction(action));

--- a/source/org/zfin/uniprot/secondary/handlers/RemoveSecondaryTermToGoActionProcessor.java
+++ b/source/org/zfin/uniprot/secondary/handlers/RemoveSecondaryTermToGoActionProcessor.java
@@ -21,7 +21,7 @@ public class RemoveSecondaryTermToGoActionProcessor implements ActionProcessor {
     }
 
     @Override
-    public void processActions(List<SecondaryTermLoadAction> actions) {
+    public void processActions(List<SecondaryTermLoadAction> actions, SecondaryTermLoadAction.Type type) {
         for(SecondaryTermLoadAction action : actions) {
             switch (action.getDbName()) {
                 case INTERPRO -> deleteMarkerGoTermEvidence(action, IP_MRKRGOEV_PUBLICATION_ATTRIBUTION_ID);

--- a/source/org/zfin/uniprot/secondary/handlers/RemoveSpKeywordTermToGoActionProcessor.java
+++ b/source/org/zfin/uniprot/secondary/handlers/RemoveSpKeywordTermToGoActionProcessor.java
@@ -18,8 +18,8 @@ public class RemoveSpKeywordTermToGoActionProcessor implements ActionProcessor {
     }
 
     @Override
-    public void processActions(List<SecondaryTermLoadAction> actions) {
-        (new RemoveSecondaryTermToGoActionProcessor()).processActions(actions);
+    public void processActions(List<SecondaryTermLoadAction> actions, SecondaryTermLoadAction.Type type) {
+        (new RemoveSecondaryTermToGoActionProcessor()).processActions(actions, type);
     }
 
 }

--- a/source/org/zfin/uniprot/task/UniProtReleaseCheckTask.java
+++ b/source/org/zfin/uniprot/task/UniProtReleaseCheckTask.java
@@ -105,21 +105,14 @@ public class UniProtReleaseCheckTask extends AbstractScriptWrapper {
     }
 
     private void downloadFiles(Date releaseDate) {
-        String url1 = downloadUrlForTremblFile;
-        String fileName1 = TREMBL_LOCAL_FILENAME;
-
-        String url2 = downloadUrlForSprotFile;
-        String fileName2 = SPROT_LOCAL_FILENAME;
-
         //set class properties
         downloadedDirectory = createPathForDownloadDestination(releaseDate);
-        downloadedFile1 = downloadedDirectory.resolve(fileName1);
-        downloadedFile2 = downloadedDirectory.resolve(fileName2);
+        downloadedFile1 = downloadedDirectory.resolve(TREMBL_LOCAL_FILENAME);
+        downloadedFile2 = downloadedDirectory.resolve(SPROT_LOCAL_FILENAME);
 
         //download the files
-        downloadFileIfNotExists(url1, downloadedFile1);
-        downloadFileIfNotExists(url2, downloadedFile2);
-
+        downloadFileIfNotExists(downloadUrlForTremblFile, downloadedFile1);
+        downloadFileIfNotExists(downloadUrlForSprotFile, downloadedFile2);
     }
 
     private Path processFiles() throws IOException {
@@ -171,6 +164,11 @@ public class UniProtReleaseCheckTask extends AbstractScriptWrapper {
     }
 
     private void downloadFileIfNotExists(String url, Path localFile) {
+        if (localFile.toFile().exists()) {
+            log.info("File already exists: " + localFile + " size: (" + localFile.toFile().length() + " bytes)");
+            return;
+        }
+
         try {
             log.info("Downloading file: " + url + " to " + localFile);
             log.info("   exists? " + localFile.toFile().exists());


### PR DESCRIPTION
This previously got ZFIN IDs from the richSequenceAdapter (ie. the uniprot release file), but it should be getting them from the context (ie. current ZFIN database contents). This commit fixes that.

I also added more efficient DB loading for the tables marker_to_protein, protein, protein_to_interpro.