### PR TITLE
Triple upgrade: Hibernate fixes

### DIFF
--- a/conf/hibernate.cfg.xml
+++ b/conf/hibernate.cfg.xml
@@ -211,6 +211,8 @@
         <mapping class="org.zfin.mapping.Location"/>
         <mapping class="org.zfin.mapping.FeatureLocation"/>
         <mapping class="org.zfin.mapping.MarkerLocation"/>
+        <mapping class="org.zfin.mutant.FishExperiment"/>
+        <mapping class="org.zfin.mutant.GeneGenotypeExperiment"/>
 
  <!--<listener class="org.hibernate.envers.event.AuditEventListener" type="post-insert"/>
 

--- a/source/org/zfin/marker/MarkerHistory.java
+++ b/source/org/zfin/marker/MarkerHistory.java
@@ -46,7 +46,7 @@ public class MarkerHistory implements Comparable<MarkerHistory>, EntityZdbID {
     @ManyToOne
     @JoinColumn(name = "mhist_dalias_zdb_id")
     private MarkerAlias markerAlias;
-    @Column(name = "mhist_mrkr_prev_name", nullable = false)
+    @Column(name = "mhist_mrkr_prev_name")
     private String oldMarkerName;
     @Column(name = "mhist_comments")
     private String comments;

--- a/source/org/zfin/marker/MarkerRelationship.java
+++ b/source/org/zfin/marker/MarkerRelationship.java
@@ -7,7 +7,6 @@ import org.zfin.infrastructure.EntityAttribution;
 import org.zfin.infrastructure.PublicationAttribution;
 import org.zfin.publication.Publication;
 
-import java.util.HashSet;
 import java.util.Set;
 
 

--- a/source/org/zfin/marker/repository/HibernateMarkerRepository.java
+++ b/source/org/zfin/marker/repository/HibernateMarkerRepository.java
@@ -494,21 +494,22 @@ public class HibernateMarkerRepository implements MarkerRepository {
 
         currentSession().save(mrel);
         currentSession().flush();
-        currentSession().refresh(mrel);
-
-        String updateComment = "Creating relationship \"" + mrel.getFirstMarker().getAbbreviation()
-                               + " " + mrel.getMarkerRelationshipType().getFirstToSecondLabel()
-                               + " " + mrel.getSecondMarker().getAbbreviation()
-                               + "\" with Attribution: " + sourceZdbID;
-        log.debug(updateComment);
-        InfrastructureService.insertUpdate(mrel.getFirstMarker(), updateComment);
-        InfrastructureService.insertUpdate(mrel.getSecondMarker(), updateComment);
 
         //now deal with attribution
         if (sourceZdbID != null && sourceZdbID.length() > 0) {
             Publication publication = RepositoryFactory.getPublicationRepository().getPublication(sourceZdbID);
             addMarkerRelationshipAttribution(mrel, publication);
         }
+
+        currentSession().refresh(mrel);
+
+        String updateComment = "Creating relationship \"" + mrel.getFirstMarker().getAbbreviation()
+                + " " + mrel.getMarkerRelationshipType().getFirstToSecondLabel()
+                + " " + mrel.getSecondMarker().getAbbreviation()
+                + "\" with Attribution: " + sourceZdbID;
+        log.debug(updateComment);
+        InfrastructureService.insertUpdate(mrel.getFirstMarker(), updateComment);
+        InfrastructureService.insertUpdate(mrel.getSecondMarker(), updateComment);
 
         return mrel;
     }

--- a/source/org/zfin/mutant.hbm.xml
+++ b/source/org/zfin/mutant.hbm.xml
@@ -219,49 +219,6 @@
         <many-to-one name="feature" class="org.zfin.feature.Feature" column="genofeat_feature_zdb_id"/>
     </class>
 
-    <class name="org.zfin.mutant.FishExperiment" table="fish_experiment">
-        <id name="zdbID">
-            <column name="genox_zdb_id"/>
-            <generator class="org.zfin.database.ZdbIdGenerator">
-                <param name="type">GENOX</param>
-                <param name="insertActiveData">true</param>
-            </generator>
-        </id>
-
-        <property name="standard" column="genox_is_standard" not-null="true" type="java.lang.Boolean"/>
-        <property name="standardOrGenericControl" column="genox_is_std_or_generic_control" not-null="true"
-                  type="java.lang.Boolean"/>
-
-        <many-to-one name="experiment" class="org.zfin.expression.Experiment">
-            <column name="genox_exp_zdb_id"/>
-        </many-to-one>
-
-        <many-to-one name="fish">
-            <column name="genox_fish_zdb_id"/>
-        </many-to-one>
-
-        <set name="phenotypeExperiments" lazy="true" inverse="true">
-            <key column="phenox_genox_zdb_id"/>
-            <one-to-many class="org.zfin.mutant.PhenotypeExperiment"/>
-        </set>
-
-        <set name="expressionExperiments" lazy="true">
-            <key column="xpatex_genox_zdb_id"/>
-            <one-to-many class="org.zfin.expression.ExpressionExperiment2"/>
-        </set>
-
-        <set name="geneGenotypeExperiments" lazy="true">
-            <key column="mfs_genox_zdb_id"/>
-            <one-to-many class="GeneGenotypeExperiment"/>
-        </set>
-
-        <set name="diseaseAnnotationModels" lazy="true">
-            <key column="damo_genox_zdb_id"/>
-            <one-to-many class="DiseaseAnnotationModel"/>
-        </set>
-
-    </class>
-
     <class name="org.zfin.mutant.PhenotypeExperiment" table="phenotype_experiment">
         <id name="id" type="long">
             <column name="phenox_pk_id" not-null="true"/>
@@ -384,13 +341,6 @@
         </component>
         <many-to-one name="qualityTerm" column="api_quality_zdb_id"/>
 
-    </class>
-
-    <class name="org.zfin.mutant.GeneGenotypeExperiment" table="mutant_fast_Search">
-        <composite-id>
-            <key-many-to-one name="gene" column="mfs_data_zdb_id"/>
-            <key-many-to-one name="fishExperiment" column="mfs_genox_zdb_id"/>
-        </composite-id>
     </class>
 
 </hibernate-mapping>

--- a/source/org/zfin/mutant/FishExperiment.java
+++ b/source/org/zfin/mutant/FishExperiment.java
@@ -1,30 +1,62 @@
 package org.zfin.mutant;
 
 import com.fasterxml.jackson.annotation.JsonView;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.GenericGenerator;
 import org.zfin.expression.Experiment;
 import org.zfin.expression.ExpressionExperiment2;
 import org.zfin.framework.api.View;
 
+import org.hibernate.annotations.Parameter;
 import java.util.Objects;
 import java.util.Set;
 
 @Setter
 @Getter
+@Entity
+@Table(name = "fish_experiment")
 public class FishExperiment implements Comparable<FishExperiment> {
 
+    @Id
+    @GeneratedValue(generator = "zdbIdGenerator")
+    @GenericGenerator(name = "zdbIdGenerator",
+            strategy = "org.zfin.database.ZdbIdGenerator",
+            parameters = {
+                    @Parameter(name = "type", value = "GENOX"),
+                    @Parameter(name = "insertActiveData", value = "true")
+            })
+    @Column(name = "genox_zdb_id")
     @JsonView(View.API.class)
     private String zdbID;
+
+    @Column(name = "genox_is_standard", nullable = false)
     private boolean standard;
+
+    @Column(name = "genox_is_std_or_generic_control", nullable = false)
     private boolean standardOrGenericControl;
+
+    @ManyToOne
+    @JoinColumn(name = "genox_exp_zdb_id")
     @JsonView(View.API.class)
     private Experiment experiment;
+
+    @ManyToOne
+    @JoinColumn(name = "genox_fish_zdb_id")
     @JsonView(View.API.class)
     private Fish fish;
+
+    @OneToMany(mappedBy = "fishExperiment", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Set<PhenotypeExperiment> phenotypeExperiments;
+
+    @OneToMany(mappedBy = "fishExperiment", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Set<ExpressionExperiment2> expressionExperiments;
+
+    @OneToMany(mappedBy = "fishExperiment", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Set<GeneGenotypeExperiment> geneGenotypeExperiments;
+
+    @OneToMany(mappedBy = "fishExperiment", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Set<DiseaseAnnotationModel> diseaseAnnotationModels;
 
     @Override
@@ -36,24 +68,15 @@ public class FishExperiment implements Comparable<FishExperiment> {
         return experiment.compareTo(o.getExperiment());
     }
 
-    public Set<GeneGenotypeExperiment> getGeneGenotypeExperiments() {
-        return geneGenotypeExperiments;
-    }
-
-    public void setGeneGenotypeExperiments(Set<GeneGenotypeExperiment> geneGenotypeExperiments) {
-        this.geneGenotypeExperiments = geneGenotypeExperiments;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!getClass().isAssignableFrom(o.getClass()) ||
-            o.getClass().isAssignableFrom(getClass())) {
+        if (!getClass().isAssignableFrom(o.getClass()) || o.getClass().isAssignableFrom(getClass())) {
             return false;
         }
         FishExperiment that = (FishExperiment) o;
         return Objects.equals(this.getExperiment(), that.getExperiment()) &&
-               Objects.equals(this.getFish(), that.getFish());
+                Objects.equals(this.getFish(), that.getFish());
     }
 
     @Override

--- a/source/org/zfin/mutant/GeneGenotypeExperiment.java
+++ b/source/org/zfin/mutant/GeneGenotypeExperiment.java
@@ -1,52 +1,47 @@
 package org.zfin.mutant;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.zfin.marker.Marker;
 
+import jakarta.persistence.*;
 import java.io.Serializable;
+import java.util.Objects;
 
-/**
- * Convenience entity that maps to fast search table: MUTANT_FAST_SEARCH
- * which relates genes to clean fish experiments
- */
+@Getter
+@Setter
+@Entity
+@Table(name = "mutant_fast_search")
+@IdClass(GeneGenotypeExperimentId.class)
 public class GeneGenotypeExperiment implements Serializable {
 
+    @Id
+    @Column(name = "mfs_data_zdb_id")
+    private String markerId;
+
+    @Id
+    @Column(name = "mfs_genox_zdb_id")
+    private String fishExperimentId;
+
+    @ManyToOne
+    @JoinColumn(name = "mfs_data_zdb_id")
     private Marker gene;
+
+    @ManyToOne
+    @JoinColumn(name = "mfs_genox_zdb_id")
     private FishExperiment fishExperiment;
-
-    public Marker getGene() {
-        return gene;
-    }
-
-    public void setGene(Marker gene) {
-        this.gene = gene;
-    }
-
-    public FishExperiment getFishExperiment() {
-        return fishExperiment;
-    }
-
-    public void setFishExperiment(FishExperiment fishExperiment) {
-        this.fishExperiment = fishExperiment;
-    }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         GeneGenotypeExperiment that = (GeneGenotypeExperiment) o;
-
-        if (gene != null ? !gene.equals(that.gene) : that.gene != null) return false;
-        if (fishExperiment != null ? !fishExperiment.equals(that.fishExperiment) : that.fishExperiment != null)
-            return false;
-
-        return true;
+        return Objects.equals(gene, that.gene) &&
+                Objects.equals(fishExperiment, that.fishExperiment);
     }
 
     @Override
     public int hashCode() {
-        int result = gene != null ? gene.hashCode() : 0;
-        result = 31 * result + (fishExperiment != null ? fishExperiment.hashCode() : 0);
-        return result;
+        return Objects.hash(gene, fishExperiment);
     }
 }

--- a/source/org/zfin/mutant/GeneGenotypeExperimentId.java
+++ b/source/org/zfin/mutant/GeneGenotypeExperimentId.java
@@ -1,0 +1,10 @@
+package org.zfin.mutant;
+
+import java.io.Serializable;
+
+public class GeneGenotypeExperimentId implements Serializable {
+    private String markerId;
+
+    private String fishExperimentId;
+
+}

--- a/source/org/zfin/mutant/repository/HibernateMutantRepository.java
+++ b/source/org/zfin/mutant/repository/HibernateMutantRepository.java
@@ -108,7 +108,7 @@ public class HibernateMutantRepository implements MutantRepository {
 
         Query<Tuple> query = session.createQuery(hql, Tuple.class);
         query.setParameter("aoTerm", item);
-        query.setParameter("tag", PhenotypeStatement.Tag.NORMAL);
+        query.setParameter("tag", PhenotypeStatement.Tag.NORMAL.toString());
         if (MapUtils.isNotEmpty(bean.getFilterMap())) {
             for (Map.Entry<String, String> entry : bean.getFilterMap().entrySet()) {
                 query.setParameter(entry.getKey(), "%" + entry.getValue().toLowerCase() + "%");
@@ -147,7 +147,7 @@ public class HibernateMutantRepository implements MutantRepository {
 
         Query<Tuple> query = session.createQuery(hql, Tuple.class);
         query.setParameter("aoTerm", item);
-        query.setParameter("tag", PhenotypeStatement.Tag.NORMAL);
+        query.setParameter("tag", PhenotypeStatement.Tag.NORMAL.toString());
         query.setParameter("standardOrGeneric", false);
 
         // have to add extra select because of ordering, but we only want to return the first
@@ -211,7 +211,7 @@ public class HibernateMutantRepository implements MutantRepository {
 
         Query<Tuple> query = session.createQuery(hql, Tuple.class);
         query.setParameter("aoTerm", item);
-        query.setParameter("tag", PhenotypeStatement.Tag.NORMAL);
+        query.setParameter("tag", PhenotypeStatement.Tag.NORMAL.toString());
         if (MapUtils.isNotEmpty(bean.getFilterMap())) {
             for (Map.Entry<String, String> entry : bean.getFilterMap().entrySet()) {
                 query.setParameter(entry.getKey(), "%" + entry.getValue().toLowerCase() + "%");

--- a/source/org/zfin/publication/repository/HibernatePublicationRepository.java
+++ b/source/org/zfin/publication/repository/HibernatePublicationRepository.java
@@ -977,14 +977,17 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
     public List<Publication> getPublicationWithPubMedId(Integer maxResult) {
         Session session = HibernateUtil.currentSession();
 
-        String hql = "from Publication as publication" +
-                     "      where publication.accessionNumber is not null " +
-                     "      AND publication.type in (:type) " +
-                     "      AND publication.status = :status";
+        String hql = """
+                    from Publication as publication
+                    where publication.accessionNumber is not null
+                    AND publication.type in (:type)
+                    AND publication.status = :status
+                """;
+
 
         Query<Publication> query = session.createQuery(hql, Publication.class);
-        query.setParameterList("type", new String[]{"Journal", "Review"});
-        query.setParameter("status", "active");
+        query.setParameterList("type", List.of(PublicationType.JOURNAL, PublicationType.REVIEW));
+        query.setParameter("status", Publication.Status.ACTIVE);
         if (maxResult != null) {
             query.setMaxResults(maxResult);
         }
@@ -998,29 +1001,35 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
         List<Publication> resultList;
         Session session = HibernateUtil.currentSession();
 
-        hql = "select p.publication " +
-              " from PublicationAttribution p " +
-              " where p.dataZdbID = :featureZdbID ";
+        hql = """
+              select p.publication
+              from PublicationAttribution p
+              where p.dataZdbID = :featureZdbID
+              """;
         query = session.createQuery(hql, Publication.class);
         query.setParameter("featureZdbID", feature.getZdbID());
         resultList = query.list();
         SortedSet<Publication> pubList = new TreeSet<>(resultList);
 
 
-        hql = "select p.publication " +
-              " from PublicationAttribution p , DataAlias  da " +
-              "  where p.dataZdbID = da.zdbID " +
-              " and da.dataZdbID = :featureZdbID ";
+        hql = """
+                select p.publication
+                from PublicationAttribution p , DataAlias  da
+                where p.dataZdbID = da.zdbID
+                and da.dataZdbID = :featureZdbID
+                """;
         query = session.createQuery(hql, Publication.class);
         query.setParameter("featureZdbID", feature.getZdbID());
         resultList = query.list();
         pubList.addAll(resultList);
 
 
-        hql = "select p.publication " +
-              " from PublicationAttribution p , FeatureMarkerRelationship fmr " +
-              " where fmr.feature.zdbID  = :featureZdbID " +
-              " and fmr.feature.zdbID  = p.dataZdbID ";
+        hql = """
+                select p.publication
+                from PublicationAttribution p , FeatureMarkerRelationship fmr
+                where fmr.feature.zdbID  = :featureZdbID
+                and fmr.feature.zdbID  = p.dataZdbID
+                """;
 
         query = session.createQuery(hql, Publication.class);
         query.setParameter("featureZdbID", feature.getZdbID());
@@ -1418,12 +1427,15 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
 
     @Override
     public Long getPublicationTrackingStatus(Person person, int days, PublicationTrackingStatus... status) {
+        Calendar dateInPast = Calendar.getInstance();
+        dateInPast.add(Calendar.DATE, -days);
+
         String hql = "select count(m) from PublicationTrackingHistory as m where " +
-                     "m.updater = :person AND m.status in (:status) and m.date > current_date - :days";
+                     "m.updater = :person AND m.status in (:status) and m.date > :dateInPast";
         return HibernateUtil.currentSession().createQuery(hql, Long.class)
             .setParameter("person", person)
             .setParameterList("status", status)
-            .setParameter("days", days)
+            .setParameter("dateInPast", dateInPast)
             .uniqueResult();
     }
 

--- a/source/org/zfin/publication/repository/HibernatePublicationRepository.java
+++ b/source/org/zfin/publication/repository/HibernatePublicationRepository.java
@@ -977,14 +977,17 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
     public List<Publication> getPublicationWithPubMedId(Integer maxResult) {
         Session session = HibernateUtil.currentSession();
 
-        String hql = "from Publication as publication" +
-                     "      where publication.accessionNumber is not null " +
-                     "      AND publication.type in (:type) " +
-                     "      AND publication.status = :status";
+        String hql = """
+                    from Publication as publication
+                    where publication.accessionNumber is not null
+                    AND publication.type in (:type)
+                    AND publication.status = :status
+                """;
+
 
         Query<Publication> query = session.createQuery(hql, Publication.class);
-        query.setParameterList("type", new String[]{"Journal", "Review"});
-        query.setParameter("status", "active");
+        query.setParameterList("type", List.of(PublicationType.JOURNAL, PublicationType.REVIEW));
+        query.setParameter("status", Publication.Status.ACTIVE);
         if (maxResult != null) {
             query.setMaxResults(maxResult);
         }
@@ -998,29 +1001,35 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
         List<Publication> resultList;
         Session session = HibernateUtil.currentSession();
 
-        hql = "select p.publication " +
-              " from PublicationAttribution p " +
-              " where p.dataZdbID = :featureZdbID ";
+        hql = """
+                select p.publication "
+                from PublicationAttribution p
+                where p.dataZdbID = :featureZdbID
+                """;
         query = session.createQuery(hql, Publication.class);
         query.setParameter("featureZdbID", feature.getZdbID());
         resultList = query.list();
         SortedSet<Publication> pubList = new TreeSet<>(resultList);
 
 
-        hql = "select p.publication " +
-              " from PublicationAttribution p , DataAlias  da " +
-              "  where p.dataZdbID = da.zdbID " +
-              " and da.dataZdbID = :featureZdbID ";
+        hql = """
+                select p.publication
+                from PublicationAttribution p , DataAlias  da
+                where p.dataZdbID = da.zdbID
+                and da.dataZdbID = :featureZdbID
+                """;
         query = session.createQuery(hql, Publication.class);
         query.setParameter("featureZdbID", feature.getZdbID());
         resultList = query.list();
         pubList.addAll(resultList);
 
 
-        hql = "select p.publication " +
-              " from PublicationAttribution p , FeatureMarkerRelationship fmr " +
-              " where fmr.feature.zdbID  = :featureZdbID " +
-              " and fmr.feature.zdbID  = p.dataZdbID ";
+        hql = """
+                select p.publication
+                from PublicationAttribution p , FeatureMarkerRelationship fmr
+                where fmr.feature.zdbID  = :featureZdbID
+                and fmr.feature.zdbID  = p.dataZdbID
+                """;
 
         query = session.createQuery(hql, Publication.class);
         query.setParameter("featureZdbID", feature.getZdbID());
@@ -1418,12 +1427,15 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
 
     @Override
     public Long getPublicationTrackingStatus(Person person, int days, PublicationTrackingStatus... status) {
+        Calendar dateInPast = Calendar.getInstance();
+        dateInPast.add(Calendar.DATE, -days);
+
         String hql = "select count(m) from PublicationTrackingHistory as m where " +
-                     "m.updater = :person AND m.status in (:status) and m.date > current_date - :days";
+                     "m.updater = :person AND m.status in (:status) and m.date > :dateInPast";
         return HibernateUtil.currentSession().createQuery(hql, Long.class)
             .setParameter("person", person)
             .setParameterList("status", status)
-            .setParameter("days", days)
+            .setParameter("dateInPast", dateInPast)
             .uniqueResult();
     }
 

--- a/source/org/zfin/sequence.hbm.xml
+++ b/source/org/zfin/sequence.hbm.xml
@@ -312,15 +312,14 @@
 
     <!--    Note:  this should go away when the types are properly discriminated-->
     <sql-query name="loadBlastableDBLinksForAccession">
-        <return alias="acc" class="org.zfin.sequence.Accession"/>
-        <return-join alias="link" property="acc.blastableMarkerDBLinks"/>
+        <return alias="link" class="org.zfin.sequence.MarkerDBLink"/>
+        <return-join alias="acc" property="acc.blastableMarkerDBLinks"/>
         select
-        acc.accbk_pk_id ,
-        link.dblink_zdb_id ,
-        link.dblink_acc_num ,
-        link.dblink_info ,
-        link.dblink_length ,
-        link.dblink_fdbcont_zdb_id ,
+        link.dblink_zdb_id,
+        link.dblink_acc_num,
+        link.dblink_info,
+        link.dblink_length,
+        link.dblink_fdbcont_zdb_id,
         link.dblink_linked_recid,
         link.dblink_acc_num_display,
         av.accver_version,
@@ -332,7 +331,7 @@
         left outer join accession_version av on acc.accbk_acc_num=av.accver_acc_num
         where acc.accbk_pk_id=?
         and fdbdt.fdbdt_super_type = 'sequence'
-        and fdbdt.fdbdt_data_type in ( 'RNA','Polypeptide' )
+        and fdbdt.fdbdt_data_type in ('RNA','Polypeptide')
     </sql-query>
 
     <!--    <database-object>

--- a/test/org/zfin/marker/repository/MarkerRepositoryTest.java
+++ b/test/org/zfin/marker/repository/MarkerRepositoryTest.java
@@ -10,8 +10,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.springframework.ui.ExtendedModelMap;
-import org.springframework.ui.Model;
 import org.zfin.AbstractDatabaseTest;
 import org.zfin.Species;
 import org.zfin.antibody.Antibody;
@@ -29,7 +27,6 @@ import org.zfin.marker.fluorescence.FluorescentMarker;
 import org.zfin.marker.fluorescence.FluorescentProtein;
 import org.zfin.marker.presentation.*;
 import org.zfin.marker.service.MarkerService;
-import org.zfin.mutant.Genotype;
 import org.zfin.mutant.OmimPhenotype;
 import org.zfin.mutant.SequenceTargetingReagent;
 import org.zfin.ontology.GenericTerm;
@@ -44,7 +41,7 @@ import org.zfin.repository.RepositoryFactory;
 import org.zfin.sequence.*;
 import org.zfin.sequence.repository.SequenceRepository;
 
-import javax.persistence.Tuple;
+import jakarta.persistence.Tuple;
 import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;


### PR DESCRIPTION
Fixing errors:

1. This error: ``` Unable to find column position by name: accbk_abbreviation [The column name accbk_abbreviation was not found in this ResultSet.] [n/a] org.hibernate.exception.SQLGrammarException: Unable to find column position by name: accbk_abbreviation [The column name accbk_abbreviation was not found in this ResultSet.] [n/a] at app//org.hibernate.exception.internal.SQLStateConversionDelegate.convert(SQLStateConversionDelegate.java:91) at app//org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:58) at app//org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:108) ``` related to calling refresh on Accession.getBlastableMarkerDBLinks which uses the named query "loadBlastableDBLinksForAccession"

2. This error:
```
Expected object of type `org.zfin.infrastructure.RecordAttribution`, but found `org.zfin.infrastructure.PublicationAttribution`; discriminator = other
org.hibernate.WrongClassException: Expected object of type `org.zfin.infrastructure.RecordAttribution`, but found `org.zfin.infrastructure.PublicationAttribution`; discriminator = other
```
Which was due to the MarkerRelationship creation calling a refresh before it had the necessary association publication saved.

3. Fix hibernate error when trying to insert MarkerHistory entity with null for OldMarkerName