### PR TITLE
ZFIN-9335: Add ensembl load pub as a UniProt "load pub" 

### DIFF
--- a/server_apps/jenkins/jobs/UniProt-Diff-Load/config.xml
+++ b/server_apps/jenkins/jobs/UniProt-Diff-Load/config.xml
@@ -36,12 +36,13 @@
     <hudson.tasks.Shell>
       <command>
         <![CDATA[
+TIMESTAMP=`date +%Y-%m-%d_%H-%M-%S`
 echo "WORKSPACE=$WORKSPACE"
 echo "PWD=$PWD"
 echo "UNIPROT_COMMIT_CHANGES=$UNIPROT_COMMIT_CHANGES"
-rm -f $PWD/uniprot_load_report.html $PWD/uniprot_context.json
-export UNIPROT_OUTPUT_REPORT_FILE="$PWD/uniprot_load_report.html"
-export UNIPROT_CONTEXT_FILE="$PWD/uniprot_context.json"
+rm -f $PWD/uniprot_load_report*.html $PWD/uniprot_context*.json $PWD/uniprot_load_report*.html.zip $PWD/uniprot_context*.json.zip
+export UNIPROT_OUTPUT_REPORT_FILE="$PWD/uniprot_load_report_$TIMESTAMP.html.zip"
+export UNIPROT_CONTEXT_FILE="$PWD/uniprot_context_$TIMESTAMP.json.zip"
 cd $SOURCEROOT
 gradle uniprotLoadTask
         ]]>

--- a/server_apps/jenkins/jobs/UniProt-Secondary-Term-Load/config.xml
+++ b/server_apps/jenkins/jobs/UniProt-Secondary-Term-Load/config.xml
@@ -42,11 +42,12 @@
     <hudson.tasks.Shell>
       <command>
         <![CDATA[
+TIMESTAMP=`date +%Y-%m-%d_%H-%M-%S`
 echo "WORKSPACE=$WORKSPACE"
 echo "PWD=$PWD"
 echo "UNIPROT_LOAD_MODE=$UNIPROT_LOAD_MODE"
-rm -f $PWD/uniprot_secondary_load_report.json $PWD/uniprot_secondary_load_report.json.report.html
-export UNIPROT_OUTPUT_FILE="$PWD/uniprot_secondary_load_report.json"
+rm -f $PWD/uniprot_secondary_load_report.json $PWD/uniprot_secondary_load_report.json.report.html $PWD/uniprot_secondary_load_report*.json.zip $PWD/uniprot_secondary_load_report*.html.zip
+export UNIPROT_OUTPUT_FILE="$PWD/uniprot_secondary_load_report_$TIMESTAMP.json.zip"
 cd $SOURCEROOT
 gradle uniprotSecondaryTermLoadTask
         ]]>

--- a/source/org/zfin/infrastructure/repository/HibernateInfrastructureRepository.java
+++ b/source/org/zfin/infrastructure/repository/HibernateInfrastructureRepository.java
@@ -1778,6 +1778,19 @@ public class HibernateInfrastructureRepository implements InfrastructureReposito
     }
 
     @Override
