### PR TITLE
Hide features on ZFIN lab page

### DIFF
--- a/home/WEB-INF/jsp/profile/lab-view.jsp
+++ b/home/WEB-INF/jsp/profile/lab-view.jsp
@@ -56,12 +56,14 @@
             <jsp:include page="lab-view-summary.jsp"/>
         </div>
 
-        <z:section title="${GENOMIC_FEATURES}" infoPopup="/action/marker/note/citations">
-            <div class="__react-root" id="FeatureLabTable" data-org-id="${formBean.zdbID}"></div>
-            <div class="mt-2">
-                <a href="/search?q=&amp;fq=category%3A%22Mutation+%2F+Tg%22&amp;fq=xref%3A%22${formBean.zdbID}%22">View all lines for this lab</a>
-            </div>
-        </z:section>
+        <c:if test="${showGenomicFeatures}">
+            <z:section title="${GENOMIC_FEATURES}" infoPopup="/action/marker/note/citations">
+                <div class="__react-root" id="FeatureLabTable" data-org-id="${formBean.zdbID}"></div>
+                <div class="mt-2">
+                    <a href="/search?q=&amp;fq=category%3A%22Mutation+%2F+Tg%22&amp;fq=xref%3A%22${formBean.zdbID}%22">View all lines for this lab</a>
+                </div>
+            </z:section>
+        </c:if>
 
         <z:section title="${STATEMENT}">
             <div id='bio'><zfin2:splitLines input="${formBean.bio}"/></div>

--- a/source/org/zfin/profile/presentation/LabController.java
+++ b/source/org/zfin/profile/presentation/LabController.java
@@ -185,11 +185,14 @@ public class LabController {
 
         // a lab could have prefixes while having no features (example as of 2013-01-24: ZDB-LAB-111031-1
         model.addAttribute("numOfFeatures", RepositoryFactory.getFeatureRepository().getFeaturesForLabCount(zdbID));
-
+        model.addAttribute("showGenomicFeatures", this.showGenomicFeaturesFromLab(lab));
         model.addAttribute(LookupStrings.DYNAMIC_TITLE, Area.LAB.getTitleString() + lab.getName());
         return "profile/lab-view";
     }
 
+    private boolean showGenomicFeaturesFromLab(Lab lab) {
+        return !ZFIN_DATABASE_TEAM.equals(lab.getName());
+    }
 
     @RequestMapping(value = "/lab/create", method = RequestMethod.GET)
     public String createLabSetup(Model model, @ModelAttribute("formBean") Lab lab) {


### PR DESCRIPTION
Hide this on ZFIN lab page. We used to have this logic before the new "prototype" pages were released (See: ZFIN-9082).

![image](https://github.com/user-attachments/assets/c43942d6-9bab-4eee-8038-c99dfd53c2ce)
