### PR TITLE
ZFIN-9351: Logic Check on ScrollableResults

### DIFF
--- a/source/org/zfin/feature/presentation/FeatureAPIController.java
+++ b/source/org/zfin/feature/presentation/FeatureAPIController.java
@@ -42,6 +42,7 @@ public class FeatureAPIController {
         return response;
     }
 
+    //TODO: check logic -> done (https://zfin.org/action/api/lab/ZDB-LAB-971209-4/features?limit=1&page=2)
     @JsonView(View.FeatureAPI.class)
     @RequestMapping(value = "/lab/{zdbID}/features")
     public JsonResultResponse<Feature> getFeatureForLab(@PathVariable String zdbID,

--- a/source/org/zfin/feature/repository/HibernateFeatureRepository.java
+++ b/source/org/zfin/feature/repository/HibernateFeatureRepository.java
@@ -998,6 +998,8 @@ public class HibernateFeatureRepository implements FeatureRepository {
         return result.getPopulatedResults();
     }
 
+    //TODO: check scrollable logic (https://zfin.org/action/api/lab/ZDB-LAB-971209-4/features?limit=10&page=2)
+    //Done: Actually, new logic is good, old logic is bad
     @Override
     public PaginationResult<Feature> getFeaturesForLab(String zdbID, Pagination pagination) {
         Session session = currentSession();

--- a/source/org/zfin/marker/repository/HibernateMarkerRepository.java
+++ b/source/org/zfin/marker/repository/HibernateMarkerRepository.java
@@ -1249,6 +1249,7 @@ public class HibernateMarkerRepository implements MarkerRepository {
         return session.createQuery(hql, String.class).list();
     }
 
+    //TODO: check scrollable logic -> done (https://trunk.zfin.org/action/ontology/show-high-quality-probes-substructures/ZDB-TERM-100331-730?page=3)
     @SuppressWarnings("unchecked")
     public PaginationResult<HighQualityProbe> getHighQualityProbeStatistics(GenericTerm aoTerm, PaginationBean pagination, boolean includeSubstructures) {
         Session session = HibernateUtil.currentSession();

--- a/source/org/zfin/publication/repository/HibernatePublicationRepository.java
+++ b/source/org/zfin/publication/repository/HibernatePublicationRepository.java
@@ -94,6 +94,7 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
     //TODO: ScrollableResults makes it difficult to refactor to Tuple-based hql
 
 
+    //TODO: check scrollable logic -> done (https://zfin.org/action/api/ontology/ZDB-TERM-100331-1074/expressed-genes?&limit=10&page=2)
     /**
      * Note: firstRow must be 1 or greater, i.e. the way a user would describes
      * the record number. Hibernate starts with the first row numbered '0'.

--- a/source/org/zfin/repository/PaginationResultFactory.java
+++ b/source/org/zfin/repository/PaginationResultFactory.java
@@ -13,6 +13,7 @@ import java.util.List;
  */
 public class PaginationResultFactory {
 
+    //TODO: check logic -> done (https://zfin.org/action/expression/results?geneField=EGFP&journalType=ALL&includeSubstructures=true&geneZdbID=ZDB-EFG-070117-1&page=5)
     /**
      * Return records from 0 to max records
      *
@@ -35,6 +36,7 @@ public class PaginationResultFactory {
         return returnResult;
     }
 
+    //TODO: check logic -> done
     /**
      * @param startRecord       This is inclusive.
      * @param stopRecord        This is exclusive.
@@ -88,6 +90,7 @@ public class PaginationResultFactory {
         return returnResult;
     }
 
+    //TODO: check logic -> done (See: https://zfin.org/action/api/ontology/ZDB-TERM-160831-150272/chebi-zebrafish-models?directAnnotation=true&limit=5&page=2)
     /**
      * @param bean              PaginationBean
      * @param scrollableResults Scrollable Object
@@ -97,10 +100,12 @@ public class PaginationResultFactory {
         return createResultFromScrollableResultAndClose(bean.getFirstRecord() - 1, bean.getLastRecord(), scrollableResults);
     }
 
+    //TODO: check logic -> done (used by getProbes only. See: https://zfin.org/action/api/publication/ZDB-PUB-040907-1/probes?limit=10&page=6)
     public static <T> PaginationResult<T> createResultFromScrollableResultAndClose(Pagination pagination, ScrollableResults scrollableResults) {
         return createResultFromScrollableResultAndClose(pagination.getStart(), pagination.getEnd(), scrollableResults);
     }
 
+    //TODO: Check logic -> done (only use on pages like https://zfin.org/action/updates/ZDB-GENE-991019-3)
     /**
      * Return a paginated subset of the list provided based on the pagination object provided
      * It will use the parameters of pagination (size, page number, etc.) to figure out the subset


### PR DESCRIPTION
Add notes about checking the logic for scrollable results to make sure the hibernate upgrade doesn't affect them.