### PR TITLE
ZFIN-9237 & ZFIN-9238 & ZFIN-9118: Fix QuickSearchDialog

### DIFF
--- a/home/javascript/react/containers/QuickSearchDialog.js
+++ b/home/javascript/react/containers/QuickSearchDialog.js
@@ -44,6 +44,15 @@ const QuickSearchDialog = ({baseUrlWithoutPage, queryString, eventBus}) => {
         setFilter(event.target.value);
     }
 
+    const handlePageSizeChange = (e) => {
+        const newPageSize = e.target.value;
+        const newLastPageNumber = lastPageNumberByPageSize(newPageSize);
+        setPageSize(newPageSize);
+        if (page > newLastPageNumber) {
+            setPage(newLastPageNumber);
+        }
+    }
+
     //important!  the input to a filter is the entire list, not one record at a time
     const filteredValues = () => {
         let input = facetValues;
@@ -106,6 +115,10 @@ const QuickSearchDialog = ({baseUrlWithoutPage, queryString, eventBus}) => {
         return Math.ceil(filteredValues().length / pageSize);
     }
 
+    const lastPageNumberByPageSize = (byPageSize) => {
+        return Math.ceil(filteredValues().length / byPageSize);
+    }
+
     const nextPage = () => {
         if (page < lastPageNumber()) {
             setPage(page + 1);
@@ -137,7 +150,9 @@ const QuickSearchDialog = ({baseUrlWithoutPage, queryString, eventBus}) => {
                         <a className='facet-exclude' href={baseUrlWithoutPage + 'fq=-' + field + ':%22' + row.name + '%22'}>
                             <i className='include-exclude-icon fa fa-minus-circle'/>
                         </a>{' '}
-                        {' '}<a href={baseUrlWithoutPage + 'fq=' + field + ':%22' + row.name + '%22'}>{row.value}</a>{' '}
+                        {' '}
+                        <a href={baseUrlWithoutPage + 'fq=' + field + ':%22' + row.name + '%22'} dangerouslySetInnerHTML={{__html: row.value}}/>
+                        {' '}
                         {' '}<span style={{'paddingLeft': '1em'}} className='float-right'>({row.count})</span>{' '}
                     </li>
                 )}
@@ -156,7 +171,7 @@ const QuickSearchDialog = ({baseUrlWithoutPage, queryString, eventBus}) => {
                     Show:{' '}
                     <select
                         value={pageSize}
-                        onChange={(e) => {setPageSize(e.target.value)}}
+                        onChange={handlePageSizeChange}
                         style={{'width': '4em', 'position': 'relative', 'top': '.3em'}}
                     >
                         <option value='10'>10</option>

--- a/source/org/zfin/framework/api/Pagination.java
+++ b/source/org/zfin/framework/api/Pagination.java
@@ -21,7 +21,7 @@ public class Pagination {
     private List<String> invalidFilterList = new ArrayList<>();
 
     private Map<String, String> filterMap = new HashMap<>();
-    private Map<String, String> exactFilterMap = new HashMap<>();
+    private Map<String, Boolean> booleanFilterMap = new HashMap<>();
     private Set<String> notNullFilterMap = new HashSet<>();
     private Set<String> nullFilterMap = new HashSet<>();
     private boolean isCount = false;
@@ -181,8 +181,16 @@ public class Pagination {
         filterMap.put(key, value);
     }
 
-    public void addToExactFilterMap(String key, String value) {
-        exactFilterMap.put(key, value);
+    public void addToBooleanFilterMapIfNotNull(String s, Boolean booleanValue) {
+        if (booleanValue != null) {
+            booleanFilterMap.put(s, booleanValue);
+        }
+    }
+
+    public void addToFilterMapIfNotEmpty(String key, String value) {
+        if (StringUtils.isNotEmpty(value)) {
+            filterMap.put(key, value);
+        }
     }
 
     public void addToNotNullFilterMap(String value) {
@@ -195,10 +203,6 @@ public class Pagination {
 
     public Map<String, String> getFilterMap() {
         return filterMap;
-    }
-
-    public Map<String, String> getExactFilterMap() {
-        return exactFilterMap;
     }
 
     public Set<String> getNotNullFilterMap() {

--- a/source/org/zfin/ontology/presentation/TermAPIController.java
+++ b/source/org/zfin/ontology/presentation/TermAPIController.java
@@ -218,30 +218,18 @@ public class TermAPIController {
         if (isAmelioratedExacerbated != null) {
             pagination.addToNotNullFilterMap("chebiPhenotype.amelioratedExacerbatedPhenoSearch");
         }
-        if (wildType != null) {
-            pagination.addToExactFilterMap("chebiPhenotype.fish.wildtype", wildType ? "t" : "f");
-        }
-        if (isMultiChebiCondition != null) {
-            pagination.addToExactFilterMap("chebiPhenotype.multiChebiCondition", isMultiChebiCondition ? "t" : "f");
-        }
-        if (StringUtils.isNotEmpty(filterConditionName)) {
-            pagination.addToFilterMap("chebiPhenotype.conditionSearch", filterConditionName);
-        }
-        if (StringUtils.isNotEmpty(filterModification)) {
-            pagination.addToFilterMap("chebiPhenotype.amelioratedExacerbatedPhenoSearch", filterModification);
-        }
-        if (StringUtils.isNotEmpty(filterFishName)) {
-            pagination.addToFilterMap("chebiPhenotype.fish.name", filterFishName);
-        }
-        if (StringUtils.isNotEmpty(filterPhenotype)) {
-            pagination.addToFilterMap("chebiPhenotype.phenotypeStatementSearch", filterPhenotype);
-        }
-        if (StringUtils.isNotEmpty(filterTermName)) {
-            pagination.addToFilterMap("chebiPhenotype.expConditionChebiSearch", filterTermName);
-        }
 
-        PaginationResult<ChebiPhenotypeDisplay> genesInvolvedForDiseaseDirect = getDiseasePageRepository().getPhenotypeChebi(term, pagination, false);
-        PaginationResult<ChebiPhenotypeDisplay> genesInvolvedForDiseaseAll = getDiseasePageRepository().getPhenotypeChebi(term, pagination, true);
+        pagination.addToBooleanFilterMapIfNotNull("chebiPhenotype.fish.wildtype", wildType);
+        pagination.addToBooleanFilterMapIfNotNull("chebiPhenotype.multiChebiCondition", isMultiChebiCondition);
+
+        pagination.addToFilterMapIfNotEmpty("chebiPhenotype.conditionSearch", filterConditionName);
+        pagination.addToFilterMapIfNotEmpty("chebiPhenotype.amelioratedExacerbatedPhenoSearch", filterModification);
+        pagination.addToFilterMapIfNotEmpty("chebiPhenotype.fish.name", filterFishName);
+        pagination.addToFilterMapIfNotEmpty("chebiPhenotype.phenotypeStatementSearch", filterPhenotype);
+        pagination.addToFilterMapIfNotEmpty("chebiPhenotype.expConditionChebiSearch", filterTermName);
+
+        PaginationResult<ChebiPhenotypeDisplay> genesInvolvedForDiseaseDirect = getDiseasePageRepository().getPhenotypeChebi(term, pagination, filterPhenotype, false);
+        PaginationResult<ChebiPhenotypeDisplay> genesInvolvedForDiseaseAll = getDiseasePageRepository().getPhenotypeChebi(term, pagination, filterPhenotype, true);
 
         int totalCountDirect = genesInvolvedForDiseaseDirect.getTotalCount();
         response.addSupplementalData("countDirect", totalCountDirect);

--- a/source/org/zfin/ui/repository/DiseasePageRepository.java
+++ b/source/org/zfin/ui/repository/DiseasePageRepository.java
@@ -22,7 +22,7 @@ public interface DiseasePageRepository {
     List<ChebiFishModelDisplay> getFishDiseaseChebiModels(GenericTerm term, boolean includeChildren);
     List<FishModelDisplay> getAllFishDiseaseModels();
 
-    PaginationResult<ChebiPhenotypeDisplay> getPhenotypeChebi(GenericTerm term, Pagination pagination, boolean includeChildren);
+    PaginationResult<ChebiPhenotypeDisplay> getPhenotypeChebi(GenericTerm term, Pagination pagination, String filterPhenotype, boolean includeChildren);
 
     int deleteUiTables(String... tableName);
 }


### PR DESCRIPTION
Fix 2 aspects of the facet dialog (QuickSearchDialog) that appears when you click "Show All" on the facets:

1. pagination could get into a weird state if you paginated, then changed the page size (ZFIN-9118)
2. Some facets have html (like <sup>...</sup>) that was not getting rendered correctly.