### PR TITLE
ZFIN-9119: Use the printf instead of print to get %.3f to get filled in

### DIFF
--- a/server_apps/data_transfer/GO/goparser2.2.pl
+++ b/server_apps/data_transfer/GO/goparser2.2.pl
@@ -12,7 +12,7 @@ $versionNumber += 0.001;
 open (automated_only, ">gene_association2.2_automated_only.zfin") or die "Cannot open gene_association2.2_automated_only.zfin";
 
 print automated_only "!gaf-version: 2.2\n";
-print automated_only "!Version: %.3f\n", $versionNumber;
+printf automated_only "!Version: %.3f\n", $versionNumber;
 print automated_only "!date-generated: ".`/bin/date +%Y-%m-%d`;
 print automated_only "!generated-by: ZFIN \n";
 print automated_only "! \n";
@@ -21,7 +21,7 @@ print automated_only "! \n";
 open (all_annot, ">gene_association2.2.zfin") or die "Cannot open gene_association2.2.zfin";
 
 print all_annot "!gaf-version: 2.2\n";
-print all_annot "!Version: %.3f\n", $versionNumber;
+printf all_annot "!Version: %.3f\n", $versionNumber;
 print all_annot "!date-generated: ".`/bin/date +%Y-%m-%d`;
 print all_annot "!generated-by: ZFIN \n";
 print all_annot "! \n";


### PR DESCRIPTION
Fixes our gaf file headers that were previously created as:

```
!gaf-version: 2.2
!Version: %.3f
0.001!date-generated: 2024-04-04
!generated-by: ZFIN
!
```