### PR TITLE
ZFIN-9674: Update fetchPubsFromPubMed to allow updating existing pub authors

### DIFF
--- a/home/WEB-INF/web.xml
+++ b/home/WEB-INF/web.xml
@@ -5,10 +5,6 @@
          version="3.0">
 
     <display-name>ZFIN: Zebrafish Information Network</display-name>
-
-<!--    <request-character-encoding>UTF-8</request-character-encoding>-->
-<!--    <response-character-encoding>UTF-8</response-character-encoding>-->
-
     <context-param>
         <param-name>log4jConfigLocation</param-name>
         <param-value>/WEB-INF/log4j2.xml</param-value>
@@ -91,10 +87,6 @@
             <param-name>dispatchOptionsRequest</param-name>
             <param-value>true</param-value>
         </init-param>
-<!--        <init-param>-->
-<!--            <param-name>defaultEncoding</param-name>-->
-<!--            <param-value>UTF-8</param-value>-->
-<!--        </init-param>-->
         <load-on-startup>1</load-on-startup>
         <multipart-config />
     </servlet>
@@ -111,10 +103,6 @@
             <param-name>property-file-directory</param-name>
             <param-value>WEB-INF</param-value>
         </init-param>
-<!--        <init-param>-->
-<!--            <param-name>defaultEncoding</param-name>-->
-<!--            <param-value>UTF-8</param-value>-->
-<!--        </init-param>-->
         <load-on-startup>1</load-on-startup>
     </servlet>
     <!-- Standard Action Servlet Mapping -->

--- a/home/WEB-INF/web.xml
+++ b/home/WEB-INF/web.xml
@@ -6,6 +6,9 @@
 
     <display-name>ZFIN: Zebrafish Information Network</display-name>
 
+<!--    <request-character-encoding>UTF-8</request-character-encoding>-->
+<!--    <response-character-encoding>UTF-8</response-character-encoding>-->
+
     <context-param>
         <param-name>log4jConfigLocation</param-name>
         <param-value>/WEB-INF/log4j2.xml</param-value>
@@ -71,6 +74,10 @@
             <param-name>dispatchOptionsRequest</param-name>
             <param-value>true</param-value>
         </init-param>
+<!--        <init-param>-->
+<!--            <param-name>defaultEncoding</param-name>-->
+<!--            <param-value>UTF-8</param-value>-->
+<!--        </init-param>-->
         <load-on-startup>1</load-on-startup>
         <multipart-config />
     </servlet>
@@ -87,6 +94,10 @@
             <param-name>property-file-directory</param-name>
             <param-value>WEB-INF</param-value>
         </init-param>
+<!--        <init-param>-->
+<!--            <param-name>defaultEncoding</param-name>-->
+<!--            <param-value>UTF-8</param-value>-->
+<!--        </init-param>-->
         <load-on-startup>1</load-on-startup>
     </servlet>
     <!-- Standard Action Servlet Mapping -->

--- a/home/WEB-INF/web.xml
+++ b/home/WEB-INF/web.xml
@@ -23,6 +23,23 @@
         </param-value>
     </context-param>
 
+    <filter>
+        <filter-name>characterEncodingFilter</filter-name>
+        <filter-class>org.springframework.web.filter.CharacterEncodingFilter</filter-class>
+        <init-param>
+            <param-name>encoding</param-name>
+            <param-value>UTF-8</param-value>
+        </init-param>
+        <init-param>
+            <param-name>forceEncoding</param-name>
+            <param-value>true</param-value>
+        </init-param>
+    </filter>
+    <filter-mapping>
+        <filter-name>characterEncodingFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
     <!--this forces it to use the default security bean in security.xml springSecurityFilterChain-->
     <filter>
         <filter-name>springSecurityFilterChain</filter-name>

--- a/server_apps/data_transfer/PUBMED/loadNewPubs.sql
+++ b/server_apps/data_transfer/PUBMED/loadNewPubs.sql
@@ -22,7 +22,7 @@ create temp table tmp_pubs (
   pubType text);
 
 \copy tmp_pubs from 'parsePubs.log';
