### PR TITLE
ZFIN-9622: Handle edge case for manually curated UniProt accessions flagged for deletion

### DIFF
--- a/source/org/zfin/uniprot/UniProtLoadAction.java
+++ b/source/org/zfin/uniprot/UniProtLoadAction.java
@@ -76,7 +76,9 @@ public class UniProtLoadAction implements Comparable<UniProtLoadAction> {
         REMOVE_ATTRIBUTION("Remove Attribution"),
         ADD_ATTRIBUTION("Add Attribution"),
         GENE_LOST_ALL_UNIPROTS("ZFIN Gene Lost All UniProt Accessions"),
-        GENE_GAINS_FIRST_UNIPROT("ZFIN Gene Gains First UniProt Accession");
+        GENE_GAINS_FIRST_UNIPROT("ZFIN Gene Gains First UniProt Accession"),
+        MANUALLY_CURATED_ACCESSION_WOULD_BE_LOST("Manually Curated UniProt Accession Would Be Lost"),
+        ;
 
         private final String value;
 

--- a/source/org/zfin/uniprot/UniProtLoadService.java
+++ b/source/org/zfin/uniprot/UniProtLoadService.java
@@ -82,22 +82,25 @@ public class UniProtLoadService {
     }
 
     private static void bulkLoadActionForNewDbLinks(List<UniProtLoadAction> actions) {
+        ReferenceDatabase refDB = getUniProtReferenceDatabase();
+        String linkInfo = getUniProtLoadLinkInfo();
         List<Marker> markers = getMarkerRepository().getMarkersByZdbIDs(actions.stream().map(UniProtLoadAction::getGeneZdbID).toList());
         Map<String, Marker> markerMap = markers.stream().collect(Collectors.toMap(Marker::getZdbID, marker -> marker));
         List<MarkerDBLink> dblinks = new ArrayList<>();
         for(UniProtLoadAction action : actions) {
-            log.info("Adding dblink: " + action.getAccession() + " " + action.getGeneZdbID());
+            log.info("Adding dblink to load list: " + action.getAccession() + " " + action.getGeneZdbID());
             Marker marker = markerMap.get(action.getGeneZdbID());
             MarkerDBLink newLink = new MarkerDBLink();
             newLink.setAccessionNumber(action.getAccession());
             newLink.setMarker(marker);
-            newLink.setReferenceDatabase(getUniProtReferenceDatabase());
+            newLink.setReferenceDatabase(refDB);
             newLink.setLength(action.getLength());
-            newLink.setLinkInfo(getUniProtLoadLinkInfo());
+            newLink.setLinkInfo(linkInfo);
             dblinks.add(newLink);
         }
         addHistoryUpdatesForNewDbLinks(dblinks);
         Publication publication = getPublicationRepository().getPublication(PUBLICATION_ATTRIBUTION_ID);
+        log.info("Loading dblink list to database");
         getSequenceRepository().addDBLinks(dblinks, publication, 50);
     }
 

--- a/source/org/zfin/uniprot/secondary/SecondaryTermLoadService.java
+++ b/source/org/zfin/uniprot/secondary/SecondaryTermLoadService.java
@@ -5,6 +5,9 @@ import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 import org.zfin.sequence.ReferenceDatabase;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.zfin.repository.RepositoryFactory.getSequenceRepository;
 import static org.zfin.uniprot.UniProtTools.AUTOMATED_CURATION_OF_UNIPROT_DATABASE_LINKS;
 
@@ -13,18 +16,15 @@ import static org.zfin.uniprot.UniProtTools.AUTOMATED_CURATION_OF_UNIPROT_DATABA
 @Log4j2
 public class SecondaryTermLoadService {
 
-
     public static final String DBLINK_PUBLICATION_ATTRIBUTION_ID = AUTOMATED_CURATION_OF_UNIPROT_DATABASE_LINKS;
     public static final String EXTNOTE_PUBLICATION_ATTRIBUTION_ID = AUTOMATED_CURATION_OF_UNIPROT_DATABASE_LINKS;
-
 
     public static final String EXTNOTE_REFERENCE_DATABASE_ID = "ZDB-FDBCONT-040412-47";
     public static final String INTERPRO_REFERENCE_DATABASE_ID = "ZDB-FDBCONT-040412-48";
     public static final String EC_REFERENCE_DATABASE_ID = "ZDB-FDBCONT-040412-49";
     public static final String PFAM_REFERENCE_DATABASE_ID = "ZDB-FDBCONT-040412-50";
     public static final String PROSITE_REFERENCE_DATABASE_ID = "ZDB-FDBCONT-040412-51";
-
-
+    public static final Map<String, ReferenceDatabase> referenceDatabasesCache = new HashMap<>();
 
     public static ReferenceDatabase getReferenceDatabaseForAction(SecondaryTermLoadAction action) {
         return getReferenceDatabase(getReferenceDatabaseIDForAction(action));
@@ -43,12 +43,10 @@ public class SecondaryTermLoadService {
     }
 
     public static ReferenceDatabase getReferenceDatabase(String referenceDatabaseID) {
-        return getSequenceRepository().getReferenceDatabaseByID(referenceDatabaseID);
+        ReferenceDatabase refDB = referenceDatabasesCache.get(referenceDatabaseID);
+        if (refDB == null) {
+            refDB = getSequenceRepository().getReferenceDatabaseByID(referenceDatabaseID);
+        }
+        return refDB;
     }
-
-
-
-
-
-
 }

--- a/source/org/zfin/uniprot/task/UniProtLoadTask.java
+++ b/source/org/zfin/uniprot/task/UniProtLoadTask.java
@@ -136,7 +136,7 @@ public class UniProtLoadTask extends AbstractScriptWrapper {
             log.info("Loading changes into database.");
             loadChanges(actions);
         } else {
-            log.info("Dry run, not loading changes into database.");
+            log.info("Dry run, not loading changes into database. (set UNIPROT_COMMIT_CHANGES environment variable to 'true' to load changes).");
         }
     }
 


### PR DESCRIPTION
Handle edge case for manually curated UniProt accessions flagged for deletion

- Added logic to detect manually curated UniProt accessions that would otherwise be lost
	- Introduced new SubType: MANUALLY_CURATED_ACCESSION_WOULD_BE_LOST
	- Enhanced CheckLostUniprotsForObsoletesHandler to review this subtype
	- These accessions are included in the report for curator review
- Improved log messages
- Improve efficiency with reuse of reference database object