### PR TITLE
ZFIN-9112: Remove "Format into a printable listing" button

### DIFF
--- a/home/WEB-INF/jsp/publication/publication-search.jsp
+++ b/home/WEB-INF/jsp/publication/publication-search.jsp
@@ -11,11 +11,6 @@
 
 <z:page>
     <c:if test="${formBean.results != null}">
-        <div class="pub-export-controls">
-            <input type="button" value="Format into a printable listing" id="pub-printable-results">
-            <input type="button" value="Output as REFER format file" id="pub-refer-results">
-            <a href="/ZFIN/misc_html/refer_info.html" class="popup-link help-popup-link"></a>
-        </div>
         <table class="pub-search-results">
             <caption>
                 Publication Search Results<br>
@@ -237,8 +232,7 @@
             });
             $('#list-all-pubs').click(function (evt) {
                 evt.preventDefault();
-                resetForm($form);
-                $form.submit();
+                window.location.href = '/search?q=&fq=category%3A%22Publication%22&category=Publication';
             });
             $('#pub-printable-results').click(function (evt) {
                 evt.preventDefault();

--- a/source/org/zfin/publication/presentation/PublicationSearchController.java
+++ b/source/org/zfin/publication/presentation/PublicationSearchController.java
@@ -31,6 +31,7 @@ public class PublicationSearchController {
     private final static int MIN_PAGE_SIZE = 1;
     private final static int DEFAULT_PAGE_SIZE = 10;
     private final static int MAX_PAGE_SIZE = 1000;
+    private final static String PUB_FACETED_SEARCH_URL = "/search?q=&fq=category%3A%22Publication%22&category=Publication";
 
     @Autowired
     private PublicationSearchService publicationSearchService;
@@ -88,29 +89,15 @@ public class PublicationSearchController {
     @RequestMapping(value = "/search/printable", method = RequestMethod.GET)
     public String returnPrintableResults(Model model,
                                          @ModelAttribute PublicationSearchBean formBean) {
-        formBean.setMaxDisplayRecords(Integer.MAX_VALUE);
-        formBean.setPageInteger(1);
-        model.addAttribute("formBean", formBean);
-        model.addAttribute("resultBeans", publicationSearchService.getResultsAsResultBeans(formBean));
-        model.addAttribute("today", new Date());
-        // this isn't really called via an ajax request, but this is how you get an unstyled page so...
-        return "publication/printable-results";
+        //redirect to PUB_FACETED_SEARCH_URL
+        return "redirect:" + PUB_FACETED_SEARCH_URL;
     }
 
-    @RequestMapping(value = "/search/refer", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
-    public void returnReferResults(@ModelAttribute PublicationSearchBean formBean,
+    @RequestMapping(value = "/search/refer", method = RequestMethod.GET)
+    public String returnReferResults(@ModelAttribute PublicationSearchBean formBean,
                                    HttpServletResponse response) throws IOException {
-        formBean.setMaxDisplayRecords(Integer.MAX_VALUE);
-        formBean.setPageInteger(1);
-        List<PublicationSearchResultBean> results = publicationSearchService.getResultsAsResultBeans(formBean);
-        String fileName = "ZFIN-Pub-Search-" + DateTimeFormatter.ISO_INSTANT.format(Instant.now());
-        response.addHeader("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
-        response.setCharacterEncoding("UTF-8");
-        PrintWriter writer = response.getWriter();
-        for (PublicationSearchResultBean result : results) {
-            writer.println(publicationSearchService.formatAsRefer(result));
-        }
-        writer.close();
+        //redirect to PUB_FACETED_SEARCH_URL
+        return "redirect:" + PUB_FACETED_SEARCH_URL;
     }
 
     private void setDefaultValue(PublicationSearchBean formBean, String property, Object value) {

--- a/source/org/zfin/publication/presentation/PublicationSearchResultBean.java
+++ b/source/org/zfin/publication/presentation/PublicationSearchResultBean.java
@@ -1,7 +1,11 @@
 package org.zfin.publication.presentation;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.solr.client.solrj.beans.Field;
 
+@Setter
+@Getter
 public class PublicationSearchResultBean {
 
     @Field("id")
@@ -28,67 +32,4 @@ public class PublicationSearchResultBean {
     @Field("publication_status")
     private String status;
 
-    public String getZdbID() {
-        return zdbID;
-    }
-
-    public void setZdbID(String zdbID) {
-        this.zdbID = zdbID;
-    }
-
-    public String getAuthors() {
-        return authors;
-    }
-
-    public void setAuthors(String authors) {
-        this.authors = authors;
-    }
-
-    public String getYear() {
-        return year;
-    }
-
-    public void setYear(String year) {
-        this.year = year;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public String getJournal() {
-        return journal;
-    }
-
-    public void setJournal(String journal) {
-        this.journal = journal;
-    }
-
-    public String getPages() {
-        return pages;
-    }
-
-    public void setPages(String pages) {
-        this.pages = pages;
-    }
-
-    public String getVolume() {
-        return volume;
-    }
-
-    public void setVolume(String volume) {
-        this.volume = volume;
-    }
-
-    public String getStatus() {
-        return status;
-    }
-
-    public void setStatus(String status) {
-        this.status = status;
-    }
 }


### PR DESCRIPTION
Remove buttons for "Format into a printable listing" that generate a printable list of citations for a given publication search due to expensive back-end solr query that is causing problems in solr.

Redirect to faceted search for "List all pubs" link.

Redirect to faceted search for any direct requests to the endpoints for "Format into a printable listing"