### PR TITLE
Add pre-commit hook to remind myself to remove certain changes before committing

### DIFF
--- a/.githooks/helpers
+++ b/.githooks/helpers
@@ -19,3 +19,17 @@ run_cmd () {
 run_if_changes () {
 	echo "$1" | grep --quiet "$2" && print "$2 changed" && run_cmd $3
 }
+
+check_for_comment_marker () {
+  FILES="$1"
+  FLAG_STRING="REMOVE BEFORE COMMIT"
+
+  # Loop through each file and search for "$FLAG_STRING"
+  for FILE in $FILES; do
+    if grep -q "$FLAG_STRING" "$FILE"; then
+      echo "Error: '$FILE' contains '$FLAG_STRING'."
+      echo "Please remove this string before committing."
+      exit 1
+    fi
+  done
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,4 +6,6 @@ changed_files=$(git diff --cached --name-only --diff-filter=ACMR)
 
 run_if_changes "$changed_files" home/javascript/react/ "npm run lint"
 
+check_for_comment_marker "$changed_files"
+
 exit 0


### PR DESCRIPTION
Sometimes I add some temporary code while I'm trying to work out a problem that I don't want to check into main.
In order to avoid accidentally committing that code, I wrote a pre-commit hook that checks for the flag "REMOVE BEFORE COMMIT" and stops that string from being checked in.
For example, in java, I might write:

```
//REMOVE BEFORE COMMIT
someDangerousCodeHere();
...
```
