### PR TITLE
ZFIN-9669: Implement JMX-based metrics monitoring with CAPTCHA control

### DIFF
--- a/docker/tomcat/Dockerfile
+++ b/docker/tomcat/Dockerfile
@@ -22,6 +22,15 @@ RUN usermod  -aG zfishweb zfishweb
 RUN groupadd -g 1477 zfloadup
 RUN usermod  -aG zfloadup zfishweb
 
+RUN echo 'CATALINA_OPTS="${CATALINA_OPTS} \
+-Dcom.sun.management.jmxremote \
+-Dcom.sun.management.jmxremote.local.only=false \
+-Dcom.sun.management.jmxremote.authenticate=false \
+-Dcom.sun.management.jmxremote.port=9012 \
+-Djava.rmi.server.hostname=$(hostname -i) \
+-Dcom.sun.management.jmxremote.rmi.port=9012 \
+-Dcom.sun.management.jmxremote.ssl=false"' > bin/setenv.sh
+
 USER zfishweb
 
 COPY ./postgresql-42.2.18.jar  /usr/local/tomcat/lib

--- a/source/org/zfin/task/metricsmonitor/HighLoadAction.java
+++ b/source/org/zfin/task/metricsmonitor/HighLoadAction.java
@@ -6,7 +6,7 @@ import java.util.Date;
 public class HighLoadAction {
 
     public static final String TRIGGER_ON_SQL = "update zdb_feature_flag set zfeatflag_enabled=true, zfeatflag_last_modified=now() where zfeatflag_name in ('Enable Captcha', 'Use altcha')";
-    public static final String TRIGGER_OFF_SQL = "update zdb_feature_flag set zfeatflag_enabled=false";
+    public static final String TRIGGER_OFF_SQL = "update zdb_feature_flag set zfeatflag_enabled=false, zfeatflag_last_modified=now() where zfeatflag_name in ('Enable Captcha')";
     private final MetricsMonitorConfig configuration;
 
     public boolean isTriggered = false;

--- a/source/org/zfin/task/metricsmonitor/HighLoadAction.java
+++ b/source/org/zfin/task/metricsmonitor/HighLoadAction.java
@@ -1,0 +1,120 @@
+package org.zfin.task.metricsmonitor;
+
+import java.sql.*;
+import java.util.Date;
+
+public class HighLoadAction {
+
+    public final double MS_PER_REQUEST_THRESHOLD_HIGH;
+    public final double MS_PER_REQUEST_THRESHOLD_LOW;
+    public final double LOAD_THRESHOLD_HIGH;
+    public final double LOAD_THRESHOLD_LOW;
+    public final long MS_TO_ENABLE;
+    public final String DBHOST;
+    public final String DBUSER;
+    public final String DBNAME;
+    public static final String TRIGGER_ON_SQL = "update zdb_feature_flag set zfeatflag_enabled=true, zfeatflag_last_modified=now() where zfeatflag_name in ('Enable Captcha', 'Use altcha')";
+    public static final String TRIGGER_OFF_SQL = "update zdb_feature_flag set zfeatflag_enabled=false";
+
+    public boolean isTriggered = false;
+    public Date lastTriggered = new Date();
+
+    public HighLoadAction() {
+        if (System.getenv("MS_PER_REQUEST_THRESHOLD_HIGH") != null) {
+            MS_PER_REQUEST_THRESHOLD_HIGH = Double.parseDouble(System.getenv("MS_PER_REQUEST_THRESHOLD_HIGH"));
+        } else {
+            MS_PER_REQUEST_THRESHOLD_HIGH = 1000.0;
+        }
+
+        if (System.getenv("MS_PER_REQUEST_THRESHOLD_LOW") != null) {
+            MS_PER_REQUEST_THRESHOLD_LOW = Double.parseDouble(System.getenv("MS_PER_REQUEST_THRESHOLD_LOW"));
+        } else {
+            MS_PER_REQUEST_THRESHOLD_LOW = 300.0;
+        }
+
+        if (System.getenv("LOAD_THRESHOLD_HIGH") != null) {
+            LOAD_THRESHOLD_HIGH = Double.parseDouble(System.getenv("LOAD_THRESHOLD_HIGH"));
+        } else {
+            LOAD_THRESHOLD_HIGH = 19.0;
+        }
+
+        if (System.getenv("LOAD_THRESHOLD_LOW") != null) {
+            LOAD_THRESHOLD_LOW = Double.parseDouble(System.getenv("LOAD_THRESHOLD_LOW"));
+        } else {
+            LOAD_THRESHOLD_LOW = 15.0;
+        }
+
+        if (System.getenv("SECONDS_TO_ENABLE") != null) {
+            MS_TO_ENABLE = Long.parseLong(System.getenv("SECONDS_TO_ENABLE"));
+        } else {
+            MS_TO_ENABLE = 1800 * 1000;
+        }
+
+        if (System.getenv("DBHOST") != null) {
+            DBHOST = System.getenv("DBHOST");
+        } else {
+            DBHOST = "db";
+        }
+
+        if (System.getenv("DBUSER") != null) {
+            DBUSER = System.getenv("DBUSER");
+        } else {
+            DBUSER = "postgres";
+        }
+
+        if (System.getenv("DBNAME") != null) {
+            DBNAME = System.getenv("DBNAME");
+        } else {
+            DBNAME = "zfindb";
+        }
+    }
+
+    public void trigger(SystemMetricsDTO metrics) {
+        if (shouldTurnOn(metrics)) {
+            turnOn();
+        }
+        if (shouldTurnOff(metrics)) {
+            turnOff();
+        }
+    }
+
+    private boolean shouldTurnOn(SystemMetricsDTO metrics) {
+        return !isTriggered &&
+                ((metrics.getLoad1min() > LOAD_THRESHOLD_HIGH) ||
+                 (metrics.getIntervalAverage() > MS_PER_REQUEST_THRESHOLD_HIGH));
+    }
+
+    private void turnOn() {
+        isTriggered = true;
+        lastTriggered = new Date();
+        int rowsAffected = executeUpdate(TRIGGER_ON_SQL);
+        System.out.println("Captcha enabled: " + rowsAffected + " row(s) updated");
+    }
+
+    private boolean shouldTurnOff(SystemMetricsDTO metrics) {
+        long timeSinceEnable = System.currentTimeMillis() - lastTriggered.getTime();
+        return isTriggered &&
+                ((metrics.getLoad1min() < LOAD_THRESHOLD_LOW) ||
+                 (metrics.getIntervalAverage() < MS_PER_REQUEST_THRESHOLD_LOW)) &&
+                (timeSinceEnable > MS_TO_ENABLE);
+    }
+
+    private void turnOff() {
+        isTriggered = false;
+        int rowsAffected = executeUpdate(TRIGGER_OFF_SQL);
+        System.out.println("Captcha disabled: " + rowsAffected + " row(s) updated");
+    }
+
+    private int executeUpdate(String sql) {
+        // Establish connection
+        String url = "jdbc:postgresql://" + DBHOST + ":5432/" + DBNAME;
+        String user = DBUSER;
+        String password = "";
+        try (Connection connection = DriverManager.getConnection(url, user, password);
+             Statement statement = connection.createStatement()) {
+            return statement.executeUpdate(sql);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/source/org/zfin/task/metricsmonitor/HighLoadAction.java
+++ b/source/org/zfin/task/metricsmonitor/HighLoadAction.java
@@ -5,68 +5,15 @@ import java.util.Date;
 
 public class HighLoadAction {
 
-    public final double MS_PER_REQUEST_THRESHOLD_HIGH;
-    public final double MS_PER_REQUEST_THRESHOLD_LOW;
-    public final double LOAD_THRESHOLD_HIGH;
-    public final double LOAD_THRESHOLD_LOW;
-    public final long MS_TO_ENABLE;
-    public final String DBHOST;
-    public final String DBUSER;
-    public final String DBNAME;
     public static final String TRIGGER_ON_SQL = "update zdb_feature_flag set zfeatflag_enabled=true, zfeatflag_last_modified=now() where zfeatflag_name in ('Enable Captcha', 'Use altcha')";
     public static final String TRIGGER_OFF_SQL = "update zdb_feature_flag set zfeatflag_enabled=false";
+    private final MetricsMonitorConfig configuration;
 
     public boolean isTriggered = false;
     public Date lastTriggered = new Date();
 
     public HighLoadAction() {
-        if (System.getenv("MS_PER_REQUEST_THRESHOLD_HIGH") != null) {
-            MS_PER_REQUEST_THRESHOLD_HIGH = Double.parseDouble(System.getenv("MS_PER_REQUEST_THRESHOLD_HIGH"));
-        } else {
-            MS_PER_REQUEST_THRESHOLD_HIGH = 1000.0;
-        }
-
-        if (System.getenv("MS_PER_REQUEST_THRESHOLD_LOW") != null) {
-            MS_PER_REQUEST_THRESHOLD_LOW = Double.parseDouble(System.getenv("MS_PER_REQUEST_THRESHOLD_LOW"));
-        } else {
-            MS_PER_REQUEST_THRESHOLD_LOW = 300.0;
-        }
-
-        if (System.getenv("LOAD_THRESHOLD_HIGH") != null) {
-            LOAD_THRESHOLD_HIGH = Double.parseDouble(System.getenv("LOAD_THRESHOLD_HIGH"));
-        } else {
-            LOAD_THRESHOLD_HIGH = 19.0;
-        }
-
-        if (System.getenv("LOAD_THRESHOLD_LOW") != null) {
-            LOAD_THRESHOLD_LOW = Double.parseDouble(System.getenv("LOAD_THRESHOLD_LOW"));
-        } else {
-            LOAD_THRESHOLD_LOW = 15.0;
-        }
-
-        if (System.getenv("SECONDS_TO_ENABLE") != null) {
-            MS_TO_ENABLE = Long.parseLong(System.getenv("SECONDS_TO_ENABLE"));
-        } else {
-            MS_TO_ENABLE = 1800 * 1000;
-        }
-
-        if (System.getenv("DBHOST") != null) {
-            DBHOST = System.getenv("DBHOST");
-        } else {
-            DBHOST = "db";
-        }
-
-        if (System.getenv("DBUSER") != null) {
-            DBUSER = System.getenv("DBUSER");
-        } else {
-            DBUSER = "postgres";
-        }
-
-        if (System.getenv("DBNAME") != null) {
-            DBNAME = System.getenv("DBNAME");
-        } else {
-            DBNAME = "zfindb";
-        }
+        this.configuration = MetricsMonitorConfig.getInstance();
     }
 
     public void trigger(SystemMetricsDTO metrics) {
@@ -80,8 +27,8 @@ public class HighLoadAction {
 
     private boolean shouldTurnOn(SystemMetricsDTO metrics) {
         return !isTriggered &&
-                ((metrics.getLoad1min() > LOAD_THRESHOLD_HIGH) ||
-                 (metrics.getIntervalAverage() > MS_PER_REQUEST_THRESHOLD_HIGH));
+                ((metrics.getLoad1min() > configuration.getLoadThresholdHigh()) ||
+                 (metrics.getIntervalAverage() > configuration.getMsPerRequestThresholdHigh()));
     }
 
     private void turnOn() {
@@ -94,9 +41,9 @@ public class HighLoadAction {
     private boolean shouldTurnOff(SystemMetricsDTO metrics) {
         long timeSinceEnable = System.currentTimeMillis() - lastTriggered.getTime();
         return isTriggered &&
-                ((metrics.getLoad1min() < LOAD_THRESHOLD_LOW) ||
-                 (metrics.getIntervalAverage() < MS_PER_REQUEST_THRESHOLD_LOW)) &&
-                (timeSinceEnable > MS_TO_ENABLE);
+                ((metrics.getLoad1min() < configuration.getLoadThresholdLow()) ||
+                 (metrics.getIntervalAverage() < configuration.getMsPerRequestThresholdLow())) &&
+                (timeSinceEnable > configuration.getMillisToEnable());
     }
 
     private void turnOff() {
@@ -107,8 +54,8 @@ public class HighLoadAction {
 
     private int executeUpdate(String sql) {
         // Establish connection
-        String url = "jdbc:postgresql://" + DBHOST + ":5432/" + DBNAME;
-        String user = DBUSER;
+        String url = "jdbc:postgresql://" + configuration.getDbHost() + ":5432/" + configuration.getDbName();
+        String user = configuration.getDbUser();
         String password = "";
         try (Connection connection = DriverManager.getConnection(url, user, password);
              Statement statement = connection.createStatement()) {

--- a/source/org/zfin/task/metricsmonitor/MetricsMonitor.java
+++ b/source/org/zfin/task/metricsmonitor/MetricsMonitor.java
@@ -1,0 +1,201 @@
+package org.zfin.task.metricsmonitor;
+
+import javax.management.*;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Uses jmx to connect to tomcat for various tomcat metrics and
+ * Reads /proc/loadavg to get the cpu load averages.
+ * Once the "1 minute load average" exceeds the LOAD_THRESHOLD_HIGH or
+ * the "average number of milliseconds processing time per request" from tomcat exceeds MS_PER_REQUEST_THRESHOLD_HIGH,
+ * it will turn on captcha.
+ *
+ * If the captcha is enabled, it will disable when the relevant metrics drop below the corresponding "_LOW" thresholds
+ * and a certain amount of time has passed (SECONDS_TO_ENABLE)
+ */
+public class MetricsMonitor {
+    private static final String JMX_URL = "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi";
+    private static final String TOMCAT_CONNECTOR_NAME = "https-openssl-nio-8443";
+
+    private final String host;
+    private final int port;
+    private final int interval;
+    private final SimpleDateFormat timeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private HighLoadAction triggerAction = new HighLoadAction();
+    private JMXConnector jmxConnector;
+    private MBeanServerConnection mbeanConn;
+    private SystemMetricsDTO previousSystemMetrics;
+    private long rowNumber = 0;
+
+    public MetricsMonitor(String host, int port, int interval) {
+        this.host = host;
+        this.port = port;
+        this.interval = interval;
+    }
+
+    private void run() throws IOException {
+            this.connect();
+            this.startMonitoring();
+    }
+
+    public void connect() throws IOException {
+        String urlString = String.format(JMX_URL, host, port);
+        System.out.println("Connecting to " + urlString);
+        JMXServiceURL url = new JMXServiceURL(urlString);
+        jmxConnector = JMXConnectorFactory.connect(url);
+        mbeanConn = jmxConnector.getMBeanServerConnection();
+        System.out.println("Connected to Tomcat JMX at " + urlString);
+    }
+
+    public void startMonitoring() {
+        System.out.println("Starting Monitoring");
+        while (true) {
+            try {
+                SystemMetricsDTO metrics = collectMetrics();
+                printMetrics(metrics);
+                triggerActionForMetrics(metrics);
+                Thread.sleep(this.interval * 1000);
+            } catch (Exception e) {
+                System.err.println("Error collecting metrics: " + e.getMessage());
+                e.printStackTrace();
+
+                // Try to reconnect
+                try {
+                    System.out.println("Attempting to reconnect...");
+                    disconnect();
+                    connect();
+                } catch (IOException reconnectEx) {
+                    System.err.println("Failed to reconnect: " + reconnectEx.getMessage());
+                }
+            }
+        }
+    }
+
+    private void triggerActionForMetrics(SystemMetricsDTO metrics) {
+        triggerAction.trigger(metrics);
+    }
+
+    private SystemMetricsDTO collectMetrics() {
+        SystemMetricsDTO metricsRow = new SystemMetricsDTO();
+        metricsRow.setCurrentTime(timeFormat.format(new Date()));
+        collectResponseTimeMetrics(metricsRow);
+        collectLoadAverageMetrics(metricsRow);
+        return metricsRow;
+    }
+
+    private void printMetrics(SystemMetricsDTO metrics) {
+        if (rowNumber == 0) {
+            System.out.println(metrics.getHeader());
+        }
+        System.out.println(metrics.getRow());
+        rowNumber++;
+    }
+
+    private void collectResponseTimeMetrics(SystemMetricsDTO metricsRow) {
+        try {
+            Long totalRequestCount = getTomcatRequestCount();
+            Long totalProcessingTime = getTomcatProcessingTime();
+
+            //get interval values
+            long intervalRequestCount = 0;
+            long intervalProcessingTime = 0;
+            if (previousSystemMetrics != null) {
+                intervalRequestCount = totalRequestCount - previousSystemMetrics.getTotalRequestCount();
+                intervalProcessingTime = totalProcessingTime - previousSystemMetrics.getTotalProcessingTime();
+            }
+
+            //seconds per request
+            double intervalAverage = (double) intervalProcessingTime / intervalRequestCount;
+            double totalAverage = (double) totalProcessingTime / totalRequestCount;
+
+            metricsRow.setTotalRequestCount(totalRequestCount);
+            metricsRow.setTotalProcessingTime(totalProcessingTime);
+            metricsRow.setTotalAverage(totalAverage);
+            metricsRow.setIntervalRequestCount(intervalRequestCount);
+            metricsRow.setIntervalProcessingTime(intervalProcessingTime);
+            metricsRow.setIntervalAverage(intervalAverage);
+            previousSystemMetrics = metricsRow.duplicate();
+        } catch (MalformedObjectNameException | MBeanException | AttributeNotFoundException |
+                 InstanceNotFoundException | ReflectionException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Long getTomcatRequestCount() throws MBeanException, AttributeNotFoundException, InstanceNotFoundException, ReflectionException, IOException, MalformedObjectNameException {
+        ObjectName httpsName = new ObjectName("Catalina:name=\"" + TOMCAT_CONNECTOR_NAME + "\",type=GlobalRequestProcessor");
+        return ((Integer)mbeanConn.getAttribute(httpsName, "requestCount")).longValue();
+    }
+
+    private Long getTomcatProcessingTime() throws MBeanException, AttributeNotFoundException, InstanceNotFoundException, ReflectionException, IOException, MalformedObjectNameException {
+        ObjectName httpsName = new ObjectName("Catalina:name=\"" + TOMCAT_CONNECTOR_NAME + "\",type=GlobalRequestProcessor");
+        return ((Long)mbeanConn.getAttribute(httpsName, "processingTime"));
+    }
+
+    private void collectLoadAverageMetrics(SystemMetricsDTO metrics) {
+        try {
+            // Path to the loadavg file
+            String filePath = "/proc/loadavg";
+
+            // Read the file
+            BufferedReader reader = null;
+            reader = new BufferedReader(new FileReader(filePath));
+            String line = reader.readLine();
+            reader.close();
+
+            if (line != null) {
+                // Parse the content
+                // Format: load1 load5 load15 nr_running/nr_threads last_pid
+                String[] parts = line.split(" ");
+
+                double load1min = Double.parseDouble(parts[0]);
+                double load5min = Double.parseDouble(parts[1]);
+                double load15min = Double.parseDouble(parts[2]);
+
+                String[] processInfo = parts[3].split("/");
+                Integer runningProcesses = Integer.parseInt(processInfo[0]);
+                Integer totalProcesses = Integer.parseInt(processInfo[1]);
+
+                Long lastPid = Long.parseLong(parts[4]);
+
+                metrics.setLoad1min(load1min);
+                metrics.setLoad5min(load5min);
+                metrics.setLoad15min(load15min);
+                metrics.setRunningProcesses(runningProcesses);
+                metrics.setTotalProcesses(totalProcesses);
+                metrics.setLastPid(lastPid);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void disconnect() throws IOException {
+        if (jmxConnector != null) {
+            jmxConnector.close();
+            System.out.println("Disconnected from Tomcat JMX");
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        if (args.length < 3) {
+            System.out.println("Usage: java MetricsMonitor <host> <port> [pollingIntervalSeconds]");
+            System.out.println("Example: java MetricsMonitor localhost 9012 60");
+            System.out.println("Other configuration items by environment variables: MS_PER_REQUEST_THRESHOLD_HIGH MS_PER_REQUEST_THRESHOLD_LOW LOAD_THRESHOLD_HIGH LOAD_THRESHOLD_LOW MS_TO_ENABLE DBHOST DBUSER DBNAME");
+            System.exit(1);
+        }
+
+        String host = args[0];
+        int port = Integer.parseInt(args[1]);
+        int interval = args.length > 2 ? Integer.parseInt(args[2]) : 60;  // Default to 60 seconds
+
+        MetricsMonitor monitor = new MetricsMonitor(host, port, interval);
+        monitor.run();
+    }
+}

--- a/source/org/zfin/task/metricsmonitor/MetricsMonitorConfig.java
+++ b/source/org/zfin/task/metricsmonitor/MetricsMonitorConfig.java
@@ -1,0 +1,132 @@
+package org.zfin.task.metricsmonitor;
+
+import lombok.Data;
+
+/**
+ * Configuration class for the MetricsMonitor
+ */
+@Data
+public class MetricsMonitorConfig {
+    private static final String JMX_URL_FORMAT = "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi";
+
+    // JMX Connection Settings
+    private String jmxHost;
+    private long jmxPort;
+    private long pollingIntervalSeconds;
+    private String tomcatConnectorName;
+
+    // Performance Thresholds
+    private double msPerRequestThresholdHigh;
+    private double msPerRequestThresholdLow;
+    private double loadThresholdHigh;
+    private double loadThresholdLow;
+    private long millisToEnable;
+
+    // Database Connection Settings
+    private String dbHost;
+    private String dbName;
+    private String dbUser;
+
+    // Singleton instance
+    private static MetricsMonitorConfig instance;
+
+    public static synchronized MetricsMonitorConfig getInstance() {
+        if (instance == null) {
+            instance = new MetricsMonitorConfig();
+            instance.loadConfiguration();
+        }
+        return instance;
+    }
+
+    private void loadConfiguration() {
+        // Set defaults
+        setDefaults();
+
+        // Override with environment variables
+        loadFromEnvironment();
+    }
+
+    /**
+     * Set default values for all configuration properties
+     */
+    private void setDefaults() {
+        // JMX Connection Settings
+        jmxHost = "localhost";
+        jmxPort = 9012;
+        pollingIntervalSeconds = 60;
+        tomcatConnectorName = "https-openssl-nio-8443";
+
+        // Performance Thresholds
+        msPerRequestThresholdHigh = 1000.0;
+        msPerRequestThresholdLow = 300.0;
+        loadThresholdHigh = 19.0;
+        loadThresholdLow = 15.0;
+        millisToEnable = 1800 * 1000; // 30 minutes
+
+        // Database Connection Settings
+        dbHost = "db";
+        dbName = "zfindb";
+        dbUser = "postgres";
+    }
+
+    /**
+     * Load configuration values from environment variables
+     */
+    private void loadFromEnvironment() {
+        // JMX Connection Settings
+        jmxHost = getEnv("JMX_HOST", jmxHost);
+        jmxPort = getEnvAsLong("JMX_PORT", jmxPort);
+        pollingIntervalSeconds = getEnvAsLong("POLLING_INTERVAL_SECONDS", pollingIntervalSeconds);
+        tomcatConnectorName = getEnv("TOMCAT_CONNECTOR_NAME", tomcatConnectorName);
+
+        // Performance Thresholds
+        msPerRequestThresholdHigh = getEnvAsDouble("MS_PER_REQUEST_THRESHOLD_HIGH", msPerRequestThresholdHigh);
+        msPerRequestThresholdLow = getEnvAsDouble("MS_PER_REQUEST_THRESHOLD_LOW", msPerRequestThresholdLow);
+        loadThresholdHigh = getEnvAsDouble("LOAD_THRESHOLD_HIGH", loadThresholdHigh);
+        loadThresholdLow = getEnvAsDouble("LOAD_THRESHOLD_LOW", loadThresholdLow);
+        millisToEnable = getEnvAsLong("SECONDS_TO_ENABLE", millisToEnable / 1000) * 1000;
+
+        // Database Connection Settings
+        dbHost = getEnv("DBHOST", dbHost);
+        dbName = getEnv("DBNAME", dbName);
+        dbUser = getEnv("DBUSER", dbUser);
+    }
+
+    public String dbUrl() {
+        // Construct DB URL
+        return String.format("jdbc:postgresql://%s:5432/%s", dbHost, dbName);
+    }
+
+    public String jmxUrl() {
+        return String.format(JMX_URL_FORMAT, jmxHost, jmxPort);
+    }
+
+
+    // Helper methods for environment variable loading
+    private String getEnv(String name, String defaultValue) {
+        String value = System.getenv(name);
+        return (value != null && !value.isEmpty()) ? value : defaultValue;
+    }
+
+    private long getEnvAsLong(String name, long defaultValue) {
+        String value = System.getenv(name);
+        if (value != null && !value.isEmpty()) {
+            try {
+                return Long.parseLong(value);
+            } catch (NumberFormatException e) {
+            }
+        }
+        return defaultValue;
+    }
+
+    private double getEnvAsDouble(String name, double defaultValue) {
+        String value = System.getenv(name);
+        if (value != null && !value.isEmpty()) {
+            try {
+                return Double.parseDouble(value);
+            } catch (NumberFormatException e) {
+            }
+        }
+        return defaultValue;
+    }
+}

--- a/source/org/zfin/task/metricsmonitor/SystemMetricsDTO.java
+++ b/source/org/zfin/task/metricsmonitor/SystemMetricsDTO.java
@@ -1,0 +1,63 @@
+package org.zfin.task.metricsmonitor;
+import lombok.*;
+
+import java.util.List;
+
+@Data
+public class SystemMetricsDTO {
+
+    private String currentTime;
+    private Long totalRequestCount;
+    private Long totalProcessingTime;
+    private Double totalAverage;
+    private Long intervalRequestCount;
+    private Long intervalProcessingTime;
+    private Double intervalAverage;
+    private Double load1min;
+    private Double load5min;
+    private Double load15min;
+    private Integer runningProcesses;
+    private Integer totalProcesses;
+    private Long lastPid;
+
+    public String getHeader() {
+        return "currentTime,totalRequestCount,totalProcessingTime,totalAverage,intervalRequestCount,intervalProcessingTime,intervalAverage,load1min,load5min,load15min,runningProcesses,totalProcesses,lastPid";
+    }
+
+    public String getRow() {
+        List<String> values = List.of(
+                currentTime,
+                totalRequestCount.toString(),
+                totalProcessingTime.toString(),
+                String.format("%.3f", totalAverage),
+                intervalRequestCount.toString(),
+                intervalProcessingTime.toString(),
+                String.format("%.3f", intervalAverage),
+                load1min.toString(),
+                load5min.toString(),
+                load15min.toString(),
+                runningProcesses.toString(),
+                totalProcesses.toString(),
+                lastPid.toString());
+        return String.join(",", values);
+    }
+
+    public SystemMetricsDTO duplicate() {
+        SystemMetricsDTO copy = new SystemMetricsDTO();
+        copy.currentTime = currentTime;
+        copy.totalRequestCount = totalRequestCount;
+        copy.totalAverage = totalAverage;
+        copy.intervalProcessingTime = intervalProcessingTime;
+        copy.totalProcessingTime = totalProcessingTime;
+        copy.intervalAverage = intervalAverage;
+        copy.intervalRequestCount = intervalRequestCount;
+        copy.load5min = load5min;
+        copy.lastPid = lastPid;
+        copy.load1min = load1min;
+        copy.load15min = load15min;
+        copy.runningProcesses = runningProcesses;
+        copy.totalProcesses = totalProcesses;
+        return copy;
+    }
+
+}


### PR DESCRIPTION
- Added MetricsMonitor to collect Tomcat JMX metrics and system load averages
- Created HighLoadAction to automatically enable/disable CAPTCHA under high load
- Updated Tomcat Dockerfile to enable JMX port for remote monitoring
- System triggers CAPTCHA when load or request processing time exceeds thresholds
- Added CSV-formatted metrics output for monitoring and analysis

Can run in a tomcat container like so:
```
docker exec -it zfin_org-tomcat-1 bash -lc 'cd /opt/zfin/www_homes/zfin.org/home/WEB-INF/classes && java -cp ".:../lib/*" org.zfin.task.metricsmonitor.MetricsMonitor'
```