### PR TITLE
Updates for check indexer ant task

### DIFF
--- a/source/org/zfin/search/IndexerStatus.java
+++ b/source/org/zfin/search/IndexerStatus.java
@@ -3,7 +3,6 @@ package org.zfin.search;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.extern.log4j.Log4j2;
 
 @Getter
 @Setter


### PR DESCRIPTION
Add a max timeout for checking the indexer.
Handle all possible cases in the loop with logging for troubleshooting unexpected scenarios.