-\copy (select zdb_id from tmp_pubs,publication where accession_no = pmid) to '<!--|TARGETROOT|-->/server_apps/data_transfer/PUBMED/pubAlreadyinZFIN.txt' delimiter '|';
+\copy (select zdb_id from tmp_pubs,publication where accession_no = pmid) to 'pubAlreadyinZFIN.txt' delimiter '|';
 
 delete from tmp_pubs
 where (authors = 'none' or authors is null)
@@ -148,7 +148,7 @@ from tmp_new_journals;
 insert into zdb_active_source (zactvs_zdb_id)
   select id from tmp_ids;
 
-\copy (select distinct get_id('JRNL'), journaltitle, iso, issn from tmp_new_pubs where journal_zdb_id is null) to '<!--|TARGETROOT|-->/server_apps/data_transfer/PUBMED/newJournals.txt' delimiter '|';
+\copy (select distinct get_id('JRNL'), journaltitle, iso, issn from tmp_new_pubs where journal_zdb_id is null) to 'newJournals.txt' delimiter '|';
 
 insert into journal (jrnl_zdb_id, jrnl_name, jrnl_abbrev, jrnl_is_nice, jrnl_print_issn)
   select id, journaltitle, iso, false, issn
@@ -191,9 +191,9 @@ update tmp_new_pubs
 set day = '0'||day
 where length(day) = 1;
 
-\copy (select * from tmp_new_pubs) to '<!--|TARGETROOT|-->/server_apps/data_transfer/PUBMED/newPublicationsAdded.txt' delimiter '|';
+\copy (select * from tmp_new_pubs) to 'newPublicationsAdded.txt' delimiter '|';
 
