### PR TITLE
ZFIN-9478: Fix cases where thumbnail and medium images are swapped

### DIFF
--- a/console.gradle
+++ b/console.gradle
@@ -175,3 +175,8 @@ task checkSequenceValidationRulesTask(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'org.zfin.sequence.CheckSequenceValidationRulesTask'
 }
+
+task imageThumbnailAndMediumSwapTask(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'org.zfin.figure.service.ImageThumbnailAndMediumSwapTask'
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - ${DOCKER_BLASTSERVER_BLAST_DATABASE_PATH}:/opt/zfin/blastdb
       - ${DOCKER_ABBLAST_PATH}:/opt/ab-blast
       - ${DOCKER_RESEARCH_PATH}:/mnt/research
+      - ${DOCKER_LOADUP_PATH}:/opt/zfin/loadUp
       - solr_data:/var/solr
       - ${DOCKER_SSH_AUTH_SOCK}:/run/host-services/ssh-auth.sock
       - ~/.ssh/known_hosts:/home/gradle/.ssh/known_hosts

--- a/source/org/zfin/figure/service/ImageService.java
+++ b/source/org/zfin/figure/service/ImageService.java
@@ -163,12 +163,12 @@ public class ImageService {
                 convertBinary = convertBinaryFile.getAbsolutePath();
             }
         }
-        String makeThumb = convertBinary + " -thumbnail " + dimensions + " " + imageFilename + " " + thumbnailFilename;
-        log.info("running makeThumb command: " + makeThumb);
+        String[] makeThumbCommand = {convertBinary, "-thumbnail", dimensions, imageFilename, thumbnailFilename};
+        log.info("running makeThumb command: " + makeThumbCommand);
         if (!previewCommandOnly) {
-            Runtime.getRuntime().exec(makeThumb);
+            Runtime.getRuntime().exec(makeThumbCommand);
         }
