### PR TITLE
Add zfin_login cookie to the httpd access log

### DIFF
--- a/docker/httpd/conf-zfin.org
+++ b/docker/httpd/conf-zfin.org
@@ -5,9 +5,9 @@
     ServerAlias     crick.zfin.org
     ServerAlias     stage.zfin.org
     DocumentRoot	/srv/www/zfin.org/home
-    LogFormat "%h %V %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %T" timing
-    LogFormat "{ \"@timestamp\": \"%{%Y-%m-%dT%H:%M:%S%z}t\", \"@fields\": { \"client\": \"%a\", \"duration_usec\": %D, \"status\": %s, \"request\": \"%U%q\", \"method\": \"%m\", \"referrer\": \"%{Referer}i\" } }" logstash_json
-    CustomLog	/var/log/httpd/zfin_access timing
+    LogFormat "%h %V %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %D \"zfin_login:%{zfin_login}C\"" timing_with_cookie
+    LogFormat "{ \"@timestamp\": \"%{%Y-%m-%dT%H:%M:%S%z}t\", \"@fields\": { \"client\": \"%a\", \"duration_usec\": %D, \"status\": %s, \"request\": \"%U%q\", \"method\": \"%m\", \"referrer\": \"%{Referer}i\", \"zfin_login\": \"%{zfin_login}C\"} }" logstash_json
+    CustomLog	/var/log/httpd/zfin_access timing_with_cookie
     ErrorLog	/var/log/httpd/zfin_errors
     CustomLog       /var/log/httpd/zfin_access.json logstash_json
 
@@ -107,7 +107,10 @@
     SSLProxyEngine on
     DocumentRoot	/srv/www/zfin.org/home
     ScriptAlias	/cgi-bin /srv/www/zfin.org/cgi-bin
-    CustomLog	/var/log/httpd/zfin_access combined
+    LogFormat "%h %V %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %D \"zfin_login:%{zfin_login}C\"" timing_with_cookie
+    LogFormat "{ \"@timestamp\": \"%{%Y-%m-%dT%H:%M:%S%z}t\", \"@fields\": { \"client\": \"%a\", \"duration_usec\": %D, \"status\": %s, \"request\": \"%U%q\", \"method\": \"%m\", \"referrer\": \"%{Referer}i\", \"zfin_login\": \"%{zfin_login}C\"} }" logstash_json
+    CustomLog	/var/log/httpd/zfin_access timing_with_cookie
+    CustomLog   /var/log/httpd/zfin_access.json logstash_json
     ErrorLog	/var/log/httpd/zfin_errors
     <Location /server-status>
         SetHandler server-status


### PR DESCRIPTION
This would add the zfin_login cookie to our httpd logs. For example:

```
172.19.0.1 cell-mac.zfin.org - [17/Sep/2024:00:55:22 +0000] "GET /search?q=crispr&fq=-background%3A%22AB%22&fq=-background%3A%22WIK%22&fq=-background%3A%22T%C3%BCbingen%22&fq=-background%3A%22AB%2FTuebingen%22&fq=-background%3A%22WIK%2FAB%22&fq=-construct%3A%22Gt%28%3ACRISPR2-etsrp-2A-GAL4%29%22&fq=-construct%3A%22Tg%28rnu6-32%3ACRISPR1-tyr%2Ccryaa%3ACerulean%29%22&category=Fish&fq=-construct:%22Tg%28rnu6-32%3ACRISPR1-tyr%2Crnu6-32%3ACRISPR1-insra%2Crnu6-14%3ACRISPR2-insra%2Crnu6-7%3ACRISPR1-insrb%2Crnu6-279%3ACRISPR2-insrb%2Ccryaa%3ACerulean%29%22 HTTP/1.1" 200 27978 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36" 0 "zfin_login:B2AF7EC66563C09C5EF"
```

or
```
... Chrome/127.0.0.0 Safari/537.36" 0 "zfin_login:GUEST_91FEAB0A4C2CF"
```

or
```
... Chrome/127.0.0.0 Safari/537.36" 0 "zfin_login:-"
```

That would allow us to tweak fail2ban to ignore logged in users by adding something like this:
```
ignoreregex = <HOST> zfin.org - .*?zfin_login:[A-F0-9]+
```

to the existing rule:
```
failregex = <HOST> zfin.org - .*?/search\?\S{500,}
```

