### PR TITLE
ZFIN-9062: Fix shifting layout on term page

### DIFF
--- a/source/org/zfin/gwt/root/ui/LookupComposite.java
+++ b/source/org/zfin/gwt/root/ui/LookupComposite.java
@@ -445,10 +445,13 @@ public class LookupComposite extends Composite implements Revertible {
         noteString = note;
         errorString = "";
         noteLabel.setHTML(noteString);
-        if (StringUtils.isNotEmptyTrim(note))
-            noteLabel.setVisible(true);
-        else
-            noteLabel.setVisible(false);
+        if (StringUtils.isNotEmptyTrim(note)) {
+            noteLabel.setStyleName("gwt-lookup-note visible");
+            noteLabel.getElement().removeAttribute("aria-hidden");
+        } else {
+            noteLabel.setStyleName("gwt-lookup-note invisible");
+            noteLabel.getElement().setAttribute("aria-hidden", "true");
+        }
     }
 
     public String getNoteString() {


### PR DESCRIPTION
Use the css property 'visibility' instead of 'display' so the hiding/showing logic doesn't shift things around.