### PR TITLE
ZFIN-9364: Refactor NCBI gene load perl

### DIFF
--- a/server_apps/data_transfer/NCBIGENE/clear-artifacts.sh
+++ b/server_apps/data_transfer/NCBIGENE/clear-artifacts.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm debug* *md5 *.danio.* loadLog* *unl report* prepareLog* logNCBIgeneLoad
+


### PR DESCRIPTION
Did some refactoring while I was investigating lost RefSeqs. No logic changes were made. 

- Moved the loop over toMap to repeatedly query for Gene/Accession relationships into a single query in the prepareNCBIgeneLoad.sql so that toMap becomes a 2 column file instead of 1 column
- Used `//=` perl syntax to make array initialization more concise
- Introduced some helper functions to cut down on boilerplate