### PR TITLE
ZFIN-9406: Handle 500 exceptions in search console reports

### DIFF
--- a/docker/httpd/conf-zfin.org
+++ b/docker/httpd/conf-zfin.org
@@ -59,11 +59,6 @@
     ProxyPass /ajax/ http://tomcat:2008/ajax/
     ProxyPassReverse /ajax/ http://tomcat:2008/ajax/ 
 
-    ProxyPass /gb2/ http://gbrowse1.zfin.org/gb2/
-    ProxyPassReverse /gb2/ http://gbrowse1.zfin.org/gb2/
-    ProxyPass /gbrowse2/ http://gbrowse1.zfin.org/gbrowse2/
-    ProxyPassReverse /gbrowse2/ http://gbrowse1.zfin.org/gbrowse2/
-
     ProxyPass /webapp/ http://tomcat:2008/webapp/
     ProxyPassReverse /webapp/ http://tomcat:2008/webapp/
     ProxyPass /webservice/ http://tomcat:2008/webservice/
@@ -142,11 +137,6 @@
     ProxyPassReverse /webapp/ https://tomcat:8443/webapp/
     ProxyPass /webservice/ https://tomcat:8443/webservice/
     ProxyPassReverse /webservice/ https://tomcat:8443/webservice/
-
-    ProxyPass /gb2/ http://gbrowse1.zfin.org/gb2/
-    ProxyPassReverse /gb2/ http://gbrowse1.zfin.org/gb2/
-    ProxyPass /gbrowse2/ http://gbrowse1.zfin.org/gbrowse2/
-    ProxyPassReverse /gbrowse2/ http://gbrowse1.zfin.org/gbrowse2/
 
     #for using the prototype search from kinetix/zfin.org
     ProxyPass /zfinlabs/ http://zygotix.zfin.org:9109/action/quicksearch/

--- a/home/WEB-INF/jsp/gbrowse/gbrowse-view.jsp
+++ b/home/WEB-INF/jsp/gbrowse/gbrowse-view.jsp
@@ -1,44 +1,25 @@
 <%@ include file="/WEB-INF/jsp-include/tag-import.jsp" %>
 
-<z:page>
-    <i class="fas fa-spinner fa-spin" id="loading"></i>
+<c:set var="canonicalUrl" value="/action/gbrowse" />
 
-    <%-- this should be the only place that the raw gbrowse url is used --%>
-    <iframe src="${urlPrefix}?${requestParams}" width="100%"
-            id="gbrowseFrame" marginheight="0" frameborder="0"></iframe>
-
+<z:page bootstrap="true">
+    <div class="container mt-2">
+        <div class="row">
+            <div class="col-2"></div>
+            <div class="col-8">
+                <h3>Genome Browser Moved</h3>
+                <p>For the latest genome browser, please click the link below.</p>
+                <p><a class="btn btn-primary" href="/jbrowse">Continue to jBrowse</a></p>
+                <p>This page was previously the home of our instance of the gBrowse genome browser.<br/>
+                   We have since migrated to the newer <a href="https://jbrowse.org/jb2/" target="_blank">jBrowse</a>.</p>
+                <p>For any questions or concerns, please feel free to <a id="contact-us-link" href="#input-welcome-button">contact us</a>.</p>
+            </div>
+            <div class="col-2"></div>
+        </div>
+    </div>
     <script>
-        <%-- this keeps the iframe size in sync with the gbrowse content, on old browsers
-        that don't support MutationObserver (IE <11) you just get a very tall iframe --%>
-        jQuery("#gbrowseFrame").on("load", function () {
-            var MutationObserver = window.MutationObserver || window.WebKitMutationObserver,
-                iframe = this,
-                $iframe = jQuery(this);
-            jQuery("#loading").hide();
-
-            <%-- absolute urls that don't already have a target should get popup out --%>
-            $iframe.contents().on("click", "a", function () {
-                var $this = jQuery(this),
-                    url = $this.attr("href"),
-                    target = $this.attr("target");
-                if ((url.indexOf('http://') === 0 || url.indexOf('https://') === 0) && target === undefined) {
-                    $this.attr("target", "_blank");
-                }
-            });
-
-            if (MutationObserver) {
-                new MutationObserver(function () {
-                    <%-- 20 is a bit of fudge to keep iframe's scroll bars to from showing up --%>
-                    $iframe.height($iframe.contents().find("body").height() + 20);
-                }).observe(iframe.contentDocument.body, {
-                    attributes: true,
-                    childList: true,
-                    characterData: true,
-                    subtree: true
-                });
-            } else {
-                $iframe.height(3000);
-            }
+        document.getElementById('contact-us-link').addEventListener('click', function () {
+            document.getElementById('input-welcome-button').click();
         });
     </script>
 </z:page>

--- a/server_apps/apache/inc-redirect
+++ b/server_apps/apache/inc-redirect
@@ -256,3 +256,7 @@ RewriteRule ^/action/(.*) /action/$1 [PT]
 #path so that they're still supported
 RewriteCond <!--|MUTANT_NAME|--> !=zfin.org
 RewriteRule ^/<!--|MUTANT_NAME|-->/webdriver(.*) /cgi-bin/webdriver$1 [R=301]
+
+#Rewrite anything from /gb2/gbrowse/... to /action/gbrowse/ transparently (no redirect)
+#That page has a message about the switch from gbrowse to jbrowse
+RewriteRule ^/gb2/gbrowse/(.*) /action/gbrowse/ [PT]

--- a/source/org/zfin/marker/presentation/OrthologyPresentationBean.java
+++ b/source/org/zfin/marker/presentation/OrthologyPresentationBean.java
@@ -2,6 +2,7 @@ package org.zfin.marker.presentation;
 
 import org.zfin.orthology.presentation.OrthologyPresentationRow;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -13,6 +14,9 @@ public class OrthologyPresentationBean {
     private String note;
 
     public List<OrthologyPresentationRow> getOrthologs() {
+        if (orthologs == null) {
+            return Collections.emptyList();
+        }
         return orthologs;
     }
 


### PR DESCRIPTION
Most of the errors in the report for 500 exceptions were due to visits to our old gbrowse page (eg. /action/gbrowse/?name=ENSDARG00000005626). This commit returns a page with a link to the newer jbrowse page.