### PR TITLE
ZFIN-9028: Generate error message for "Known Insertion Site"

### DIFF
--- a/source/org/zfin/gwt/curation/ui/FeatureValidationService.java
+++ b/source/org/zfin/gwt/curation/ui/FeatureValidationService.java
@@ -32,6 +32,9 @@ public class FeatureValidationService {
                 if (StringUtils.isEmptyTrim(featureDTO.getFeatureAssembly())) {
                     return "You must specify an assembly if you specify a location";
                 }
+                if (!featureDTO.getKnownInsertionSite()) {
+                    return "You must mark \"Known Insertion Site\" if you specify a location";
+                }
             }
 
         } else if (featureDTO.getFeatureStartLoc() != null || featureDTO.getFeatureEndLoc() != null) {


### PR DESCRIPTION
if a chromosome location is specified without marking as "Known Insertion Site"