+    public UniProtRelease getLatestProcessedUniProtRelease() {
+        Session session = currentSession();
+        CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+
+        CriteriaQuery<UniProtRelease> query = criteriaBuilder.createQuery(UniProtRelease.class);
+        Root<UniProtRelease> uniProtRelease = query.from(UniProtRelease.class);
+        query.where(criteriaBuilder.isNotNull(uniProtRelease.get("processedDate")));
+        query.orderBy(criteriaBuilder.desc(uniProtRelease.get("date")));
+
+        return session.createQuery(query).getResultList().stream().findFirst().orElse(null);
+    }
+
+    @Override
     public List<UniProtRelease> getAllUniProtReleases() {
         Session session = currentSession();
         CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();

--- a/source/org/zfin/infrastructure/repository/InfrastructureRepository.java
+++ b/source/org/zfin/infrastructure/repository/InfrastructureRepository.java
@@ -424,6 +424,8 @@ public interface InfrastructureRepository {
     UniProtRelease getUniProtReleaseByDate(Date date);
     UniProtRelease getLatestUnprocessedUniProtRelease();
 
+    UniProtRelease getLatestProcessedUniProtRelease();
+
     List<UniProtRelease> getAllUniProtReleases();
 
     UniProtRelease getUniProtReleaseByID(Long id);

--- a/source/org/zfin/uniprot/UniProtTools.java
+++ b/source/org/zfin/uniprot/UniProtTools.java
@@ -17,7 +17,7 @@ public class UniProtTools {
     public static final String CURATION_OF_PROTEIN_DATABASE_LINKS = "ZDB-PUB-020723-2";
     public static final String AUTOMATED_CURATION_OF_UNIPROT_DATABASE_LINKS = "ZDB-PUB-230615-71";
 
-    public static final String[] LOAD_PUBS = new String[]{CURATION_OF_PROTEIN_DATABASE_LINKS, AUTOMATED_CURATION_OF_UNIPROT_DATABASE_LINKS};
+    public static final String[] LOAD_PUBS = new String[]{CURATION_OF_PROTEIN_DATABASE_LINKS, AUTOMATED_CURATION_OF_UNIPROT_DATABASE_LINKS, UNIPROT_ID_LOAD_FROM_ENSEMBL};
 
 
     //use passed in lambda expression to transform the notes

--- a/source/org/zfin/uniprot/secondary/SecondaryLoadContext.java
+++ b/source/org/zfin/uniprot/secondary/SecondaryLoadContext.java
@@ -374,14 +374,18 @@ public class SecondaryLoadContext {
     }
 
     public Map<String, List<DBLinkSlimDTO>> getMapOfDbLinksByAccession(ForeignDB.AvailableName dbName) {
-        return switch (dbName) {
+        Map<String, List<DBLinkSlimDTO>> dblinks = switch (dbName) {
             case INTERPRO -> getInterproDbLinks();
             case EC -> getEcDbLinks();
             case PFAM -> getPfamDbLinks();
             case PROSITE -> getPrositeDbLinks();
             case UNIPROTKB -> getUniprotDbLinks();
-            default -> null;
+            default -> Collections.emptyMap();
         };
+        if (dblinks == null) {
+            return Collections.emptyMap();
+        }
+        return dblinks;
     }
 
     public List<DBLinkSlimDTO> getFlattenedDbLinksByDbName(ForeignDB.AvailableName dbName) {
@@ -414,6 +418,11 @@ public class SecondaryLoadContext {
     }
     public List<MarkerGoTermEvidenceSlimDTO> getExistingMarkerGoTermEvidenceRecords(ForeignDB.AvailableName dbName) {
         String pubID = getPubIDForMarkerGoTermEvidenceByDB(dbName);
+
+        if (getExistingMarkerGoTermEvidenceRecords() == null) {
+            return Collections.emptyList();
+        }
+
         return this.getExistingMarkerGoTermEvidenceRecords()
                 .stream()
                 .filter(markerGoTermEvidenceSlimDTO -> markerGoTermEvidenceSlimDTO.getPublicationID().equals(pubID))

--- a/source/org/zfin/uniprot/secondary/handlers/InterproDomainActionCreator.java
+++ b/source/org/zfin/uniprot/secondary/handlers/InterproDomainActionCreator.java
@@ -38,10 +38,10 @@ public class InterproDomainActionCreator implements ActionCreator {
         List<SecondaryTermLoadAction> newActions = new ArrayList<>();
 
         //existing records
-        List<InterProProteinDTO> existingProteinDomains = context.getExistingInterproDomainRecords();
+        List<InterProProteinDTO> existingProteinDomains = (context.getExistingInterproDomainRecords() != null) ? context.getExistingInterproDomainRecords() : new ArrayList<>();
 
         //new records from download file
-        List<InterProProteinDTO> newProteinDomains = downloadedInterproDomainRecords;
+        List<InterProProteinDTO> newProteinDomains = (downloadedInterproDomainRecords != null) ? downloadedInterproDomainRecords : new ArrayList<>();
 
         //create new result set that contains only records in the existing records and not in the new records
         List<InterProProteinDTO> toDeleteProteinDomains = ListUtils.subtract(existingProteinDomains, newProteinDomains);

--- a/source/org/zfin/uniprot/secondary/handlers/InterproProteinActionCreator.java
+++ b/source/org/zfin/uniprot/secondary/handlers/InterproProteinActionCreator.java
@@ -30,7 +30,7 @@ public class InterproProteinActionCreator implements ActionCreator {
     @Override
     public List<SecondaryTermLoadAction> createActions(UniprotReleaseRecords uniProtRecords, List<SecondaryTermLoadAction> actions, SecondaryLoadContext context) {
 
-        List<ProteinDTO> existingProteins = context.getExistingProteinRecords();
+        List<ProteinDTO> existingProteins = (context.getExistingProteinRecords() != null) ? context.getExistingProteinRecords() : new ArrayList<>();
         List<ProteinDTO> proteinsToKeep = new ArrayList<>();
         List<SecondaryTermLoadAction> newActions = new ArrayList<>();
 

--- a/source/org/zfin/uniprot/secondary/handlers/PDBActionCreator.java
+++ b/source/org/zfin/uniprot/secondary/handlers/PDBActionCreator.java
@@ -28,7 +28,7 @@ public class PDBActionCreator implements ActionCreator {
     @Override
     public List<SecondaryTermLoadAction> createActions(UniprotReleaseRecords uniProtRecords, List<SecondaryTermLoadAction> actions, SecondaryLoadContext context) {
 
-        List<PdbDTO> existingRecords = context.getExistingPdbRecords();
+        List<PdbDTO> existingRecords = (context.getExistingPdbRecords() != null) ? context.getExistingPdbRecords() : new ArrayList<>();
         List<PdbDTO> keepRecords = new ArrayList<>(); //all the records to keep (not delete) includes new records too
         List<SecondaryTermLoadAction> newActions = new ArrayList<>();
 

--- a/source/org/zfin/uniprot/secondary/handlers/ProteinToInterproActionCreator.java
+++ b/source/org/zfin/uniprot/secondary/handlers/ProteinToInterproActionCreator.java
@@ -26,7 +26,7 @@ public class ProteinToInterproActionCreator implements ActionCreator {
     @Override
     public List<SecondaryTermLoadAction> createActions(UniprotReleaseRecords uniProtRecords, List<SecondaryTermLoadAction> actions, SecondaryLoadContext context) {
 
-        List<ProteinToInterproDTO> existingRecords = context.getExistingProteinToInterproRecords();
+        List<ProteinToInterproDTO> existingRecords = (context.getExistingProteinToInterproRecords() != null) ? context.getExistingProteinToInterproRecords() : new java.util.ArrayList<>();
         List<ProteinToInterproDTO> keepRecords = new java.util.ArrayList<>(); //all the records to keep (not delete) includes new records too
         List<SecondaryTermLoadAction> newActions = new java.util.ArrayList<>();
 

--- a/source/org/zfin/uniprot/task/UniProtLoadTask.java
+++ b/source/org/zfin/uniprot/task/UniProtLoadTask.java
@@ -26,6 +26,7 @@ import org.zfin.uniprot.persistence.UniProtRelease;
 import static org.zfin.repository.RepositoryFactory.getInfrastructureRepository;
 import static org.zfin.uniprot.UniProtFilterTask.readAllZebrafishEntriesFromSourceIntoMap;
 import static org.zfin.uniprot.UniProtTools.getArgOrEnvironmentVar;
+import static org.zfin.util.FileUtil.writeToFileOrZip;
 
 /**
  * The UniProtLoadTask class loads UniProt data from a given dat file,
@@ -146,7 +147,7 @@ public class UniProtLoadTask extends AbstractScriptWrapper {
             ObjectMapper objectMapper = new ObjectMapper();
             try {
                 log.info("Writing context file: " + contextOutputFile + ".");
-                objectMapper.writeValue(new File(contextOutputFile), context);
+                writeToFileOrZip(new File(contextOutputFile), objectMapper.writeValueAsString(context), "UTF-8");
             } catch (IOException e) {
                 log.error("Error writing context file " + contextOutputFile + ": " + e.getMessage(), e);
             }
@@ -154,10 +155,18 @@ public class UniProtLoadTask extends AbstractScriptWrapper {
     }
 
     private void setInputFileName() {
-        Optional<UniProtRelease> releaseOptional = getLatestUnprocessedUniProtRelease();
-        if (inputFileName.isEmpty() && releaseOptional.isPresent()) {
-            inputFileName = releaseOptional.get().getLocalFile().getAbsolutePath();
-            release = releaseOptional.get();
+        Optional<UniProtRelease> latestUnprocessedUniProtRelease = getLatestUnprocessedUniProtRelease();
+        if (inputFileName.isEmpty() && latestUnprocessedUniProtRelease.isPresent()) {
+
+            //if the latest unprocessed release is older than a processed release, throw an exception
+            UniProtRelease latestProcessed = getInfrastructureRepository().getLatestProcessedUniProtRelease();
+            if (latestProcessed != null && latestProcessed.getDownloadDate().after(latestUnprocessedUniProtRelease.get().getDownloadDate())) {
+                throw new RuntimeException("The latest unprocessed UniProt release (from " + latestUnprocessedUniProtRelease.get().getDownloadDate() + ") is older than the latest processed UniProt release (from " + latestProcessed.getDownloadDate() + ").");
+            }
+
+            log.info("No input file specified, using latest unprocessed UniProt release: " + latestUnprocessedUniProtRelease.get().getLocalFile().getAbsolutePath() + ".");
+            inputFileName = latestUnprocessedUniProtRelease.get().getLocalFile().getAbsolutePath();
+            release = latestUnprocessedUniProtRelease.get();
         } else if (inputFileName.isEmpty()) {
             throw new RuntimeException("No input file specified and no unprocessed UniProt release found.");
         }
@@ -199,8 +208,8 @@ public class UniProtLoadTask extends AbstractScriptWrapper {
             String template = ZfinPropertiesEnum.SOURCEROOT.value() + LOAD_REPORT_TEMPLATE_HTML;
             String templateContents = FileUtils.readFileToString(new File(template), "UTF-8");
             String filledTemplate = templateContents.replace(JSON_PLACEHOLDER_IN_TEMPLATE, jsonContents);
-            FileUtils.writeStringToFile(new File(reportFile), filledTemplate, "UTF-8");
-            FileUtils.writeStringToFile(new File(jsonFile), jsonContents, "UTF-8");
+            writeToFileOrZip(new File(reportFile), filledTemplate, "UTF-8");
+            writeToFileOrZip(new File(jsonFile), jsonContents, "UTF-8");
             log.info("Finished creating report file: " + reportFile + " and json file: " + jsonFile);
         } catch (IOException e) {
             log.error("Error creating report (" + reportFile + ") from template\n" + e.getMessage(), e);

--- a/source/org/zfin/util/FileUtil.java
+++ b/source/org/zfin/util/FileUtil.java
@@ -1,5 +1,6 @@
 package org.zfin.util;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -8,9 +9,12 @@ import org.zfin.properties.ZfinPropertiesEnum;
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 /**
  * Utility class for creating file path names and other things.
@@ -415,6 +419,47 @@ public final class FileUtil {
             LOG.info("The file was decompressed successfully!");
         } catch (IOException ex) {
             ex.printStackTrace();
+        }
+    }
+
+
+    /**
+     * Create a zip file with the given content and encoding.
+     * @param zipFile The zip file to create. Expect the file to end with ".ORIGINALEXTENSION.zip" (eg. examplefile.html.zip)
+     * @param content The content to write to the zip file
+     * @param encoding The encoding to use when writing the content
+     * @throws IOException
+     */
+    public static void stringToZipFile(File zipFile, String content, String encoding) throws IOException {
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile), StandardCharsets.UTF_8)) {
+            zos.setLevel(9);
+            // Create a zip entry with the same name as the zip file but without the ".zip" extension
+            String entryName = zipFile.getName().replaceFirst("\\.zip$", "");
+            zos.putNextEntry(new ZipEntry(entryName));
+
+            // Write the content to the zip entry
+            byte[] bytes = content.getBytes(encoding);
+            zos.write(bytes, 0, bytes.length);
+            zos.closeEntry();
+        }
+    }
+
+    /**
+     * Writes the specified content to the given file, optionally compressing it into a ZIP format.
+     *
+     * If the file name ends with ".zip", the content will be written as a zipped file. Otherwise,
+     * the content will be written as a plain text file.
+     *
+     * @param file     the file to write the content to; if the file name ends with ".zip", the content will be zipped
+     * @param content  the content to be written to the file
+     * @param encoding the encoding to be used when writing the content to the file
+     * @throws IOException if an I/O error occurs during writing
+     */
+    public static void writeToFileOrZip(File file, String content, String encoding) throws IOException {
+        if (file.getName().endsWith(".zip")) {
+            stringToZipFile(file, content, encoding);
+        } else {
+            FileUtils.writeStringToFile(file, content, encoding);
         }
     }
 


### PR DESCRIPTION
...meaning its attributions can be removed during uniprot load.

- cleanup: add artifact zipping to save space
- cleanup: add some null checks
- when looking for latest unprocessed release, don't consider any that are older than an existing processed release