### PR TITLE
ZFIN-9618: Allow scripts to run in artifacts in jenkins

### DIFF
--- a/docker/jenkins/Dockerfile
+++ b/docker/jenkins/Dockerfile
@@ -113,6 +113,7 @@ CMD /bin/bash -l -c "/opt/java/openjdk/bin/java \
 	--add-opens java.base/java.lang.reflect=ALL-UNNAMED \
 	--add-opens java.desktop/java.awt=ALL-UNNAMED \
 	-Dinstance=docker \
+	-Dhudson.model.DirectoryBrowserSupport.CSP= \
 	-jar /opt/zfin/source_roots/zfin.org/server_apps/jenkins/jenkins-2.492.2.war \
 	 --httpPort=9499 \
 	--sessionTimeout=604800 \


### PR DESCRIPTION
Allow script execution in artifacts (used in reports) by setting '-Dhudson.model.DirectoryBrowserSupport.CSP=' (empty string)

https://www.jenkins.io/doc/book/security/configuring-content-security-policy/