### PR TITLE
ZFIN-8997: Relationships table for construct tab on curation.

### DIFF
--- a/home/javascript/react/components/curate-construct/ConstructMarkerAutocomplete.tsx
+++ b/home/javascript/react/components/curate-construct/ConstructMarkerAutocomplete.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState, KeyboardEvent } from 'react';
 import {ConstructComponent} from './ConstructTypes';
+import {backendBaseUrl} from "./DomainInfo";
 
 /**
  * This is a React component that is used to allow the user to start typing
@@ -46,11 +47,7 @@ interface ConstructMarkerAutocompleteProps {
     onChangeWithObject?: (suggestion: ConstructComponent) => void;
 }
 
-//TODO: This is a hack to get the domain for developing locally.  It should be removed when this is deployed to production.
-let calculatedDomain = window.location.origin;
-if (calculatedDomain.indexOf('localhost') > -1) {
-    calculatedDomain = 'https://cell-mac.zfin.org';
-}
+let calculatedDomain = backendBaseUrl();
 
 function ConstructMarkerAutocomplete({publicationId, resetFlag, onSelect, onChange, onChangeWithObject}: ConstructMarkerAutocompleteProps) {
     const [input, setInput] = useState<string>('');

--- a/home/javascript/react/components/curate-construct/ConstructMarkerAutocomplete.tsx
+++ b/home/javascript/react/components/curate-construct/ConstructMarkerAutocomplete.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState, KeyboardEvent } from 'react';
 import {ConstructComponent} from './ConstructTypes';
-import {backendBaseUrl} from "./DomainInfo";
+import {backendBaseUrl} from './DomainInfo';
 
 /**
  * This is a React component that is used to allow the user to start typing

--- a/home/javascript/react/components/curate-construct/ConstructMarkerAutocomplete.tsx
+++ b/home/javascript/react/components/curate-construct/ConstructMarkerAutocomplete.tsx
@@ -47,7 +47,7 @@ interface ConstructMarkerAutocompleteProps {
     onChangeWithObject?: (suggestion: ConstructComponent) => void;
 }
 
-let calculatedDomain = backendBaseUrl();
+const calculatedDomain = backendBaseUrl();
 
 function ConstructMarkerAutocomplete({publicationId, resetFlag, onSelect, onChange, onChangeWithObject}: ConstructMarkerAutocompleteProps) {
     const [input, setInput] = useState<string>('');

--- a/home/javascript/react/components/curate-construct/ConstructRelationshipsTable.tsx
+++ b/home/javascript/react/components/curate-construct/ConstructRelationshipsTable.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect} from 'react';
-import {backendBaseUrl} from "./DomainInfo";
+import {backendBaseUrl} from './DomainInfo';
 
 interface ConstructRelationshipsTableProps {
     publicationId: string;

--- a/home/javascript/react/components/curate-construct/ConstructRelationshipsTable.tsx
+++ b/home/javascript/react/components/curate-construct/ConstructRelationshipsTable.tsx
@@ -1,0 +1,311 @@
+import React, {useEffect} from 'react';
+
+interface ConstructRelationshipsTableProps {
+    publicationId: string;
+}
+
+//type for rows of table:
+type ConstructRelationshipRow = {
+    zdbID: string;
+    constructZdbID: string;
+    constructType: string;
+    constructName: string;
+    constructLabel: string;
+    constructCssClass: string;
+    relationshipType: string;
+    markerLabel: string;
+    markerZdbID: string;
+}
+
+//what the server sends back after creating a new relationship
+type NewConstructRelationshipServerResponse = {
+    type: string;
+    zdbID: string;
+    construct: {
+        zdbID: string;
+        name: string;
+    };
+    marker: {
+        abbreviation: string;
+        zdbID: string;
+        name: string;
+    };
+}
+
+type MarkerNameAndZdbId = {
+    label: string;
+    zdbID: string;
+}
+
+//TODO: This is a hack to get the domain for developing locally.  It should be removed when this is deployed to production.
+let calculatedDomain = window.location.origin;
+if (calculatedDomain.indexOf('localhost') > -1) {
+    calculatedDomain = 'https://cell-mac.zfin.org';
+}
+
+const ConstructRelationshipsTable = ({publicationId}: ConstructRelationshipsTableProps) => {
+    const [loading, setLoading] = React.useState<boolean>(true);
+    const [constructRelationshipRows, setConstructRelationshipRows] = React.useState<ConstructRelationshipRow[]>([]);
+    const [publicationConstructs, setPublicationConstructs] = React.useState<MarkerNameAndZdbId[]>([]);
+    const [markersForRelation, setMarkersForRelation] = React.useState<MarkerNameAndZdbId[]>([]);
+    const [selectedMarker, setSelectedMarker] = React.useState<string>('');
+    const [selectedConstruct, setSelectedConstruct] = React.useState<string>('');
+    const RELATIONSHIP_TO_ADD = 'contains region';
+
+    function getOrderInConstruct(constructName: string, markerLabel: string) {
+        return constructName.indexOf(markerLabel) === -1 ? 1000 : constructName.indexOf(markerLabel);
+    }
+
+    /**
+     * Sorts the rows by constructName, then by special logic(*), then by relationshipType, then by markerLabel
+     * (*) The special logic is that if the markerLabel appears in the constructName, it should appear in the order in which it appears in the constructName
+     * @param constructRelationshipRows
+     */
+    function sortConstructRelationshipRows(constructRelationshipRows: ConstructRelationshipRow[]) {
+        const sortedRows = constructRelationshipRows.sort((a, b) => {
+            if (a.constructName === b.constructName) {
+                const constructName = a.constructName;
+                const orderInConstructA = getOrderInConstruct(constructName, a.markerLabel);
+                const orderInConstructB = getOrderInConstruct(constructName, b.markerLabel);
+
+                if (orderInConstructA === orderInConstructB) {
+                    if (a.relationshipType === b.relationshipType) {
+                        return a.markerLabel.localeCompare(b.markerLabel);
+                    }
+                    return a.relationshipType.localeCompare(b.relationshipType);
+                }
+                return orderInConstructA - orderInConstructB;
+            }
+            return a.constructName.localeCompare(b.constructName);
+        });
+        return styleRowsForTable(sortedRows);
+    }
+
+    /**
+     * The final render of the table should omit the construct name when it repeats from row to row.
+     * Each row should have a class alternating between 'evengroup' and 'oddgroup' when construct name changes.
+     * The first row of each group (a group being all the same construct name) should also have 'newgroup'
+     *
+     * @param constructRelationshipRows
+     */
+    function styleRowsForTable(constructRelationshipRows: ConstructRelationshipRow[]) {
+        let lastConstructName = '';
+        let constructCssClass = 'oddgroup';
+
+        return constructRelationshipRows.map( (rel) => {
+            constructCssClass = constructCssClass.replace(' newgroup', '');
+            if (rel.constructName === lastConstructName) {
+                return {...rel, constructLabel: '', constructCssClass};
+            }
+            lastConstructName = rel.constructName;
+
+            constructCssClass = constructCssClass === 'oddgroup' ? 'evengroup' : 'oddgroup';
+            constructCssClass = constructCssClass + ' newgroup';
+
+            return {...rel, constructCssClass};
+        });
+    }
+
+    async function submitConstructRelationship (constructZdbID: string, markerZdbID: string, relationshipType: string, publicationZdbID: string) {
+        const response = await fetch(`${calculatedDomain}/action/api/construct/${constructZdbID}/relationships`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                firstMarker: {zdbID: constructZdbID},
+                secondMarker: {zdbID: markerZdbID},
+                markerRelationshipType: {name: relationshipType},
+                references: [{zdbID: publicationZdbID}]
+            }),
+        });
+        return await response.json();
+    }
+
+    async function insertNewRelationshipRow(serverResponseData: NewConstructRelationshipServerResponse) {
+        const {zdbID, construct, marker} = serverResponseData;
+
+        //insert the new row at the correct position in the table (sorted by constructName, then by relationshipType, then by markerLabel)
+        const newRelationshipRow: ConstructRelationshipRow = {
+            zdbID,
+            constructZdbID: construct.zdbID,
+            constructType: '',
+            constructName: construct.name,
+            constructLabel: construct.name,
+            constructCssClass: '',
+            relationshipType: RELATIONSHIP_TO_ADD,
+            markerLabel: marker.abbreviation,
+            markerZdbID: marker.zdbID
+        };
+
+        const newRows = sortConstructRelationshipRows([...constructRelationshipRows, newRelationshipRow]);
+        setConstructRelationshipRows(newRows);
+    }
+
+    async function removeRelationshipRow(row: ConstructRelationshipRow) {
+        const newRows = constructRelationshipRows.filter((rel) => rel.zdbID !== row.zdbID);
+        setConstructRelationshipRows(newRows);
+    }
+
+    async function fetchConstructRelationships() {
+        setLoading(true); // Assuming you want to set loading to true at the beginning of the fetch
+        try {
+            const response = await fetch(`${calculatedDomain}/action/api/publication/${publicationId}/constructs`);
+            const constructsData = await response.json();
+            let uniqueConstructsMap = {};
+
+            let uniqueConstructs = [];
+
+            const mappedConstructRelationships = constructsData.map(({ zdbID, constructDTO, markerDTO, relationshipType }) => {
+                const { zdbID: constructZdbID, constructType: constructType, name: constructName } = constructDTO;
+                const { label: markerLabel, zdbID: markerZdbID } = markerDTO;
+
+                if (uniqueConstructsMap[constructZdbID] === undefined) {
+                    uniqueConstructs.push({label: constructName, zdbID: constructZdbID});
+                }
+                uniqueConstructsMap[constructZdbID] = constructName;
+
+                const constructLabel = constructName;
+
+                return {
+                    zdbID,
+                    constructZdbID,
+                    constructType,
+                    constructName,
+                    constructLabel,
+                    relationshipType,
+                    markerLabel,
+                    markerZdbID,
+                };
+            });
+
+            //sort by constructName, then by relationshipType, then by markerLabel
+            const sortedMappedConstructRelationships = sortConstructRelationshipRows(mappedConstructRelationships);
+
+            setPublicationConstructs(uniqueConstructs.sort((a, b) => a.label.localeCompare(b.label)));
+            setConstructRelationshipRows(sortedMappedConstructRelationships);
+        } catch (error) {
+            console.error('Failed to fetch construct relationships:', error);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    async function fetchMarkersForRelation() {
+        try {
+            const response = await fetch(`${calculatedDomain}/action/api/publication/${publicationId}/${RELATIONSHIP_TO_ADD}/markersForRelation`);
+            const markersData = await response.json();
+
+            setMarkersForRelation(markersData.map(({ label, zdbID }) => ({ label, zdbID })).sort((a, b) => a.label.localeCompare(b.label)));
+        } catch (error) {
+            console.error('Failed to fetch markers for relation:', error);
+        }
+    }
+
+    async function deleteConstructMarkerRelationship(row: ConstructRelationshipRow) {
+        const {constructZdbID, zdbID} = row;
+        await fetch(`${calculatedDomain}/action/api/construct/${constructZdbID}/relationships/${zdbID}`, {
+            method: 'DELETE'
+        });
+    }
+
+    async function handleAddButton() {
+        if (selectedConstruct === '' || selectedMarker === '') {
+            return;
+        }
+        try {
+            const newRelationshipFromServer = await submitConstructRelationship(selectedConstruct, selectedMarker, RELATIONSHIP_TO_ADD, publicationId);
+            insertNewRelationshipRow(newRelationshipFromServer);
+        } catch (error) {
+            alert('Failed to add construct marker relationship');
+        }
+    }
+
+
+    async function handleDeleteButton(rel: ConstructRelationshipRow) {
+        try {
+            await deleteConstructMarkerRelationship(rel);
+            removeRelationshipRow(rel);
+        } catch (error) {
+            alert('Failed to delete construct marker relationship');
+        }
+    }
+
+    useEffect(() => {
+        fetchConstructRelationships();
+    }, [publicationId]);
+
+    useEffect(() => {
+        fetchMarkersForRelation();
+    }, [publicationId]);
+
+    if (loading) {
+        return <div>Loading...</div>;
+    }
+
+    return <>
+        <table className='searchresults groupstripes-hover' style={{width: '100%'}}>
+            <thead></thead>
+            <tbody>
+            <tr className='table-header'>
+                <td>Construct</td>
+                <td>Type</td>
+                <td>Relationship</td>
+                <td>Target</td>
+                <td>Delete</td>
+            </tr>
+            {constructRelationshipRows.map(rel => (
+                <tr className={'experiment-row ' + rel.constructCssClass } key={rel.zdbID}>
+                    <td>
+                        <div className='gwt-HTML'>
+                            {rel.constructLabel !== '' && <a href={`/${rel.constructZdbID}`} title={rel.constructLabel}>{rel.constructLabel}</a>}
+                        </div>
+                    </td>
+                    <td>
+                        <div className='gwt-Label'>Transgenic Construct</div>
+                    </td>
+                    <td>
+                        <div className='gwt-Label'>{rel.relationshipType}</div>
+                    </td>
+                    <td>
+                        <div className='gwt-HTML'>
+                            <a href={`/${rel.markerZdbID}`} id={rel.markerZdbID} title={rel.markerLabel}>
+                                <span className='genedom' title={rel.markerLabel} id='Gene Symbol'>{rel.markerLabel}</span>
+                            </a>
+                        </div>
+                    </td>
+                    <td>
+                        {rel.relationshipType == RELATIONSHIP_TO_ADD &&
+                            <button type='button' className='gwt-Button' onClick={() => handleDeleteButton(rel)}>X</button>}
+                    </td>
+                </tr>
+            ))}
+            <tr className='experiment-row'>
+                <td><select className='gwt-ListBox' name='constructToAddList' onChange={(e) => setSelectedConstruct(e.target.value)}>
+                    <option value='-----------'>-----------</option>
+                    {publicationConstructs.map(construct => (
+                        <option key={construct.zdbID} value={construct.zdbID}>{construct.label}</option>
+                    ))}
+                </select></td>
+                <td>
+                    <div className='gwt-Label'></div>
+                </td>
+                <td><select className='gwt-ListBox'><option>{RELATIONSHIP_TO_ADD}</option></select></td>
+                <td><select className='gwt-ListBox' onChange={(e) => setSelectedMarker(e.target.value)}>
+                    <option value='-----------'>-----------</option>
+                    {markersForRelation.map(marker => (
+                        <option key={marker.zdbID} value={marker.zdbID}>{marker.label}</option>
+                    ))}
+                </select></td>
+            </tr>
+            <tr>
+                <td align='left'>
+                    <button type='button' className='gwt-Button' onClick={handleAddButton}>Add</button>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </>;
+}
+
+export default ConstructRelationshipsTable;

--- a/home/javascript/react/components/curate-construct/ConstructRelationshipsTable.tsx
+++ b/home/javascript/react/components/curate-construct/ConstructRelationshipsTable.tsx
@@ -152,9 +152,9 @@ const ConstructRelationshipsTable = ({publicationId}: ConstructRelationshipsTabl
         try {
             const response = await fetch(`${calculatedDomain}/action/api/publication/${publicationId}/constructs`);
             const constructsData = await response.json();
-            let uniqueConstructsMap = {};
+            const uniqueConstructsMap = {};
 
-            let uniqueConstructs = [];
+            const uniqueConstructs = [];
 
             const mappedConstructRelationships = constructsData.map(({ zdbID, constructDTO, markerDTO, relationshipType }) => {
                 const { zdbID: constructZdbID, constructType: constructType, name: constructName } = constructDTO;
@@ -217,6 +217,8 @@ const ConstructRelationshipsTable = ({publicationId}: ConstructRelationshipsTabl
             const newRelationshipFromServer = await submitConstructRelationship(selectedConstruct, selectedMarker, RELATIONSHIP_TO_ADD, publicationId);
             insertNewRelationshipRow(newRelationshipFromServer);
         } catch (error) {
+            //ignore linting rule for this alert
+            //eslint-disable-next-line
             alert('Failed to add construct marker relationship');
         }
     }
@@ -227,6 +229,8 @@ const ConstructRelationshipsTable = ({publicationId}: ConstructRelationshipsTabl
             await deleteConstructMarkerRelationship(rel);
             removeRelationshipRow(rel);
         } catch (error) {
+            //ignore linting rule for this alert
+            //eslint-disable-next-line
             alert('Failed to delete construct marker relationship');
         }
     }
@@ -245,64 +249,64 @@ const ConstructRelationshipsTable = ({publicationId}: ConstructRelationshipsTabl
 
     return <>
         <table className='searchresults groupstripes-hover' style={{width: '100%'}}>
-            <thead></thead>
+            <thead/>
             <tbody>
-            <tr className='table-header'>
-                <td>Construct</td>
-                <td>Type</td>
-                <td>Relationship</td>
-                <td>Target</td>
-                <td>Delete</td>
-            </tr>
-            {constructRelationshipRows.map(rel => (
-                <tr className={'experiment-row ' + rel.constructCssClass } key={rel.zdbID}>
+                <tr className='table-header'>
+                    <td>Construct</td>
+                    <td>Type</td>
+                    <td>Relationship</td>
+                    <td>Target</td>
+                    <td>Delete</td>
+                </tr>
+                {constructRelationshipRows.map(rel => (
+                    <tr className={'experiment-row ' + rel.constructCssClass } key={rel.zdbID}>
+                        <td>
+                            <div className='gwt-HTML'>
+                                {rel.constructLabel !== '' && <a href={`/${rel.constructZdbID}`} title={rel.constructLabel}>{rel.constructLabel}</a>}
+                            </div>
+                        </td>
+                        <td>
+                            <div className='gwt-Label'>Transgenic Construct</div>
+                        </td>
+                        <td>
+                            <div className='gwt-Label'>{rel.relationshipType}</div>
+                        </td>
+                        <td>
+                            <div className='gwt-HTML'>
+                                <a href={`/${rel.markerZdbID}`} id={rel.markerZdbID} title={rel.markerLabel}>
+                                    <span className='genedom' title={rel.markerLabel} id='Gene Symbol'>{rel.markerLabel}</span>
+                                </a>
+                            </div>
+                        </td>
+                        <td>
+                            {rel.relationshipType === RELATIONSHIP_TO_ADD &&
+                                <button type='button' className='gwt-Button' onClick={() => handleDeleteButton(rel)}>X</button>}
+                        </td>
+                    </tr>
+                ))}
+                <tr className='experiment-row'>
+                    <td><select className='gwt-ListBox' name='constructToAddList' onChange={(e) => setSelectedConstruct(e.target.value)}>
+                        <option value='-----------'>-----------</option>
+                        {publicationConstructs.map(construct => (
+                            <option key={construct.zdbID} value={construct.zdbID}>{construct.label}</option>
+                        ))}
+                    </select></td>
                     <td>
-                        <div className='gwt-HTML'>
-                            {rel.constructLabel !== '' && <a href={`/${rel.constructZdbID}`} title={rel.constructLabel}>{rel.constructLabel}</a>}
-                        </div>
+                        <div className='gwt-Label'/>
                     </td>
-                    <td>
-                        <div className='gwt-Label'>Transgenic Construct</div>
-                    </td>
-                    <td>
-                        <div className='gwt-Label'>{rel.relationshipType}</div>
-                    </td>
-                    <td>
-                        <div className='gwt-HTML'>
-                            <a href={`/${rel.markerZdbID}`} id={rel.markerZdbID} title={rel.markerLabel}>
-                                <span className='genedom' title={rel.markerLabel} id='Gene Symbol'>{rel.markerLabel}</span>
-                            </a>
-                        </div>
-                    </td>
-                    <td>
-                        {rel.relationshipType == RELATIONSHIP_TO_ADD &&
-                            <button type='button' className='gwt-Button' onClick={() => handleDeleteButton(rel)}>X</button>}
+                    <td><select className='gwt-ListBox'><option>{RELATIONSHIP_TO_ADD}</option></select></td>
+                    <td><select className='gwt-ListBox' onChange={(e) => setSelectedMarker(e.target.value)}>
+                        <option value='-----------'>-----------</option>
+                        {markersForRelation.map(marker => (
+                            <option key={marker.zdbID} value={marker.zdbID}>{marker.label}</option>
+                        ))}
+                    </select></td>
+                </tr>
+                <tr>
+                    <td align='left'>
+                        <button type='button' className='gwt-Button' onClick={handleAddButton}>Add</button>
                     </td>
                 </tr>
-            ))}
-            <tr className='experiment-row'>
-                <td><select className='gwt-ListBox' name='constructToAddList' onChange={(e) => setSelectedConstruct(e.target.value)}>
-                    <option value='-----------'>-----------</option>
-                    {publicationConstructs.map(construct => (
-                        <option key={construct.zdbID} value={construct.zdbID}>{construct.label}</option>
-                    ))}
-                </select></td>
-                <td>
-                    <div className='gwt-Label'></div>
-                </td>
-                <td><select className='gwt-ListBox'><option>{RELATIONSHIP_TO_ADD}</option></select></td>
-                <td><select className='gwt-ListBox' onChange={(e) => setSelectedMarker(e.target.value)}>
-                    <option value='-----------'>-----------</option>
-                    {markersForRelation.map(marker => (
-                        <option key={marker.zdbID} value={marker.zdbID}>{marker.label}</option>
-                    ))}
-                </select></td>
-            </tr>
-            <tr>
-                <td align='left'>
-                    <button type='button' className='gwt-Button' onClick={handleAddButton}>Add</button>
-                </td>
-            </tr>
             </tbody>
         </table>
     </>;

--- a/home/javascript/react/components/curate-construct/ConstructRelationshipsTable.tsx
+++ b/home/javascript/react/components/curate-construct/ConstructRelationshipsTable.tsx
@@ -1,4 +1,5 @@
 import React, {useEffect} from 'react';
+import {backendBaseUrl} from "./DomainInfo";
 
 interface ConstructRelationshipsTableProps {
     publicationId: string;
@@ -37,11 +38,7 @@ type MarkerNameAndZdbId = {
     zdbID: string;
 }
 
-//TODO: This is a hack to get the domain for developing locally.  It should be removed when this is deployed to production.
-let calculatedDomain = window.location.origin;
-if (calculatedDomain.indexOf('localhost') > -1) {
-    calculatedDomain = 'https://cell-mac.zfin.org';
-}
+let calculatedDomain = backendBaseUrl();
 
 const ConstructRelationshipsTable = ({publicationId}: ConstructRelationshipsTableProps) => {
     const [loading, setLoading] = React.useState<boolean>(true);

--- a/home/javascript/react/components/curate-construct/ConstructRelationshipsTable.tsx
+++ b/home/javascript/react/components/curate-construct/ConstructRelationshipsTable.tsx
@@ -38,7 +38,7 @@ type MarkerNameAndZdbId = {
     zdbID: string;
 }
 
-let calculatedDomain = backendBaseUrl();
+const calculatedDomain = backendBaseUrl();
 
 const ConstructRelationshipsTable = ({publicationId}: ConstructRelationshipsTableProps) => {
     const [loading, setLoading] = React.useState<boolean>(true);

--- a/home/javascript/react/components/curate-construct/CurateConstructNew.tsx
+++ b/home/javascript/react/components/curate-construct/CurateConstructNew.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import ConstructCassetteListEditor, {cassetteHumanReadableList} from './ConstructCassetteListEditor';
 import {cassettesToSimplifiedCassettes, typeAbbreviationToType} from './ConstructTypes';
-import {backendBaseUrl} from "./DomainInfo";
+import {backendBaseUrl} from './DomainInfo';
 
 /*
  * This component is used to create a new construct

--- a/home/javascript/react/components/curate-construct/CurateConstructNew.tsx
+++ b/home/javascript/react/components/curate-construct/CurateConstructNew.tsx
@@ -4,38 +4,6 @@ import {cassettesToSimplifiedCassettes, typeAbbreviationToType} from './Construc
 
 /*
  * This component is used to create a new construct
- * The form eventually will be submitted to the server
- * using an object like the following for Tg5(tdg.1-Hsa.TEST1:EGFP,tdg.2-Hsa.TEST2:EGFP):
- *
- * {
- *   "typeAbbreviation": "Tg",
- *   "prefix": "5",
- *   "cassettes": [
- *     {
- *       "cassetteNumber": 1,
- *       "promoterParts": [
- *         "tdg.1",
- *         "-",
- *         "Hsa.TEST1"
- *       ],
- *       "codingParts": [
- *         "EGFP"
- *       ]
- *     },
- *     {
- *       "cassetteNumber": 2,
- *       "promoterParts": [
- *         ",",
- *         "tdg.2",
- *         "-",
- *         "Hsa.TEST2"
- *       ],
- *       "codingParts": [
- *         "EGFP"
- *       ]
- *     }
- *   ]
- * }
  */
 
 interface CurateConstructNewProps {

--- a/home/javascript/react/components/curate-construct/CurateConstructNew.tsx
+++ b/home/javascript/react/components/curate-construct/CurateConstructNew.tsx
@@ -12,7 +12,7 @@ interface CurateConstructNewProps {
     show: boolean;
 }
 
-let calculatedDomain = backendBaseUrl();
+const calculatedDomain = backendBaseUrl();
 
 const CurateConstructNew = ({publicationId, show= true}: CurateConstructNewProps) => {
 

--- a/home/javascript/react/components/curate-construct/CurateConstructNew.tsx
+++ b/home/javascript/react/components/curate-construct/CurateConstructNew.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 import ConstructCassetteListEditor, {cassetteHumanReadableList} from './ConstructCassetteListEditor';
 import {cassettesToSimplifiedCassettes, typeAbbreviationToType} from './ConstructTypes';
+import {backendBaseUrl} from "./DomainInfo";
 
 /*
  * This component is used to create a new construct
@@ -11,11 +12,7 @@ interface CurateConstructNewProps {
     show: boolean;
 }
 
-//TODO: This is a hack to get the domain for developing locally.  It should be removed when this is deployed to production.
-let calculatedDomain = window.location.origin;
-if (calculatedDomain.indexOf('localhost') > -1) {
-    calculatedDomain = 'https://cell-mac.zfin.org';
-}
+let calculatedDomain = backendBaseUrl();
 
 const CurateConstructNew = ({publicationId, show= true}: CurateConstructNewProps) => {
 

--- a/home/javascript/react/components/curate-construct/CurateConstructRelationships.tsx
+++ b/home/javascript/react/components/curate-construct/CurateConstructRelationships.tsx
@@ -1,14 +1,22 @@
-import React from 'react';
+import React, {useState} from 'react';
+import ConstructRelationshipsTable from "./ConstructRelationshipsTable";
 
 interface CurateConstructRelationshipsProps {
     publicationId: string;
 }
 
 const CurateConstructRelationships = ({publicationId}: CurateConstructRelationshipsProps) => {
+    const [displayContents, setDisplayContents] = useState<boolean>(false);
+
     return <>
         <div className={`mb-3 pub-${publicationId}`}>
             <span className='bold'>CONSTRUCT RELATIONSHIPS: </span>
-            <a style={{textDecoration: 'underline'}}>Show</a>
+            <a style={{textDecoration: 'underline'}} onClick={() => setDisplayContents(!displayContents)}>
+                {displayContents ? 'Hide' : 'Show'}
+            </a>
+            {displayContents && <div className='mt-2'>
+                <ConstructRelationshipsTable publicationId={publicationId}/>
+            </div>}
         </div>
     </>;
 }

--- a/home/javascript/react/components/curate-construct/CurateConstructRelationships.tsx
+++ b/home/javascript/react/components/curate-construct/CurateConstructRelationships.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import ConstructRelationshipsTable from "./ConstructRelationshipsTable";
+import ConstructRelationshipsTable from './ConstructRelationshipsTable';
 
 interface CurateConstructRelationshipsProps {
     publicationId: string;

--- a/home/javascript/react/components/curate-construct/DomainInfo.ts
+++ b/home/javascript/react/components/curate-construct/DomainInfo.ts
@@ -1,8 +1,8 @@
 function backendBaseUrl() {
     //TODO: This is a hack to get the domain for developing locally.  It should be removed when this is deployed to production.
-    let calculatedDomain = window.location.origin;
+    const calculatedDomain = window.location.origin;
     if (calculatedDomain.indexOf('localhost') > -1) {
-        calculatedDomain = 'https://cell-mac.zfin.org';
+        return 'https://cell-mac.zfin.org';
     }
     return calculatedDomain;
 }

--- a/home/javascript/react/components/curate-construct/DomainInfo.ts
+++ b/home/javascript/react/components/curate-construct/DomainInfo.ts
@@ -1,0 +1,10 @@
+function backendBaseUrl() {
+    //TODO: This is a hack to get the domain for developing locally.  It should be removed when this is deployed to production.
+    let calculatedDomain = window.location.origin;
+    if (calculatedDomain.indexOf('localhost') > -1) {
+        calculatedDomain = 'https://cell-mac.zfin.org';
+    }
+    return calculatedDomain;
+}
+
+export {backendBaseUrl};

--- a/source/org/zfin/construct/ConstructCuration.java
+++ b/source/org/zfin/construct/ConstructCuration.java
@@ -1,9 +1,11 @@
 package org.zfin.construct;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.zfin.construct.presentation.ConstructComponentService;
+import org.zfin.framework.api.View;
 import org.zfin.marker.MarkerType;
 import org.zfin.profile.Person;
 
@@ -15,11 +17,13 @@ import java.util.Set;
 @Getter
 public class ConstructCuration {
 
+    @JsonView(View.API.class)
     private String zdbID;
     private String publicComments;
     private Person owner;
     private Set<ConstructRelationship> constructRelations;
 
+    @JsonView(View.API.class)
     private String name;
     private MarkerType constructType;
 
@@ -30,8 +34,8 @@ public class ConstructCuration {
      * Create a basic new construct curation object from the name.
      * It uses the name to set the construct type and initializes the dates.
      *
-     * @param name
-     * @return
+     * @param name construct name
+     * @return new construct curation object
      */
     public static ConstructCuration create(String name) {
         ConstructCuration newConstruct = new ConstructCuration();

--- a/source/org/zfin/construct/ConstructRelationship.java
+++ b/source/org/zfin/construct/ConstructRelationship.java
@@ -4,8 +4,10 @@ package org.zfin.construct;
  * Created by prita on 3/2/2015.
  */
 
+import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Getter;
 import lombok.Setter;
+import org.zfin.framework.api.View;
 import org.zfin.infrastructure.EntityAttribution;
 import org.zfin.infrastructure.PublicationAttribution;
 import org.zfin.marker.Marker;
@@ -53,20 +55,19 @@ public class ConstructRelationship implements EntityAttribution {
         }
     }
 
-
-
+    @JsonView(View.API.class)
     private Type type;
 
+    @JsonView(View.API.class)
     private String zdbID;
 
-
+    @JsonView(View.API.class)
     private ConstructCuration construct;
+
+    @JsonView(View.API.class)
     private Marker marker;
 
-
-
     private Set<PublicationAttribution> publications;
-
 
     public int getPublicationCount() {
         if (publications == null)
@@ -82,8 +83,6 @@ public class ConstructRelationship implements EntityAttribution {
             return null;
         }
     }
-
-
 }
 
 

--- a/source/org/zfin/construct/name/Cassettes.java
+++ b/source/org/zfin/construct/name/Cassettes.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 public class Cassettes implements Iterable<Cassette>{
-    private static final String CASSETTE_SEPARATOR ="Cassette";
+    private static final String CASSETTE_SEPARATOR = "Cassette";
     private List<Cassette> cassettes = new ArrayList<>();
 
     public static Cassettes fromStoredName(String storedName) {
@@ -53,5 +53,11 @@ public class Cassettes implements Iterable<Cassette>{
     @Override
     public Iterator<Cassette> iterator() {
         return cassettes.iterator();
+    }
+
+    public void reinitialize() {
+        for (int i = 0; i < cassettes.size(); i++) {
+            cassettes.get(i).setCassetteNumber(i + 1);
+        }
     }
 }

--- a/source/org/zfin/construct/name/ConstructName.java
+++ b/source/org/zfin/construct/name/ConstructName.java
@@ -121,4 +121,8 @@ public class ConstructName {
     public void setTypeByAbbreviation(String componentValue) {
         getConstructTypeEnumByConstructName(componentValue).ifPresent(this::setType);
     }
+
+    public void reinitialize() {
+        cassettes.reinitialize();
+    }
 }

--- a/source/org/zfin/construct/presentation/ConstructAddController.java
+++ b/source/org/zfin/construct/presentation/ConstructAddController.java
@@ -92,6 +92,7 @@ public class ConstructAddController {
         //set the construct name from the object
         constructValues.setConstructName(constructValues.getConstructNameObject().toString());
         constructValues.setConstructSequence(constructValues.getConstructSequence().toUpperCase());
+        constructValues.getConstructNameObject().reinitialize();
         try {
             HibernateUtil.createTransaction();
             newConstruct = createNewConstructFromSubmittedForm(constructValues);

--- a/source/org/zfin/marker/ConstructMarkerRelationshipAPIController.java
+++ b/source/org/zfin/marker/ConstructMarkerRelationshipAPIController.java
@@ -1,0 +1,86 @@
+package org.zfin.marker;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import org.zfin.construct.ConstructCuration;
+import org.zfin.construct.ConstructRelationship;
+import org.zfin.framework.HibernateUtil;
+import org.zfin.framework.api.View;
+import org.zfin.framework.presentation.InvalidWebRequestException;
+import org.zfin.marker.presentation.MarkerRelationshipFormBean;
+import org.zfin.marker.presentation.MarkerRelationshipFormBeanValidator;
+import org.zfin.marker.repository.MarkerRepository;
+import org.zfin.marker.service.ConstructService;
+import org.zfin.marker.service.MarkerService;
+import org.zfin.publication.Publication;
+
+import javax.validation.Valid;
+import java.util.Collection;
+
+import static org.zfin.repository.RepositoryFactory.getConstructRepository;
+
+@RestController
+@RequestMapping("/api")
+@Log4j2
+public class ConstructMarkerRelationshipAPIController {
+
+    @Autowired
+    private MarkerRepository markerRepository;
+
+    @JsonView(View.API.class)
+    @RequestMapping(value = "/construct/{zdbID}/relationships", method = RequestMethod.POST)
+    public ConstructRelationship addConstructMarkerRelationship(@PathVariable String zdbID,
+                                                            @Valid @RequestBody MarkerRelationshipFormBean form,
+                                                            BindingResult errors) {
+        if (errors.hasErrors()) {
+            throw new InvalidWebRequestException("Invalid marker relationship", errors);
+        }
+
+        Marker firstMarker = markerRepository.getMarkerByID(zdbID);
+        Marker secondMarker = markerRepository.getMarkerByID(form.getSecondMarker().getZdbID());
+
+        MarkerRelationshipType markerRelationshipType = markerRepository.getMarkerRelationshipType(form.getMarkerRelationshipType().getName());
+
+        MarkerRelationshipFormBeanValidator.validateMarkerRelationshipType(firstMarker, secondMarker, markerRelationshipType, errors);
+        if (errors.hasErrors()) {
+            throw new InvalidWebRequestException("Invalid marker relationship", errors);
+        }
+
+        Collection<Marker> related = MarkerService.getRelatedMarkers(firstMarker, markerRelationshipType);
+        if (CollectionUtils.isNotEmpty(related) && related.contains(secondMarker)) {
+            errors.reject("marker.relationship.duplicate");
+            throw new InvalidWebRequestException("Invalid marker relationship", errors);
+        }
+
+        Publication publication = form.getReferences().iterator().next();
+
+        HibernateUtil.createTransaction();
+
+        String constructZdbID = ConstructService.addConstructMarkerRelationship(firstMarker.getZdbID(), secondMarker.getZdbID(), markerRelationshipType.getName(), publication.getZdbID());
+
+        HibernateUtil.flushAndCommitCurrentSession();
+
+        return getConstructRepository().getConstructRelationshipByID(constructZdbID);
+    }
+
+    @ResponseBody
+    @RequestMapping(value = "/construct/{zdbID}/relationships/{cmrelZdbID}", method = RequestMethod.DELETE)
+    public String deleteConstructMarkerRelationship(@PathVariable String zdbID, @PathVariable String cmrelZdbID) {
+        ConstructRelationship cmrel = getConstructRepository().getConstructRelationshipByID(cmrelZdbID);
+        ConstructCuration construct = cmrel.getConstruct();
+        if (!construct.getZdbID().equals(zdbID)) {
+            throw new RuntimeException("Deleting construct relationship for wrong construct");
+        }
+        HibernateUtil.createTransaction();
+        ConstructService.deleteConstructRelationship(cmrelZdbID);
+        HibernateUtil.flushAndCommitCurrentSession();
+        return cmrelZdbID;
+    }
+
+}
+
+

--- a/source/org/zfin/marker/service/ConstructService.java
+++ b/source/org/zfin/marker/service/ConstructService.java
@@ -6,10 +6,14 @@ import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.zfin.construct.ConstructCuration;
+import org.zfin.construct.ConstructRelationship;
 import org.zfin.feature.repository.FeatureRepository;
+import org.zfin.framework.HibernateUtil;
 import org.zfin.framework.api.FieldFilter;
 import org.zfin.framework.api.JsonResultResponse;
 import org.zfin.framework.api.Pagination;
+import org.zfin.gwt.root.dto.ConstructRelationshipDTO;
 import org.zfin.infrastructure.ControlledVocab;
 import org.zfin.infrastructure.repository.InfrastructureRepository;
 import org.zfin.marker.Marker;
@@ -27,6 +31,9 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.zfin.repository.RepositoryFactory.*;
+import static org.zfin.repository.RepositoryFactory.getInfrastructureRepository;
 
 @Service
 public class ConstructService {
@@ -62,38 +69,19 @@ public class ConstructService {
         addFilterQuery(query, FieldName.RELATED_SPECIES_NAME_AC, pagination.getFieldFilter(FieldFilter.SPECIES));
 
         switch (StringUtils.defaultString(pagination.getSortBy())) {
-            case "constructNameUp":
-                query.addSort(SolrQuery.SortClause.asc(FieldName.NAME_SORT.getName()));
-                break;
-            case "constructNameDown":
-                query.addSort(SolrQuery.SortClause.desc(FieldName.NAME_SORT.getName()));
-                break;
-            case "regulatoryRegionUp":
-                query.addSort(SolrQuery.SortClause.asc(FieldName.REGULATORY_REGION_SORT.getName()));
-                break;
-            case "regulatoryRegionDown":
-                query.addSort(SolrQuery.SortClause.desc(FieldName.REGULATORY_REGION_SORT.getName()));
-                break;
-            case "codingSequenceUp":
-                query.addSort(SolrQuery.SortClause.asc(FieldName.CODING_SEQUENCE_SORT.getName()));
-                break;
-            case "codingSequenceDown":
-                query.addSort(SolrQuery.SortClause.desc(FieldName.CODING_SEQUENCE_SORT.getName()));
-                break;
-            case "speciesUp":
-                query.addSort(SolrQuery.SortClause.asc(FieldName.CONSTRUCT_SPECIES_SORT.getName()));
-                break;
-            case "speciesDown":
-                query.addSort(SolrQuery.SortClause.desc(FieldName.CONSTRUCT_SPECIES_SORT.getName()));
-                break;
-            case "citationLeast":
-                query.addSort(SolrQuery.SortClause.asc(FieldName.CONSTRUCT_CITATION_SORT.getName()));
-                break;
-            case "citationMost":
-                query.addSort(SolrQuery.SortClause.desc(FieldName.CONSTRUCT_CITATION_SORT.getName()));
-                break;
-            default:
-                //query.addSort(SolrQuery.SortClause.asc(FieldName.REGULATORY_REGION_AC.getName()));
+            case "constructNameUp" -> query.addSort(SolrQuery.SortClause.asc(FieldName.NAME_SORT.getName()));
+            case "constructNameDown" -> query.addSort(SolrQuery.SortClause.desc(FieldName.NAME_SORT.getName()));
+            case "regulatoryRegionUp" -> query.addSort(SolrQuery.SortClause.asc(FieldName.REGULATORY_REGION_SORT.getName()));
+            case "regulatoryRegionDown" -> query.addSort(SolrQuery.SortClause.desc(FieldName.REGULATORY_REGION_SORT.getName()));
+            case "codingSequenceUp" -> query.addSort(SolrQuery.SortClause.asc(FieldName.CODING_SEQUENCE_SORT.getName()));
+            case "codingSequenceDown" -> query.addSort(SolrQuery.SortClause.desc(FieldName.CODING_SEQUENCE_SORT.getName()));
+            case "speciesUp" -> query.addSort(SolrQuery.SortClause.asc(FieldName.CONSTRUCT_SPECIES_SORT.getName()));
+            case "speciesDown" -> query.addSort(SolrQuery.SortClause.desc(FieldName.CONSTRUCT_SPECIES_SORT.getName()));
+            case "citationLeast" -> query.addSort(SolrQuery.SortClause.asc(FieldName.CONSTRUCT_CITATION_SORT.getName()));
+            case "citationMost" -> query.addSort(SolrQuery.SortClause.desc(FieldName.CONSTRUCT_CITATION_SORT.getName()));
+            default -> {
+            }
+            //query.addSort(SolrQuery.SortClause.asc(FieldName.REGULATORY_REGION_AC.getName()));
         }
 
         query.setFields(FieldName.ID.getName());
@@ -149,6 +137,62 @@ public class ConstructService {
         response.setResults(constructInfoList);
 
         return response;
+    }
+
+    public static String addConstructMarkerRelationship(ConstructRelationshipDTO constructRelationshipDTO) {
+        return addConstructMarkerRelationship(
+                constructRelationshipDTO.getConstructDTO().getZdbID(),
+                constructRelationshipDTO.getMarkerDTO().getZdbID(),
+                constructRelationshipDTO.getRelationshipType(),
+                constructRelationshipDTO.getPublicationZdbID());
+    }
+
+    public static String addConstructMarkerRelationship(String constructZdbID, String markerZdbID, String relationshipType, String publicationZdbID) {
+        ConstructRelationship constructRelationship = new ConstructRelationship();
+        MarkerRelationship markerRelationship = new MarkerRelationship();
+        ConstructCuration construct = getConstructRepository().getConstructByID(constructZdbID);
+        constructRelationship.setConstruct(construct);
+
+        Marker marker = getMarkerRepository().getMarkerByID(markerZdbID);
+        constructRelationship.setMarker(marker);
+
+        constructRelationship.setType(ConstructRelationship.Type.getType(relationshipType));
+        markerRelationship.setFirstMarker(getMarkerRepository().getMarkerByID(constructZdbID));
+        markerRelationship.setSecondMarker(marker);
+        markerRelationship.setType(MarkerRelationship.Type.getType(relationshipType));
+        HibernateUtil.currentSession().save(constructRelationship);
+        HibernateUtil.currentSession().save(markerRelationship);
+        getInfrastructureRepository().insertPublicAttribution(constructRelationship.getZdbID(), publicationZdbID);
+//        getInfrastructureRepository().insertPublicAttribution(markerRelationship.getZdbID(), publicationZdbID); ??
+        HibernateUtil.currentSession().flush();
+        return constructRelationship.getZdbID();
+    }
+
+    public static void deleteConstructRelationship(String constructRelationshipZdbID) {
+        //delete from construct_marker_relationship
+        ConstructRelationship crel = getConstructRepository().getConstructRelationshipByID(constructRelationshipZdbID);
+        getInfrastructureRepository().insertUpdatesTable(constructRelationshipZdbID, "Construct", constructRelationshipZdbID, "",
+                "deleted construct/marker relationship between: "
+                        + crel.getConstruct().getName()
+                        + " and "
+                        + crel.getMarker().getName()
+                        + " of type "
+                        + crel.getType().getValue()
+        );
+        getInfrastructureRepository().deleteActiveDataByZdbID(constructRelationshipZdbID);
+
+        //delete from marker_relationship
+        Marker marker1 = getMarkerRepository().getMarker(crel.getConstruct().getZdbID());
+        Marker marker2 = getMarkerRepository().getMarker(crel.getMarker().getZdbID());
+        MarkerRelationship.Type relationshipType = MarkerRelationship.Type.getType(crel.getType().getValue());
+        MarkerRelationship markerRelationship = getMarkerRepository().getMarkerRelationship(marker1, marker2, relationshipType);
+        if (markerRelationship != null) {
+            getInfrastructureRepository().deleteActiveDataByZdbID(markerRelationship.getZdbID());
+        }
+    }
+
+    public static void deleteConstructRelationship(ConstructRelationshipDTO constructRelationshipDTO) {
+        deleteConstructRelationship(constructRelationshipDTO.getZdbID());
     }
 
     private void addFilterQuery(SolrQuery query, FieldName field, String value) {

--- a/source/org/zfin/publication/presentation/PublicationAPIController.java
+++ b/source/org/zfin/publication/presentation/PublicationAPIController.java
@@ -9,12 +9,14 @@ import org.springframework.web.bind.annotation.*;
 import org.zfin.antibody.Antibody;
 import org.zfin.antibody.AntibodyService;
 import org.zfin.antibody.repository.AntibodyRepository;
+import org.zfin.construct.ConstructRelationship;
 import org.zfin.feature.Feature;
 import org.zfin.figure.presentation.ExpressionTableRow;
 import org.zfin.figure.presentation.PhenotypeTableRow;
 import org.zfin.figure.service.FigureViewService;
 import org.zfin.framework.api.*;
 import org.zfin.framework.presentation.PaginationResult;
+import org.zfin.gwt.root.dto.ConstructRelationshipDTO;
 import org.zfin.gwt.root.dto.MarkerDTO;
 import org.zfin.gwt.root.server.DTOConversionService;
 import org.zfin.gwt.root.util.StringUtils;
@@ -435,6 +437,31 @@ public class PublicationAPIController {
 
         response.setResults(markerList);
         return response;
+    }
+
+    @ResponseBody
+    @RequestMapping(value = "/{publicationID}/{featureTypeName}/markersForRelation")
+    public List<MarkerDTO> getMarkersForRelation(@PathVariable String publicationID, @PathVariable String featureTypeName) {
+        List<Marker> markers = markerRepository.getMarkersForRelation(featureTypeName, publicationID);
+        List<MarkerDTO> markerDTOs = new ArrayList<MarkerDTO>();
+        for (Marker m : markers) {
+            markerDTOs.add(DTOConversionService.convertToMarkerDTO(m));
+        }
+        return markerDTOs;
+    }
+
+    @ResponseBody
+    @RequestMapping(value = "/{publicationID}/constructs")
+    public List<ConstructRelationshipDTO> getConstructMarkerRelationshipsForPub(@PathVariable String publicationID) {
+        List<ConstructRelationshipDTO> constructRelnDTOs = new ArrayList<ConstructRelationshipDTO>();
+        List<ConstructRelationship> constructMarkerRelationships = getConstructRepository().getConstructRelationshipsByPublication(publicationID);
+        if (CollectionUtils.isNotEmpty(constructMarkerRelationships)) {
+            for (ConstructRelationship markerRelationship : constructMarkerRelationships) {
+                constructRelnDTOs.add(DTOConversionService.convertToConstructRelationshipDTO(markerRelationship));
+            }
+        }
+
+        return constructRelnDTOs;
     }
 
     @Getter


### PR DESCRIPTION
ZFIN-8997: fix cassette number setting on creation
ZFIN-8997: Save new construct/marker relationships to backend from the react-based construct tab on curation UI
ZFIN-8997: delete construct/marker relationships to backend from the react-based construct tab on curation UI