-\copy (select zdb_id, pmid, title from tmp_new_pubs) to '<!--|TARGETROOT|-->/server_apps/data_transfer/PUBMED/newPubSummary.txt' delimiter '|';
+\copy (select zdb_id, pmid, title from tmp_new_pubs) to 'newPubSummary.txt' delimiter '|';
 
 insert into publication (
   pub_pmc_id,
@@ -289,7 +289,7 @@ create temp table tmp_mesh (
   is_major boolean
 ) ;
 
-\copy tmp_mesh from '<!--|TARGETROOT|-->/server_apps/data_transfer/PUBMED/parseMesh.log' delimiter '|';
+\copy tmp_mesh from 'parseMesh.log' delimiter '|';
 
 insert into mesh_heading (mh_pub_zdb_id, mh_mesht_mesh_descriptor_id, mh_descriptor_is_major_topic)
   select distinct tmp_new_pubs.zdb_id, tmp_mesh.descriptor_id, tmp_mesh.is_major

--- a/server_apps/data_transfer/PUBMED/load_complete_author_names.sql
+++ b/server_apps/data_transfer/PUBMED/load_complete_author_names.sql
@@ -11,7 +11,7 @@ create temp table names (
 create index names_pid_idx on names(pubmedid);
 create index names_zdbid_idx on names(zdbid);
 
-copy names from '<!--|ROOT_PATH|-->/server_apps/data_transfer/PUBMED/authors' (delimiter '|');
+copy names from 'authors' (delimiter '|');
 
 insert into pubmed_publication_author(ppa_pubmed_id, ppa_publication_zdb_id, ppa_author_last_name, ppa_author_middle_name, ppa_author_first_name)
   select pubmedid, zdbid, lastname, middlename, firstname

--- a/server_apps/data_transfer/PUBMED/pubActivation.groovy
+++ b/server_apps/data_transfer/PUBMED/pubActivation.groovy
@@ -10,9 +10,10 @@ WORKING_DIR.eachFileMatch(~/.*\.txt/) { it.delete() }
 DBNAME = System.getenv("DBNAME")
 
 println("Running complete_auther_names.pl at " + new Date())
-def scriptPath = "${System.getenv()['TARGETROOT']}/server_apps/data_transfer/PUBMED/complete_auther_names.pl"
+def workingDir = "${System.getenv()['TARGETROOT']}/server_apps/data_transfer/PUBMED"
+def scriptPath = "${workingDir}/complete_auther_names.pl"
 def command = "perl -w $scriptPath"
-println command.execute().text
+println command.execute(null, new File(workingDir)).text
 
 println("Running pub_check_and_addback_volpg.pl at " + new Date())
 def scriptPath2 = "${System.getenv()['TARGETROOT']}/server_apps/DB_maintenance/pub_check_and_addback_volpg.pl"

--- a/server_apps/data_transfer/PUBMED/updateExistingPubs.sql
+++ b/server_apps/data_transfer/PUBMED/updateExistingPubs.sql
@@ -1,0 +1,105 @@
+begin work;
+
+create temp table tmp_pubs (
+  pmcid text,
+  mid text,
+  pmid integer,
+  keywords text,
+  title text,
+  pages text,
+  abstract text,
+  authors text,
+  numAuthors int,
+  year text,
+  month text,
+  day text,
+  issn text,
+  volume text,
+  issue text,
+  journaltitle text,
+  iso text,
+  status text,
+  pubType text);
+
+\copy tmp_pubs from 'parsePubs.log';
+
+delete from tmp_pubs
+where (authors = 'none' or authors is null)
+      and numAuthors = '0';
+
+create temp table tmp_new_pubs (
+  pmcid text,
+  mid text,
+  zdb_id text,
+  pmid integer,
+  keywords text,
+  title text,
+  pages text,
+  abstract text,
+  authors text,
+  year text,
+  month text,
+  day text,
+  issn text,
+  volume text,
+  issue text,
+  journaltitle text,
+  iso text,
+  status text,
+  journal_zdb_id text,
+  pubType text
+);
+
+insert into tmp_new_pubs
+   (pmcid,
+   mid ,
+  pmid ,
+  keywords ,
+  title ,
+  pages ,
+  abstract ,
+  authors ,
+  year ,
+  month ,
+  day ,
+  issn,
+  volume ,
+  issue ,
+  journaltitle ,
+  iso ,
+  status ,
+  journal_zdb_id, pubType)
+  select pmcid,mid,
+    pmid,
+    keywords,
+    title,
+    pages,
+    abstract,
+    authors,
+    year,
+    month,
+    day,
+    issn,
+    volume,
+    issue,
+    journaltitle,
+    iso,
+    status,
+    journaltitle,
+    pubType
+  from tmp_pubs;
+
+delete from tmp_new_pubs where pubtype='preprint';
+
+\copy (select * from tmp_new_pubs) to 'existingPublicationsUpdating.txt' delimiter '|';
+\copy (select zdb_id, pmid, title from tmp_new_pubs) to 'updatedPubSummary.txt' delimiter '|';
+
+-- update authors only for indicated publications
+UPDATE publication
+SET authors = t.authors
+    FROM tmp_pubs t
+WHERE t.pmid = accession_no;
+
+commit work;
+
+--rollback work ;


### PR DESCRIPTION
Allow passing a fetchMode = 'update' to the fetchPubsFromPubMed.groovy script along with PubMed IDs to update existing rows in publication table with the values fetched from NCBI. It updates the authors column only right now.

Example:
```
groovy -cp "$GROOVY_CLASSPATH:." -DfetchMode=update ./fetchPubsFromPubMed.groovy 39821319
```

Also, fix the content-type header to be "UTF-8":
Example curl commands to inspect the content-type from tomcat:
```
docker exec -it -u root zfin_org-tomcat-1 curl -D - -s -o /dev/null -k https://localhost:8443/action/publication/ZDB-PUB-250118-4 | grep -i content-type:

docker exec -it -u root zfin_org-tomcat-1 curl -D - -s -o /dev/null -k https://localhost:8443/action/marker/gene/view/ZDB-GENE-990415-8 | grep -i content-type:
```

Example output:
```
Before change:
Content-Type: text/html;charset=ISO-8859-1

After change:
Content-Type: text/html;charset=UTF-8
```