### PR TITLE
ZFIN-9031: Mark noctua gpad load as unstable for bad ZDB IDs

### DIFF
--- a/server_apps/jenkins/jobs/Load-GPAD-Noctua_w/config.xml
+++ b/server_apps/jenkins/jobs/Load-GPAD-Noctua_w/config.xml
@@ -17,10 +17,10 @@
   <concurrentBuild>false</concurrentBuild>
   <customWorkspace>$TARGETROOT</customWorkspace>
   <builders>
-    <hudson.tasks.Ant plugin="ant@1.2">
-      <targets>load-noctua-gpad -DjobName=Load-GPAD-Noctua_w</targets>
-      <buildFile>$TARGETROOT/server_apps/DB_maintenance/build.xml</buildFile>
-    </hudson.tasks.Ant>
+    <hudson.tasks.Shell>
+      <command>ant -f $TARGETROOT/server_apps/DB_maintenance/build.xml load-noctua-gpad -DjobName=Load-GPAD-Noctua_w</command>
+      <unstableReturn>2</unstableReturn>
+    </hudson.tasks.Shell>
   </builders>
   <publishers>
     <hudson.tasks.ArtifactArchiver>


### PR DESCRIPTION
Use shell command instead of ant task so that we can set a return value that indicates an unstable build.