-        return makeThumb;
+        return String.join(" ", makeThumbCommand);
     }
 
     private static void createDestinationParentDirectoryIfNotExists(String publicationZdbId) throws IOException {

--- a/source/org/zfin/figure/service/ImageThumbnailAndMediumSwapTask.java
+++ b/source/org/zfin/figure/service/ImageThumbnailAndMediumSwapTask.java
@@ -1,0 +1,146 @@
+package org.zfin.figure.service;
+
+
+import org.apache.commons.lang3.StringUtils;
+import org.zfin.expression.Image;
+import org.zfin.figure.repository.FigureRepository;
+import org.zfin.ontology.datatransfer.AbstractScriptWrapper;
+import org.zfin.properties.ZfinPropertiesEnum;
+import org.zfin.repository.RepositoryFactory;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Random;
+
+public class ImageThumbnailAndMediumSwapTask extends AbstractScriptWrapper {
+    private boolean dryRun = true;
+
+    public static void main(String[] args) throws IOException {
+        ImageThumbnailAndMediumSwapTask task = new ImageThumbnailAndMediumSwapTask();
+        task.runTask();
+        System.exit(0);
+    }
+
+    public void runTask() throws IOException {
+        initAll();
+        initDryRun();
+
+        if (dryRun) {
+            System.out.println("Dry run.  No changes will be made. Set RUN_IMAGE_FIXES environment variable, or runImageFixes property to run.");
+        } else {
+            System.out.println("Executing changes with imagemagick.");
+        }
+
+        FigureRepository figureRepository = RepositoryFactory.getFigureRepository();
+        List<Image> images = figureRepository.getAllImagesWithFigures();
+
+        LOG.info("Found " + images.size() + " images with figures.");
+        runFixesForThumbnailsAndMediums(images);
+
+    }
+
+    private void initDryRun() {
+        String RUN_IMAGE_FIXES = System.getenv("RUN_IMAGE_FIXES");
+        if (StringUtils.isNotEmpty(RUN_IMAGE_FIXES)) {
+            dryRun = false;
+        }
+        if (StringUtils.isNotEmpty(System.getProperty("runImageFixes"))) {
+            dryRun = false;
+        }
+    }
+
+    private void runFixesForThumbnailsAndMediums(List<Image> images) throws IOException {
+        for (Image image : images) {
+            String thumbnail = image.getThumbnail();
+            String medium = image.getMedium();
+            String fullSizeImagePath = ZfinPropertiesEnum.LOADUP_FULL_PATH + File.separator + image.getImageFilename();
+            File thumbnailFile = new File(ZfinPropertiesEnum.LOADUP_FULL_PATH + File.separator + thumbnail);
+            File mediumFile = new File(ZfinPropertiesEnum.LOADUP_FULL_PATH + File.separator + medium);
+
+            if (!thumbnailFile.exists()) {
+//                System.out.println("Thumbnail file does not exist: " + thumbnailFile);
+                continue;
+            }
+            if (!mediumFile.exists()) {
+//                System.out.println("Medium file does not exist: " + mediumFile);
+                continue;
+            }
+
+            try {
+                checkAnomalies(thumbnailFile, mediumFile);
+            } catch (Exception e) {
+                System.out.println(" error: " + thumbnailFile + " " + mediumFile);
+                System.out.println(" error: " + e.getMessage());
+            }
+
+        }
+    }
+
+    private void checkAnomalies(File thumbnailFile, File mediumFile) {
+        String fileStem = thumbnailFile.getAbsolutePath().substring(0, thumbnailFile.getAbsolutePath().lastIndexOf('.'));
+        if (fileStem.endsWith("_thumb")) {
+            throw new RuntimeException("Thumbnail file should not end with _thumb");
+        }
+        fileStem = mediumFile.getAbsolutePath().substring(0, mediumFile.getAbsolutePath().lastIndexOf('.'));
+        if (fileStem.endsWith("_medium")) {
+            throw new RuntimeException("Medium file should not end with _medium");
+        }
+
+        String extension = thumbnailFile.getAbsolutePath().substring(thumbnailFile.getAbsolutePath().lastIndexOf('.'));
+
+        if (thumbnailFile.length() > mediumFile.length()) {
+            System.out.println("Anomaly detected: " + mediumFile + " has fewer pixels than " + thumbnailFile);
+            printFilePixelDimensions(mediumFile);
+            printFilePixelDimensions(thumbnailFile);
+            swapFiles(thumbnailFile, mediumFile);
+        }
+
+    }
+
+    private void swapFiles(File filename, File mediumFile) {
+        if (!dryRun) {
+            String extension = filename.getAbsolutePath().substring(filename.getAbsolutePath().lastIndexOf('.'));
+            try {
+                String randomString = System.currentTimeMillis() + "-" + generateRandomString(6);
+                File tmpFile = new File(filename + "." + randomString + ".tmp");
+                System.out.println("Swapping " + filename + " and " + mediumFile + " via " + tmpFile);
+                Files.move(filename.toPath(), tmpFile.toPath());
+                Files.move(mediumFile.toPath(), filename.toPath());
+                Files.move(tmpFile.toPath(), mediumFile.toPath());
+            } catch (IOException e) {
+                System.out.println("Error copying file: " + e.getMessage());
+            }
+        }
+    }
+
+    private static String generateRandomString(int length) {
+        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        Random random = new Random();
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < length; i++) {
+            int randomIndex = random.nextInt(characters.length());
+            char randomChar = characters.charAt(randomIndex);
+            sb.append(randomChar);
+        }
+
+        return sb.toString();
+    }
+
+    private void printFilePixelDimensions(File imageFile) {
+        try {
+            BufferedImage bimg = ImageIO.read(imageFile);
+            int width = bimg.getWidth();
+            int height = bimg.getHeight();
+            System.out.println(imageFile + ": " + width + "x" + height);
+        } catch (IOException e) {
+            System.out.println(imageFile + ": error reading dimensions");
+        }
+    }
+
+}
+


### PR DESCRIPTION
Added gradle task to scan for publications where thumbnail and medium images are swapped.
