### PR TITLE
Set headers for content-type to utf-8

### DIFF
--- a/home/WEB-INF/web.xml
+++ b/home/WEB-INF/web.xml
@@ -6,6 +6,9 @@
 
     <display-name>ZFIN: Zebrafish Information Network</display-name>
 
+<!--    <request-character-encoding>UTF-8</request-character-encoding>-->
+<!--    <response-character-encoding>UTF-8</response-character-encoding>-->
+
     <context-param>
         <param-name>log4jConfigLocation</param-name>
         <param-value>/WEB-INF/log4j2.xml</param-value>
@@ -71,6 +74,10 @@
             <param-name>dispatchOptionsRequest</param-name>
             <param-value>true</param-value>
         </init-param>
+<!--        <init-param>-->
+<!--            <param-name>defaultEncoding</param-name>-->
+<!--            <param-value>UTF-8</param-value>-->
+<!--        </init-param>-->
         <load-on-startup>1</load-on-startup>
         <multipart-config />
     </servlet>
@@ -87,6 +94,10 @@
             <param-name>property-file-directory</param-name>
             <param-value>WEB-INF</param-value>
         </init-param>
+<!--        <init-param>-->
+<!--            <param-name>defaultEncoding</param-name>-->
+<!--            <param-value>UTF-8</param-value>-->
+<!--        </init-param>-->
         <load-on-startup>1</load-on-startup>
     </servlet>
     <!-- Standard Action Servlet Mapping -->

--- a/home/WEB-INF/web.xml
+++ b/home/WEB-INF/web.xml
@@ -23,6 +23,23 @@
         </param-value>
     </context-param>
 
+    <filter>
+        <filter-name>characterEncodingFilter</filter-name>
+        <filter-class>org.springframework.web.filter.CharacterEncodingFilter</filter-class>
+        <init-param>
+            <param-name>encoding</param-name>
+            <param-value>UTF-8</param-value>
+        </init-param>
+        <init-param>
+            <param-name>forceEncoding</param-name>
+            <param-value>true</param-value>
+        </init-param>
+    </filter>
+    <filter-mapping>
+        <filter-name>characterEncodingFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
     <!--this forces it to use the default security bean in security.xml springSecurityFilterChain-->
     <filter>
         <filter-name>springSecurityFilterChain</filter-name>


### PR DESCRIPTION
Example curl commands to inspect the content-type from tomcat:
```
docker exec -it -u root zfin_org-tomcat-1 curl -D - -s -o /dev/null -k https://localhost:8443/action/publication/ZDB-PUB-250118-4 | grep -i content-type:

docker exec -it -u root zfin_org-tomcat-1 curl -D - -s -o /dev/null -k https://localhost:8443/action/marker/gene/view/ZDB-GENE-990415-8 | grep -i content-type:
```

Example output:
```
Before change:
Content-Type: text/html;charset=ISO-8859-1

After change:
Content-Type: text/html;charset=UTF-8
```