### PR TITLE
Add an endpoint for gathering all of the publication metrics in one place

### DIFF
--- a/source/org/zfin/publication/presentation/PublicationCombinedMetrics.java
+++ b/source/org/zfin/publication/presentation/PublicationCombinedMetrics.java
@@ -1,0 +1,86 @@
+package org.zfin.publication.presentation;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import lombok.Data;
+import org.zfin.antibody.Antibody;
+import org.zfin.feature.Feature;
+import org.zfin.figure.presentation.ExpressionTableRow;
+import org.zfin.figure.presentation.PhenotypeTableRow;
+import org.zfin.framework.api.View;
+import org.zfin.marker.Marker;
+import org.zfin.marker.presentation.GeneBean;
+import org.zfin.marker.presentation.STRTargetRow;
+import org.zfin.mutant.DiseaseAnnotationModel;
+import org.zfin.mutant.Fish;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Data
+public class PublicationCombinedMetrics {
+
+    @JsonView(View.API.class)
+    private Collection<String> directAttributions;
+
+    @JsonView(View.API.class)
+    private Collection<PublicationAPIController.ChromosomeLinkage> chromosomeLinkages;
+
+    @JsonView(View.API.class)
+    private Collection<GeneBean> orthologs;
+
+    @JsonView(View.API.class)
+    private Collection<Antibody> antibodies;
+
+    @JsonView(View.API.class)
+    private Collection<Fish> fish;
+
+    @JsonView(View.API.class)
+    private Collection<STRTargetRow> strs;
+
+    @JsonView(View.API.class)
+    private Collection<DiseaseAnnotationModel> diseases;
+
+    @JsonView(View.API.class)
+    private Collection<Feature> features;
+
+    @JsonView(View.API.class)
+    private Collection<PhenotypeTableRow> phenotypes;
+
+    @JsonView(View.API.class)
+    private Collection<Marker> efgs;
+
+    @JsonView(View.API.class)
+    private Collection<String> expressionRowIDs;
+
+    @JsonView(View.API.class)
+    private Collection<Marker> markers;
+
+    @JsonView(View.API.class)
+    private Map<String, Integer> countsByType = new HashMap<>();
+
+    @JsonView(View.API.class)
+    private String publicationID;
+
+    public void setCount(String type, int count) {
+        countsByType.put(type, count);
+    }
+
+    public void setExpressionRows(Collection<ExpressionTableRow> expressionRows) {
+        this.expressionRowIDs = expressionRows.stream()
+            .map( etr -> {
+                String etrString = "[" +
+                        "subterm=" + (etr.getSubterm() == null ? "" : etr.getSubterm().getZdbID()) + "," +
+                        "superterm=" + (etr.getSuperterm() == null ? "" : etr.getSuperterm().getZdbID()) + "," +
+                        "gene=" + (etr.getGene() == null ? "" : etr.getGene().getZdbID()) + "," +
+                        "antibody=" + (etr.getAntibody() == null ? "" : etr.getAntibody().getZdbID()) + "," +
+                        "fish=" + (etr.getFish() == null ? "" : etr.getFish().getZdbID()) + "," +
+                        "experiment=" + (etr.getExperiment() == null ? "" : etr.getExperiment().getZdbID()) ;
+                etrString += "...]";
+                return etrString;
+            })
+            .collect(Collectors.toList());
+    }
+
+}


### PR DESCRIPTION
This endpoint allows us to query a single endpoint and get all the metrics for a publication gathered in one place.  For example:

```
curl -s -k -X POST -H "Content-Type: application/json" -d '["ZDB-PUB-210519-19", "ZDB-PUB-210616-20", "ZDB-PUB-210622-21"]' 'https://cell-mac.zfin.org/action/api/publication/combined-metrics'  | jq  '.results[] | {publicationID: .publicationID, countsByType: .countsByType}'
{
  "publicationID": "ZDB-PUB-210519-19",
  "countsByType": {
    "features": 0,
    "mapping": 0,
    "efgs": 0,
    "phenotypes": 37,
    "expression": 29,
    "strs": 0,
    "direct attribution": 109,
    "orthology": 0,
    "fish": 1,
    "diseases": 0,
    "antibodies": 8,
    "markers": 6
  }
}
{
  "publicationID": "ZDB-PUB-210616-20",
  "countsByType": {
    "features": 6,
    "mapping": 0,
    "efgs": 0,
    "phenotypes": 47,
    "expression": 0,
    "strs": 5,
    "direct attribution": 128,
    "orthology": 0,
    "fish": 11,
    "diseases": 10,
    "antibodies": 6,
    "markers": 9
  }
}
{
  "publicationID": "ZDB-PUB-210622-21",
  "countsByType": {
    "features": 0,
    "mapping": 0,
    "efgs": 0,
    "phenotypes": 0,
    "expression": 0,
    "strs": 0,
    "direct attribution": 23,
    "orthology": 0,
    "fish": 0,
    "diseases": 0,
    "antibodies": 4,
    "markers": 11
  }
}
```

This is roughly the same data displayed on publication page nav bar:
<img width="223" alt="image" src="https://github.com/user-attachments/assets/061926e5-f1ef-4bbf-9f24-997afef4dda3">
