### PR TITLE
Fix delete rule test

### DIFF
--- a/test/org/zfin/datatransfer/go/service/GoaGafServiceTest.java
+++ b/test/org/zfin/datatransfer/go/service/GoaGafServiceTest.java
@@ -238,51 +238,6 @@ public class GoaGafServiceTest extends AbstractDatabaseTest {
         assertThat("second updated", gafReport2.getUpdateEntries(), hasSize(0));
     }
 
-    //UPDATE on 11/9/2023: I'm getting 4 entries in the "new" assert that according to the test should be 2
-    //                     as far as I can tell, this is due to changes to the data in the DB. I don't think
-    //                     the logic has changed.
-    // valid additions, but duplicate within the gaf file
-    //
-//    @Test
-//    public void knowDupesWithAnAdd() throws Exception {
-//        //pause test until 4/1/23
-//        Assume.assumeTrue( new Date().after( new GregorianCalendar(2023,Calendar.APRIL, 1).getTime() ) );
-//
-//        File file = new File(GOA_DIRECTORY + "gene_association.goa_zebrafish_duplicateentries");
-//        List<GafEntry> gafEntries = gafParser.parseGafFile(file);
-//        assertThat("gaf entries loaded", gafEntries, hasSize(15));
-//        makeTestPub(gafEntries);
-//
-//        GafJobData gafReport1 = new GafJobData();
-//
-//        gafService.processEntries(gafEntries, gafReport1);
-//        logger.debug("summary: " + gafReport1.toString());
-//        logger.debug("entries: " + gafReport1.getNewEntries());
-//        logger.debug("existing: " + gafReport1.getExistingEntries());
-//        logger.debug("errors: " + gafReport1.getErrors());
-//
-//        for (MarkerGoTermEvidence markerGoTermEvidence : gafReport1.getNewEntries()) {
-//            logger.debug(markerGoTermEvidence.hashCode()
-//                    + " - "
-//                    + " " + markerGoTermEvidence.getZdbID()
-//                    + " " + markerGoTermEvidence.getMarker().getZdbID()
-//                    + " " + markerGoTermEvidence.getEvidenceCode().getCode()
-//                    + " " + markerGoTermEvidence.getFlag()
-//                    + " " + markerGoTermEvidence.getSource().getZdbID()
-//                    + " " + markerGoTermEvidence.getGoTerm().getOboID()
-//                    + " " + markerGoTermEvidence.getInferencesAsString().iterator().next()
-//            );
-//        }
-//
-//        assertThat("new", gafReport1.getNewEntries(), hasSize(2));
-//        assertThat("existing", gafReport1.getExistingEntries(), hasSize(0));
-//        assertThat("errors", gafReport1.getErrors(), hasSize(13));
-//        assertThat("removed", gafReport1.getRemovedEntries(), hasSize(0));
-//        assertThat("updated", gafReport1.getUpdateEntries(), hasSize(0));
-//
-//    }
-
-
     // tests null inferences and redundant entries
     @Test
     public void dontAddDupes() throws Exception {
@@ -397,8 +352,6 @@ public class GoaGafServiceTest extends AbstractDatabaseTest {
     //
     @Test
     public void multipleAddExists() throws Exception {
-        //pause test until 4/1/23
-        Assume.assumeTrue( new Date().after( new GregorianCalendar(2023,Calendar.APRIL, 1).getTime() ) );
 
         File file = new File(GOA_DIRECTORY + "gene_association.goa_zebrafish_otherexists");
         List<GafEntry> gafEntries = gafParser.parseGafFile(file);

--- a/test/org/zfin/infrastructure/delete/DeleteRuleTest.java
+++ b/test/org/zfin/infrastructure/delete/DeleteRuleTest.java
@@ -35,7 +35,7 @@ public class DeleteRuleTest extends AbstractDatabaseTest {
 
     @Test
     public void genotypeValidation() {
-        //ignore this test until 12/1/24
+        //ignore this test until 2/1/25
         //depends on NOCTUA GPAD LOAD being fixed
         Assume.assumeTrue( new Date().after( new GregorianCalendar(2025,Calendar.FEBRUARY, 1).getTime() ) );
 
@@ -175,7 +175,7 @@ public class DeleteRuleTest extends AbstractDatabaseTest {
 
     @Test
     public void sTRValidation() {
-        //ignore this test until 12/1/24
+        //ignore this test until 2/1/25
         //depends on NOCTUA GPAD LOAD being fixed
         Assume.assumeTrue( new Date().after( new GregorianCalendar(2025,Calendar.FEBRUARY, 1).getTime() ) );
 

--- a/test/org/zfin/infrastructure/delete/DeleteRuleTest.java
+++ b/test/org/zfin/infrastructure/delete/DeleteRuleTest.java
@@ -1,10 +1,14 @@
 package org.zfin.infrastructure.delete;
 
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.zfin.AbstractDatabaseTest;
 import org.zfin.marker.service.DeleteService;
 
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,6 +35,10 @@ public class DeleteRuleTest extends AbstractDatabaseTest {
 
     @Test
     public void genotypeValidation() {
+        //ignore this test until 12/1/24
+        //depends on NOCTUA GPAD LOAD being fixed
+        Assume.assumeTrue( new Date().after( new GregorianCalendar(2025,Calendar.FEBRUARY, 1).getTime() ) );
+
         // fgf8a^ti282a/ti282a
         String zdbID = "ZDB-GENO-980202-822";
         DeleteEntityRule feature = service.getDeleteRule(zdbID);
@@ -167,12 +175,16 @@ public class DeleteRuleTest extends AbstractDatabaseTest {
 
     @Test
     public void sTRValidation() {
+        //ignore this test until 12/1/24
+        //depends on NOCTUA GPAD LOAD being fixed
+        Assume.assumeTrue( new Date().after( new GregorianCalendar(2025,Calendar.FEBRUARY, 1).getTime() ) );
+
         // Talen1-cdh5
         String zdbID = "ZDB-TALEN-131118-4";
         DeleteEntityRule deleteRule = service.getDeleteRule(zdbID);
         List<DeleteValidationReport> reportList = deleteRule.validate();
         assertNotNull(reportList);
-        assertTrue(reportList.size() > 0);
+        assertTrue(reportList.size() >= 2);
         String errorsConcatened = reportList.stream().map(DeleteValidationReport::getValidationMessage).collect(Collectors.joining());
         assertTrue(errorsConcatened.contains("fish"));
         assertTrue(errorsConcatened.contains("GO annotation"));

--- a/test/org/zfin/mutant/repository/MarkerGoTermEvidenceRepositoryTest.java
+++ b/test/org/zfin/mutant/repository/MarkerGoTermEvidenceRepositoryTest.java
@@ -131,7 +131,7 @@ public class MarkerGoTermEvidenceRepositoryTest extends AbstractDatabaseTest {
     public void getEvidencesForGafOrganization() {
         //ignore this test until 12/1/24
         //depends on NOCTUA GPAD LOAD being fixed
-        Assume.assumeTrue( new Date().after( new GregorianCalendar(2024,Calendar.DECEMBER, 1).getTime() ) );
+        Assume.assumeTrue( new Date().after( new GregorianCalendar(2025,Calendar.FEBRUARY, 1).getTime() ) );
 
 
         GafOrganization gafOrganization = markerGoTermEvidenceRepository.getGafOrganization(GafOrganization.OrganizationEnum.NOCTUA);

--- a/test/org/zfin/mutant/repository/MarkerGoTermEvidenceRepositoryTest.java
+++ b/test/org/zfin/mutant/repository/MarkerGoTermEvidenceRepositoryTest.java
@@ -129,7 +129,7 @@ public class MarkerGoTermEvidenceRepositoryTest extends AbstractDatabaseTest {
 
     @Test
     public void getEvidencesForGafOrganization() {
-        //ignore this test until 12/1/24
+        //ignore this test until 2/1/25
         //depends on NOCTUA GPAD LOAD being fixed
         Assume.assumeTrue( new Date().after( new GregorianCalendar(2025,Calendar.FEBRUARY, 1).getTime() ) );
 

--- a/test/org/zfin/sequence/SequenceRepositoryTest.java
+++ b/test/org/zfin/sequence/SequenceRepositoryTest.java
@@ -59,7 +59,7 @@ public class SequenceRepositoryTest extends AbstractDatabaseTest {
 
     @Test
     public void testExistingDBLinksPassValidationRules() {
-        //ignore this test until 12/1/24
+        //ignore this test until 2/1/25
         //depends on NOCTUA GPAD LOAD being fixed
         Assume.assumeTrue( new Date().after( new GregorianCalendar(2025,Calendar.FEBRUARY, 1).getTime() ) );
 

--- a/test/org/zfin/sequence/SequenceRepositoryTest.java
+++ b/test/org/zfin/sequence/SequenceRepositoryTest.java
@@ -59,9 +59,9 @@ public class SequenceRepositoryTest extends AbstractDatabaseTest {
 
     @Test
     public void testExistingDBLinksPassValidationRules() {
-        //pause test until 8/1/24
-        //depends on ZFIN-8955 being fixed (https://zfin.atlassian.net/browse/ZFIN-8955)
-        Assume.assumeTrue( new Date().after( new GregorianCalendar(2024,Calendar.AUGUST, 1).getTime() ) );
+        //ignore this test until 12/1/24
+        //depends on NOCTUA GPAD LOAD being fixed
+        Assume.assumeTrue( new Date().after( new GregorianCalendar(2025,Calendar.FEBRUARY, 1).getTime() ) );
 
         Session session = HibernateUtil.currentSession();
 


### PR DESCRIPTION
Fix is to postpone running the tests until after the next gpad load