### PR TITLE
ZFIN-9122: Fix URL for gene2vega download file

### DIFF
--- a/server_apps/data_transfer/NCBIGENE/NCBI_gene_load.pl
+++ b/server_apps/data_transfer/NCBIGENE/NCBI_gene_load.pl
@@ -596,7 +596,7 @@ sub downloadNCBIFilesForRelease {
         $hash = md5File('gene2accession.gz');
         print "gene2accession.gz md5: $hash at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n";
 
-        downloadOrUseLocalFile("ftp://ftp.ncbi.nih.gov/gene/DATA/ARCHIVE/gene2vega.gz", "gene2vega.gz");
+        downloadOrUseLocalFile("ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/ARCHIVE/gene2vega.gz", "gene2vega.gz");
         $hash = md5File('gene2vega.gz');
         print "gene2vega.gz md5: $hash at " . strftime("%Y-%m-%d %H:%M:%S", localtime(time())) . " \n";
 


### PR DESCRIPTION
It looks like the domain "ftp.ncbi.nih.gov" no longer works. Instead we should use "ftp.ncbi.nlm.nih.gov".