### PR TITLE
ZFIN-9207: Fix sorting on curator dashboard

### DIFF
--- a/source/org/zfin/db/postGmakePostloaddb/1157/ZFIN-9207.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1157/ZFIN-9207.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+--changeset rtaylor:ZFIN-9207.sql
+-- Add a column to the pub_tracking_status table to allow for custom ordering of statuses on the dashboard
+-- Put the 'Waiting for Author' status at the bottom of the list
+
+ALTER table pub_tracking_status add column pts_dashboard_order int;
+UPDATE pub_tracking_status set pts_dashboard_order = pts_pk_id;
+UPDATE pub_tracking_status set pts_dashboard_order = 30 where pts_status_display = 'Waiting for Author';

--- a/source/org/zfin/db/postGmakePostloaddb/1157/db.changelog.master.xml
+++ b/source/org/zfin/db/postGmakePostloaddb/1157/db.changelog.master.xml
@@ -8,5 +8,6 @@
     <include file="source/org/zfin/db/postGmakePostloaddb/1157/ZFIN-9155-pre.sql" />
     <include file="source/org/zfin/db/postGmakePostloaddb/1157/ZFIN-9155.xml" />
     <include file="source/org/zfin/db/postGmakePostloaddb/1157/ZFIN-9155.sql" />
+    <include file="source/org/zfin/db/postGmakePostloaddb/1157/ZFIN-9207.sql" />
 
 </databaseChangeLog>

--- a/source/org/zfin/publication/PublicationTrackingHistory.java
+++ b/source/org/zfin/publication/PublicationTrackingHistory.java
@@ -1,11 +1,15 @@
 package org.zfin.publication;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.zfin.profile.Person;
 import org.zfin.publication.presentation.PublicationEvent;
 
 import javax.persistence.*;
 import java.util.GregorianCalendar;
 
+@Setter
+@Getter
 @Entity
 @Table(name = "pub_tracking_history")
 public class PublicationTrackingHistory implements PublicationEvent {
@@ -41,69 +45,8 @@ public class PublicationTrackingHistory implements PublicationEvent {
     @Column(name = "pth_status_is_current", updatable = false, insertable = false)
     private Boolean isCurrent;
 
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
-
-    public Publication getPublication() {
-        return publication;
-    }
-
-    public void setPublication(Publication publication) {
-        this.publication = publication;
-    }
-
-    public PublicationTrackingStatus getStatus() {
-        return status;
-    }
-
-    public void setStatus(PublicationTrackingStatus status) {
-        this.status = status;
-    }
-
-    public PublicationTrackingLocation getLocation() {
-        return location;
-    }
-
-    public void setLocation(PublicationTrackingLocation location) {
-        this.location = location;
-    }
-
-    public Person getOwner() {
-        return owner;
-    }
-
-    public void setOwner(Person owner) {
-        this.owner = owner;
-    }
-
-    public Person getUpdater() {
-        return updater;
-    }
-
-    public void setUpdater(Person updater) {
-        this.updater = updater;
-    }
-
-    @Override
-    public GregorianCalendar getDate() {
-        return date;
-    }
-
-    public void setDate(GregorianCalendar date) {
-        this.date = date;
-    }
-
     public Boolean isCurrent() {
         return isCurrent;
-    }
-
-    public void setIsCurrent(Boolean isCurrent) {
-        this.isCurrent = isCurrent;
     }
 
     @Override

--- a/source/org/zfin/publication/PublicationTrackingStatus.java
+++ b/source/org/zfin/publication/PublicationTrackingStatus.java
@@ -2,11 +2,15 @@ package org.zfin.publication;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonView;
+import lombok.Getter;
+import lombok.Setter;
 import org.zfin.framework.api.View;
 
 import javax.persistence.*;
 import java.util.Arrays;
 
+@Setter
+@Getter
 @Entity
 @Table(name = "pub_tracking_status")
 public class PublicationTrackingStatus {
@@ -96,52 +100,12 @@ public class PublicationTrackingStatus {
     @JsonView(View.API.class)
     private boolean hidden;
 
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
-
-    public Type getType() {
-        return type;
-    }
-
-    public void setType(Type type) {
-        this.type = type;
-    }
-
-    public Name getName() {
-        return name;
-    }
-
-    public void setName(Name name) {
-        this.name = name;
-    }
-
-    public String getQualifier() {
-        return qualifier;
-    }
-
-    public void setQualifier(String qualifier) {
-        this.qualifier = qualifier;
-    }
+    @Column(name = "pts_dashboard_order")
+    @JsonView(View.API.class)
+    private int dashboardOrder;
 
     public boolean isTerminal() {
         return isTerminal;
-    }
-
-    public void setIsTerminal(boolean isTerminal) {
-        this.isTerminal = isTerminal;
-    }
-
-    public boolean isHidden() {
-        return hidden;
-    }
-
-    public void setHidden(boolean hidden) {
-        this.hidden = hidden;
     }
 
     @Override

--- a/source/org/zfin/publication/repository/HibernatePublicationRepository.java
+++ b/source/org/zfin/publication/repository/HibernatePublicationRepository.java
@@ -2432,9 +2432,9 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
         }
         hql += " where " + String.join(" and ", hqlClauses);
         if (groupBy) {
-            hql += " group by pubTrack.status.name ";
+            hql += " group by pubTrack.status.name, pubTrack.status.id ";
         }
-        hql += " order by pubTrack.status.name ";
+        hql += " order by pubTrack.status.id ";
         if (StringUtils.isNotEmpty(sort)) {
             boolean isAscending = true;
             if (sort.startsWith("-")) {

--- a/source/org/zfin/publication/repository/HibernatePublicationRepository.java
+++ b/source/org/zfin/publication/repository/HibernatePublicationRepository.java
@@ -2432,9 +2432,9 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
         }
         hql += " where " + String.join(" and ", hqlClauses);
         if (groupBy) {
-            hql += " group by pubTrack.status.name, pubTrack.status.id ";
+            hql += " group by pubTrack.status.name, pubTrack.status.dashboardOrder ";
         }
-        hql += " order by pubTrack.status.id ";
+        hql += " order by pubTrack.status.dashboardOrder ";
         if (StringUtils.isNotEmpty(sort)) {
             boolean isAscending = true;
             if (sort.startsWith("-")) {


### PR DESCRIPTION
The refactor in commit db5dd8516eb changed the sort order. It was previously sorted by "status" and that got changed to "status.name" (where status refers to PublicationTrackingStatus class). I believe sorting by "status" is equivalent to sorting by "status.id" and I confirmed that sort matches our requirements for this ticket.