### PR TITLE
ZFIN-9239: Table layout

### DIFF
--- a/home/javascript/react/components/data-table/DataTable.js
+++ b/home/javascript/react/components/data-table/DataTable.js
@@ -21,6 +21,7 @@ const DataTable = ({
     setTableState,
     sortOptions,
     tableState,
+    tableFixed = true,
 }) => {
     [tableState, setTableState] = useTableState(tableState, setTableState);
 
@@ -51,6 +52,7 @@ const DataTable = ({
             rowKey={rowKey}
             supplementalData={response.supplementalData}
             total={response.total}
+            tableFixed={tableFixed}
         />
     );
 
@@ -83,6 +85,7 @@ DataTable.propTypes = {
     setTableState: PropTypes.func,
     sortOptions: PropTypes.arrayOf(sortOptionType),
     tableState: tableStateType,
+    tableFixed: PropTypes.bool,
 };
 
 export default DataTable;

--- a/home/javascript/react/components/data-table/Table.js
+++ b/home/javascript/react/components/data-table/Table.js
@@ -12,14 +12,22 @@ const Table = ({
     rowKey,
     supplementalData,
     total,
+    tableFixed = true,
 }) => {
     return (
         <div className='horizontal-scroll-container'>
-            <table className='data-table table-fixed'>
+            <table className={'data-table' + (tableFixed ? ' table-fixed' : '')}>
                 <thead>
                     <tr>
                         {columns.map(column => !column.hidden && (
-                            <th key={column.key || column.label} style={{width: column.width, textAlign: column.align}}>
+                            <th
+                                key={column.key || column.label}
+                                style={{
+                                    width: column.width,
+                                    textAlign: column.align,
+                                    ...(column.whiteSpace && { whiteSpace: column.whiteSpace })
+                                }}
+                            >
                                 {columnHeaderFormat ?
                                     columnHeaderFormat(column, supplementalData) :
                                     column.label
@@ -67,6 +75,7 @@ Table.propTypes = {
     rowKey: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     supplementalData: PropTypes.object,
     total: PropTypes.number,
+    tableFixed: PropTypes.bool,
 };
 
 export default Table;

--- a/home/javascript/react/containers/PublicationMutationTable.js
+++ b/home/javascript/react/containers/PublicationMutationTable.js
@@ -13,7 +13,6 @@ const PublicationMarkerTable = ({url, title, navigationCounter}) => {
         {
             label: 'Construct',
             content: row => (<EntityList entities={row.tgConstructs}/>),
-            width: '250px',
         },
         {
             label: 'Type',
@@ -22,6 +21,7 @@ const PublicationMarkerTable = ({url, title, navigationCounter}) => {
         {
             label: 'Affected Genomic Region',
             content: row => (<EntityList entities={row.affectedGenes}/>),
+            whiteSpace: 'nowrap',
         },
     ];
 
@@ -38,6 +38,7 @@ const PublicationMarkerTable = ({url, title, navigationCounter}) => {
             rowKey={row => row.zdbID}
             pagination={true}
             onDataLoaded={handleDataLoadedCount}
+            tableFixed={false}
         />
     );
 };


### PR DESCRIPTION
In some cases we do not want a fixed table (table-layout: fixed;). In order to accommodate long construct names with no breaking characters, this makes the Mutations/Transgenics table non-fixed.