### PR TITLE
ZFIN-9237: Use unique key for each row returned by API

### DIFF
--- a/home/javascript/react/containers/ChebiModifiedPhenotypeTable.js
+++ b/home/javascript/react/containers/ChebiModifiedPhenotypeTable.js
@@ -103,7 +103,7 @@ const ChebiModifiedPhenotypeTable = ({termId, directAnnotationOnly, endpointUrl 
                 columns={columns}
                 dataUrl={`/action/api/ontology/${termId}/${endpointUrl}?${qs.stringify(params)}`}
                 onDataLoadedCount={(count) => setCount(count)}
-                rowKey={row => row.fish.zdbID}
+                rowKey={row => JSON.stringify(row)}
             />
         </>
     );


### PR DESCRIPTION
Use JSON.stringify to create a unique key for each row based on the exact string representation of the row