### PR TITLE
ZFIN-9383: Change the display name for "zeco conditions" to be "Conditions"

### DIFF
--- a/source/org/zfin/search/FieldName.java
+++ b/source/org/zfin/search/FieldName.java
@@ -47,7 +47,7 @@ public enum FieldName {
     CODING_SEQUENCE_SORT("coding_sequence_sort"),
     CODING_SEQUENCE_SPECIES("coding_sequence_species"),
     CONDITIONS("conditions"),
-    ZECO_CONDITIONS("zeco_conditions"),
+    ZECO_CONDITIONS("zeco_conditions", "Conditions"),
     CONSEQUENCE("rna_consequence"),
     CONSTRUCT("construct"),
     CONSTRUCT_CITATION_SORT("construct_citation_sort"),


### PR DESCRIPTION
This is the place where the label is changed

<img width="1257" alt="Screenshot 2024-11-04 at 11 13 38 AM" src="https://github.com/user-attachments/assets/1d163e0d-9b98-4d3c-a609-68e4a4b2605c">
