### PR TITLE
ZFIN-9456: Use US Locale for dblink info in EnsemblTranscriptFastaReadProcess.java

### DIFF
--- a/source/org/zfin/sequence/load/EnsemblTranscriptFastaReadProcess.java
+++ b/source/org/zfin/sequence/load/EnsemblTranscriptFastaReadProcess.java
@@ -216,7 +216,7 @@ public class EnsemblTranscriptFastaReadProcess extends EnsemblTranscriptBase {
         transcriptDBLink.setLength(ensemblSequence.length());
         database.getDisplayGroups().add(nucleotideSequ);
         transcriptDBLink.setReferenceDatabase(database);
-        Locale locale = new Locale("fr", "FR");
+        Locale locale = new Locale("en", "US");
         DateFormat dateFormat = DateFormat.getDateInstance(DateFormat.DEFAULT, locale);
         String date = dateFormat.format(new Date());
         transcriptDBLink.setLinkInfo("Ensembl Load from " + date);


### PR DESCRIPTION
I noticed some french-looking times saved in the db_link table:

```
select * from db_link where dblink_acc_num = 'ENSDART00000188969';
  dblink_linked_recid   |   dblink_acc_num   |          dblink_info           |     dblink_zdb_id     | dblink_acc_num_display | dblink_length | dblink_fdbcont_zdb_id
------------------------+--------------------+--------------------------------+-----------------------+------------------------+---------------+-----------------------
 ZDB-TSCRIPT-241211-290 | ENSDART00000188969 | Ensembl Load from 11 déc. 2024 | ZDB-DBLINK-241211-290 | ENSDART00000188969     |          6805 | ZDB-FDBCONT-240304-1
```