### PR TITLE
Fix warnings about type coercion in sql files

### DIFF
--- a/lib/DB_functions/create_stg_name_long.sql
+++ b/lib/DB_functions/create_stg_name_long.sql
@@ -1,8 +1,8 @@
 create or replace function create_stg_name_long(
-  stgName           stage.stg_name%TYPE,
-  stgHrsStart       stage.stg_hours_start%TYPE,
-  stgHrsEnd         stage.stg_hours_end%TYPE,
-  stgOtherFeatures  stage.stg_other_features%TYPE)
+  stgName           text,
+  stgHrsStart       numeric,
+  stgHrsEnd         numeric,
+  stgOtherFeatures  text)
 
   returns text as $stgNameLong$
 

--- a/lib/DB_functions/fimg_overlaps_stg_window.sql
+++ b/lib/DB_functions/fimg_overlaps_stg_window.sql
@@ -1,8 +1,8 @@
 create or replace function 
 fimg_overlaps_stg_window (
-  imgZdbId       image.img_zdb_id%TYPE,
-  startStageZdbId stage.stg_zdb_id%TYPE,
-  endStageZdbId   stage.stg_zdb_id%TYPE )
+  imgZdbId       text,
+  startStageZdbId text,
+  endStageZdbId   text )
 
   returns boolean as $overlaps$
 

--- a/lib/DB_functions/jrnl_acknowledgment.sql
+++ b/lib/DB_functions/jrnl_acknowledgment.sql
@@ -1,6 +1,6 @@
 create or replace function 
 jrnl_acknowledgment (
-  jrnlZdbId        journal.jrnl_zdb_id%TYPE)
+  jrnlZdbId        text)
 
   returns text as $$
 


### PR DESCRIPTION
I'm getting these noisy messages on gradle tasks:

psql:...create_stg_name_long.sql:50: NOTICE:  type reference stage.stg_name%TYPE converted to text
...

![image](https://github.com/ZFIN/zfin/assets/90803397/f88082ca-2498-41ff-a257-e2c3e938e85f)
