### PR TITLE
Fix organism regex for Accession-Bank jenkins job

### DIFF
--- a/server_apps/data_transfer/Genbank/filterFlatFile.pl
+++ b/server_apps/data_transfer/Genbank/filterFlatFile.pl
@@ -66,7 +66,7 @@ while (my $gbfile = shift @ARGV) {
 
         $totalRecordCoundWithLocus++;
 
-        /ORGANISM\s+([\w\[\]].+)\n/ or die "ORGANISM unmatched \n";
+        /ORGANISM\s+([\w\[\]\'].+)\n/ or die "ORGANISM unmatched at record $progress : \n\n$_ \n";
         $organism = $1;
         if ($organism eq 'Danio rerio' || $organism eq 'Mus musculus' || $organism eq 'Homo sapiens') {
             $totalFilteredRecordCount++;

--- a/server_apps/data_transfer/Genbank/gbaccession.pl
+++ b/server_apps/data_transfer/Genbank/gbaccession.pl
@@ -75,13 +75,20 @@ if (!(-e "$newfile")) {
 
 # filter file to relevant entries only
 print "Running filterFlatFile.pl on $newfile \n";
-system ("./filterFlatFile.pl $newfile")  &&  &writeReport("filterFlatFile.pl failed.");
+my $returnCode = system("./filterFlatFile.pl $newfile");
+if ($returnCode != 0) {
+    &writeReport("filterFlatFile.pl failed.");
+    exit $returnCode;
+}
 
 # parse out accession number, length, datatype for zebrafish records,
 # also parse out flat file into several fasta files for blast db update
 print "Running parseDaily.pl on $newfile \n";
-system ("./parseDaily.pl $newfile")  &&  &writeReport("parseDaily.pl failed.");
-
+$returnCode = system("./parseDaily.pl $newfile")
+if ($returnCode != 0) {
+    &writeReport("parseDaily.pl failed.");
+    exit $returnCode;
+}
 
 # only move the FASTA files and flat files to development_machine if that script
 # is run from production.

--- a/server_apps/data_transfer/Genbank/parseDaily.pl
+++ b/server_apps/data_transfer/Genbank/parseDaily.pl
@@ -77,7 +77,7 @@ while (my $gbfile = shift @ARGV) {
         $accession = $1;
         $gi = $accession;
 
-        /ORGANISM\s+([\w\[\]].+)\n/ or die "ORGANISM unmatched for $locus \n";
+        /ORGANISM\s+([\w\[\]\'].+)\n/ or die "ORGANISM unmatched for $locus \n";
         $organism = $1;
         $dbsource = gb;
         $dbsource = emb if /Center code: SC/;


### PR DESCRIPTION
Fix organism regex to accommodate the occasional instance where the organism name starts with an apostrophe