### PR TITLE
Fix issue with the logic for exiting the check loop.

### DIFF
--- a/source/org/zfin/datatransfer/CheckIndexerJob.java
+++ b/source/org/zfin/datatransfer/CheckIndexerJob.java
@@ -42,13 +42,16 @@ public class CheckIndexerJob extends AbstractValidateDataReportTask {
                     log.info("Unexpected Behavior. Elapsed Time Missing. Status Object:");
                     log.info(new ObjectMapper().writeValueAsString(status));
                 }
-            } else if (!status.getStatus().equals(IndexerStatus.Status.BUSY.name().toLowerCase())) {
-                log.info("Total Time: " + status.getStatusMessages().getTimeTaken());
-                System.exit(0);
             } else {
                 log.info("Unexpected Behavior. Status Object:");
                 log.info(new ObjectMapper().writeValueAsString(status));
             }
+
+            if (!status.getStatus().equals(IndexerStatus.Status.BUSY.name().toLowerCase())) {
+                log.info("Total Time: " + status.getStatusMessages().getTimeTaken());
+                System.exit(0);
+            }
+
             Thread.sleep(LOOP_TIME_IN_MILLISECONDS);
         }
         log.info("Timeout while checking on solr indexer. Exiting.");


### PR DESCRIPTION
I compared the new logic with a known working version ([from git history](https://github.com/rtaylorzfin/zfin/blob/1735c0722dbbfb1d67281c0ddd42e3d6d6db0d70/source/org/zfin/datatransfer/CheckIndexerJob.java)). The issue was that I changed an `if ...` to and `else if ...`. I realized that in the original working code, the execution hit both if clauses because both evaluated to true.  So it wasn't an either/or situation as I expected.

To be clear, on the final execution of the loop, both of these if clauses will evaluate to true:
```java
//line 38
} else if (status.getStatusMessages() != null) {
```
and
```java
//line 50
if (!status.getStatus().equals(IndexerStatus.Status.BUSY.name().toLowerCase())) {
```

In the original version, both of these `if`s would evaluate to true on the final loop:
```java
if (status != null && status.getStatusMessages() != null) {
```
and
```java
if (status == null || !status.getStatus().equals(IndexerStatus.Status.BUSY.name().toLowerCase())) {
```