### PR TITLE
Update Download-Files_d config.xml remove redundancy

### DIFF
--- a/server_apps/jenkins/jobs/Download-Files_d/config.xml
+++ b/server_apps/jenkins/jobs/Download-Files_d/config.xml
@@ -36,9 +36,6 @@
       <command>cd $TARGETROOT/server_apps/data_transfer/GO  &amp;&amp; ./go.pl  &amp;&amp; cp gene_association.zfin.gz $DOWNLOAD_DIRECTORY/current/</command>
     </hudson.tasks.Shell>
     <hudson.tasks.Shell>
-      <command>touch $DOWNLOAD_DIRECTORY/reload-status/reload</command>
-    </hudson.tasks.Shell>
-    <hudson.tasks.Shell>
       <command>curl -k --silent --output /dev/null --show-error -s -D - https://$DOMAIN_NAME/action/unload/downloads/update-cache</command>
     </hudson.tasks.Shell>
   </builders>


### PR DESCRIPTION
The touch file command is redundant to the curl command. They both notify tomcat of the changes to the downloads directory.