### PR TITLE
ZFIN-9180: NCBI Release fetch and parse

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -782,6 +782,9 @@ task getLatestSolrIndex() {
     }
 }
 
+//loadsolr as alias for getLatestSolrIndex
+task loadsolr(dependsOn: getLatestSolrIndex)
+
 task getBlastAllDatabases() {
     doLast {
         exec {

--- a/console.gradle
+++ b/console.gradle
@@ -35,7 +35,7 @@ task importCloneAssembly(type: JavaExec) {
     main = 'org.zfin.mapping.importer.ImportCloneAssemblyTask'
 }
 
-task NCBILoadTask(type: JavaExec) {
+task NCBILoadFastaTask(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'org.zfin.datatransfer.webservice.BatchNCBIFastaFetchTask'
     systemProperty "ncbiLoadInput", System.getProperty("ncbiLoadInput", null)

--- a/server_apps/data_transfer/NCBIGENE/NCBI_gene_load.pl
+++ b/server_apps/data_transfer/NCBIGENE/NCBI_gene_load.pl
@@ -2825,7 +2825,7 @@ sub calculateLengthForAccessionsWithoutLength {
         my $cmdEfetch = "cd " . $ENV{'SOURCEROOT'} . " ; " .
             "gradle '-DncbiLoadInput=$currentDir/noLength.unl' " .
             "       '-DncbiLoadOutput=$currentDir/seq.fasta' " .
-            "         NCBILoadTask ; " .
+            "         NCBILoadFastaTask ; " .
             "cd $currentDir";
         print "Executing $cmdEfetch\n";
         print LOG "Executing $cmdEfetch\n";

--- a/source/org/zfin/datatransfer/ncbi/NCBILoadTask.java
+++ b/source/org/zfin/datatransfer/ncbi/NCBILoadTask.java
@@ -1,0 +1,38 @@
+package org.zfin.datatransfer.ncbi;
+
+import lombok.extern.log4j.Log4j2;
+import org.zfin.ontology.datatransfer.AbstractScriptWrapper;
+
+
+/**
+ * Batch fetch to pull in FASTA files from NCBI
+ *
+ */
+@Log4j2
+public class NCBILoadTask extends AbstractScriptWrapper {
+
+
+    public static void main(String[] args) {
+        NCBILoadTask task = new NCBILoadTask();
+        task.run();
+    }
+
+    public NCBILoadTask() {
+        initAll();
+    }
+
+    public void run() {
+        log.info("Starting NCBI Load Task");
+        Integer release = getReleaseNumber();
+        //... more to come
+        log.info("Finished NCBI Load Task");
+    }
+
+    private Integer getReleaseNumber() {
+        NCBIReleaseFetcher fetcher = new NCBIReleaseFetcher();
+        Integer release = fetcher.getCurrentRelease().orElseThrow(() -> new RuntimeException("Could not fetch release number"));
+        log.info("Current release is: " + release);
+        return release;
+    }
+
+}

--- a/source/org/zfin/datatransfer/ncbi/NCBIReleaseFetcher.java
+++ b/source/org/zfin/datatransfer/ncbi/NCBIReleaseFetcher.java
@@ -1,0 +1,37 @@
+package org.zfin.datatransfer.ncbi;
+
+import lombok.Setter;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+@Setter
+public class NCBIReleaseFetcher {
+    public static final String DEFAULT_URL = "https://ftp.ncbi.nlm.nih.gov/refseq/release/RELEASE_NUMBER";
+    public String releaseUrl;
+
+    public Optional<Integer> getCurrentRelease() {
+        //make http request to releaseUrl
+        try {
+            String contents = IOUtils.toString(new URL(getReleaseUrl()), StandardCharsets.UTF_8);
+            Integer release = Integer.parseInt(contents.trim());
+            if (release > 0) {
+                return Optional.of(release);
+            } else {
+                return Optional.empty();
+            }
+        } catch (IOException e) {
+            return Optional.empty();
+        }
+    }
+
+    public String getReleaseUrl() {
+        if (releaseUrl == null) {
+            return DEFAULT_URL;
+        }
+        return releaseUrl;
+    }
+}

--- a/test/org/zfin/datatransfer/ncbi/NCBIReleaseFetcherTest.java
+++ b/test/org/zfin/datatransfer/ncbi/NCBIReleaseFetcherTest.java
@@ -1,0 +1,67 @@
+package org.zfin.datatransfer.ncbi;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit test class for FileUtil.
+ */
+public class NCBIReleaseFetcherTest {
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+
+    }
+
+    @Test
+    public void getCurrentReleaseTest() {
+        NCBIReleaseFetcher fetcher = new NCBIReleaseFetcher();
+        Optional<Integer> release = fetcher.getCurrentRelease();
+        assertTrue(release.isPresent());
+
+        //should be greater than 100
+        assertTrue(release.get() > 100);
+    }
+
+    @Test
+    public void getReleaseUrlCannotConnectTest() {
+        NCBIReleaseFetcher fetcher = new NCBIReleaseFetcher();
+        fetcher.setReleaseUrl("http://127.0.0.1/bogus/url/meant/to/fail");
+        Optional<Integer> release = fetcher.getCurrentRelease();
+        assertTrue(release.isEmpty());
+    }
+
+    @Test
+    public void getReleaseUrlCannotParseTest() {
+        NCBIReleaseFetcher fetcher = new NCBIReleaseFetcher();
+        fetcher.setReleaseUrl("https://www.google.com");
+        Optional<Integer> release = fetcher.getCurrentRelease();
+        assertTrue(release.isEmpty());
+    }
+
+    @Test
+    public void getReleaseUrlFailsOnZeroTest() throws IOException {
+        NCBIReleaseFetcher fetcher = new NCBIReleaseFetcher();
+
+        //temporary file that will be deleted after test using the jre temp directory
+        Path file = Files.createTempFile(Path.of(System.getProperty("java.io.tmpdir")), "test", ".txt");         
+        Files.writeString(file, "0");
+
+        fetcher.setReleaseUrl(file.toUri().toString());
+        Optional<Integer> release = fetcher.getCurrentRelease();
+        Files.delete(file);
+        assertTrue(release.isEmpty());
+    }
+}


### PR DESCRIPTION
This is the skeleton of the java NCBI load. It includes the parser that fetches the RELEASE_NUMBER file from NCBI and parses it to get the current release (an integer).