### PR TITLE
ZFIN-9664: React-based ontology term relationship view

### DIFF
--- a/home/WEB-INF/jsp/ontology/term-view-relationship.jsp
+++ b/home/WEB-INF/jsp/ontology/term-view-relationship.jsp
@@ -5,22 +5,7 @@
 <jsp:useBean id="formBean" class="org.zfin.ontology.presentation.OntologyBean" scope="request"/>
 <c:set var="term" value="${formBean.term}"/>
 
-<z:attributeList>
-
-    <c:forEach var="relationshipPresentation" items="${formBean.termRelationships}" varStatus="index">
-        <z:attributeListItem label="${relationshipPresentation.type}">
-            <zfin2:createExpandCollapseList items="${relationshipPresentation.items}" id="${index.count}"/>
-        </z:attributeListItem>
-    </c:forEach>
-
-</z:attributeList>
-
-
-<script type="text/javascript">
-    function toggle(shortVal, longVal) {
-        document.getElementById(shortVal).style.display = 'none';
-        document.getElementById(longVal).style.display = 'inline';
-    }
-</script>
-
-
+<div class="__react-root"
+     id="TermRelationshipListView"
+     data-term-id="${term.zdbID}"
+></div>

--- a/home/javascript/react/components/term-relationships/TermRelationshipInlineView.tsx
+++ b/home/javascript/react/components/term-relationships/TermRelationshipInlineView.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import {TermRelationshipTypeStat} from '../../containers/TermRelationshipListView';
 import qs from 'qs';
-import {RelatedTerm} from "./TermRelationshipView";
+import {RelatedTerm} from './TermRelationshipView';
 
 export interface RelatedOntologyTermsProps {
     relationshipType: TermRelationshipTypeStat;

--- a/home/javascript/react/components/term-relationships/TermRelationshipInlineView.tsx
+++ b/home/javascript/react/components/term-relationships/TermRelationshipInlineView.tsx
@@ -1,0 +1,133 @@
+import React, {useEffect, useState} from 'react';
+import {TermRelationshipTypeStat} from '../../containers/TermRelationshipListView';
+import qs from 'qs';
+import {RelatedTerm} from "./TermRelationshipView";
+
+export interface RelatedOntologyTermsProps {
+    relationshipType: TermRelationshipTypeStat;
+    termId: string;
+    expandCallback: () => void;
+}
+
+// In this context, works as a substitute for zfin:link (aka CreateLinkTag.java)
+export const TermLink = ({term}: { term: RelatedTerm }) => {
+    return (
+        <>
+            <a href={`/action/ontology/term/${term.oboID}`}>{term.termName}</a>
+            <a
+                href={`/action/ontology/term-detail-popup?termID=${term.oboID}`}
+                className='popup-link data-popup-link'
+                title='Term definition, synonyms and links'
+            />
+        </>
+    );
+};
+
+export default function TermRelationshipInlineView({relationshipType, termId, expandCallback}: RelatedOntologyTermsProps) {
+    const [showAll, setShowAll] = useState(false);
+    const [relationships, setRelationships] = useState([]);
+    const totalCount = relationshipType.count;
+
+    useEffect(() => {
+        loadRelationships();
+    }, []);
+
+    async function loadRelationships() {
+        const params = {
+            relationshipType: relationshipType.relationshipType,
+            isForward: relationshipType.isForward,
+        };
+
+        await fetch(
+            `/action/api/ontology/${termId}/relationships?${qs.stringify(params)}`
+        )
+            .then((response) => response.json())
+            .then((data) => {
+                setRelationships(data.results);
+            });
+    }
+
+    const shortId = `short-${termId}`;
+    const longId = `long-${termId}`;
+
+    const toggleDisplay = () => {
+        setShowAll(!showAll);
+    };
+
+    function expandMessage() {
+        if (totalCount > relationships.length) {
+            return `Show ${relationships.length} of ${totalCount} Terms`;
+        } else {
+            return `Show All ${relationships.length} Terms`;
+        }
+    }
+
+    return (
+        relationships && (
+            <div>
+                <div id={shortId} style={{ display: showAll ? 'none' : 'inline' }}>
+                    {relationships.slice(0, 5).map((term, index) => (
+                        <span
+                            key={index}
+                            className='related-ontology-term'
+                            id={term.termName}
+                        >
+                            <TermLink term={term} />
+                        </span>
+                    ))}
+
+                    {relationships.length > 5 && (
+                        <div className='mt-2'>
+                            <a
+                                href='#'
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    toggleDisplay();
+                                }}
+                            >
+                                ... <img src='/images/plus-symbol.png' alt='expand' />{' '}
+                                {expandMessage()}
+                            </a>
+                        </div>
+                    )}
+                </div>
+
+                <div id={longId} style={{ display: showAll ? 'inline' : 'none' }}>
+                    {relationships.map((term, index) => (
+                        <span
+                            key={index}
+                            className='related-ontology-term'
+                            id={term.termName}
+                        >
+                            <TermLink term={term} />
+                        </span>
+                    ))}
+                    <div className={'mt-2'}>
+                        <a
+                            href='#'
+                            onClick={(e) => {
+                                e.preventDefault();
+                                toggleDisplay();
+                            }}
+                            className='text-sm mr-3'
+                        >
+                            <img src='/images/minus-symbol.png' alt='collapse' /> Show First 5
+                            Terms
+                        </a>
+                        <a
+                            href='#'
+                            onClick={(e) => {
+                                e.preventDefault();
+                                expandCallback();
+                            }}
+                            className='text-sm'
+                        >
+                            <img src='/images/plus-symbol.png' alt='expand more' /> Show All
+                            Terms
+                        </a>
+                    </div>
+                </div>
+            </div>
+        )
+    );
+}

--- a/home/javascript/react/components/term-relationships/TermRelationshipTable.tsx
+++ b/home/javascript/react/components/term-relationships/TermRelationshipTable.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import qs from 'qs';
+import DataTable from '../data-table';
+import {TermRelationshipTypeStat} from '../../containers/TermRelationshipListView';
+import {TermLink} from './TermRelationshipInlineView';
+import {RelatedTerm} from "./TermRelationshipView";
+
+interface TermRelationshipTableProps {
+    termId: string;
+    relationshipType: TermRelationshipTypeStat;
+}
+
+const TermRelationshipTable = ({termId, relationshipType}: TermRelationshipTableProps) => {
+
+    const columns = [
+        {
+            label: 'Term',
+            content: (row: RelatedTerm) => <TermLink term={row}/>,
+            width: '100px',
+        }
+    ];
+
+    const params = {
+        relationshipType: relationshipType.relationshipType,
+        isForward: relationshipType.isForward,
+    };
+
+    return (
+        <>
+            <DataTable
+                columns={columns}
+                dataUrl={`/action/api/ontology/${termId}/relationships?${qs.stringify(params)}`}
+                rowKey={(row: RelatedTerm) => row.zdbID}
+            />
+        </>
+    );
+};
+
+export default TermRelationshipTable;

--- a/home/javascript/react/components/term-relationships/TermRelationshipTable.tsx
+++ b/home/javascript/react/components/term-relationships/TermRelationshipTable.tsx
@@ -3,7 +3,7 @@ import qs from 'qs';
 import DataTable from '../data-table';
 import {TermRelationshipTypeStat} from '../../containers/TermRelationshipListView';
 import {TermLink} from './TermRelationshipInlineView';
-import {RelatedTerm} from "./TermRelationshipView";
+import {RelatedTerm} from './TermRelationshipView';
 
 interface TermRelationshipTableProps {
     termId: string;

--- a/home/javascript/react/components/term-relationships/TermRelationshipView.tsx
+++ b/home/javascript/react/components/term-relationships/TermRelationshipView.tsx
@@ -1,0 +1,37 @@
+import React, {useState} from 'react';
+import TermRelationshipInlineView, {RelatedOntologyTermsProps} from './TermRelationshipInlineView';
+import TermRelationshipTable from './TermRelationshipTable';
+
+export interface RelatedTerm {
+    zdbID: string;
+    termName: string;
+    oboID: string;
+    abbreviation: string;
+}
+
+export default function TermRelationshipView({relationshipType, termId,}: RelatedOntologyTermsProps) {
+    const [isTableView, setIsTableView] = useState(false);
+
+    function displayAllTerms() {
+        setIsTableView(true);
+    }
+
+    return (
+        <>
+            {isTableView ? (
+                <TermRelationshipTable
+                    termId={termId}
+                    relationshipType={relationshipType}
+                />
+            ) : (
+                <TermRelationshipInlineView
+                    termId={termId}
+                    relationshipType={relationshipType}
+                    expandCallback={() => {
+                        displayAllTerms();
+                    }}
+                />
+            )}
+        </>
+    );
+}

--- a/home/javascript/react/containers/TermRelationshipListView.tsx
+++ b/home/javascript/react/containers/TermRelationshipListView.tsx
@@ -1,0 +1,44 @@
+import React, {useEffect, useState} from 'react';
+import TermRelationshipView from '../components/term-relationships/TermRelationshipView';
+
+export interface TermRelationshipTypeStat {
+    relationshipType: string;
+    humanName: string;
+    isForward: boolean;
+    count: number;
+}
+
+interface TermRelationshipTableListProps {
+    termId: string;
+}
+
+const TermRelationshipListView = ({termId}: TermRelationshipTableListProps) => {
+
+    const [relationshipTypes, setRelationshipTypes] = useState<TermRelationshipTypeStat[]>([]);
+    useEffect(() => {
+        loadRelationships();
+    }, [termId]);
+
+    async function loadRelationships() {
+        await fetch(`/action/api/ontology/${termId}/relationshipTypes`)
+            .then(response => response.json())
+            .then(data => setRelationshipTypes(data));
+    }
+
+    return (
+        <div>
+            <dl className='row'>
+                {relationshipTypes && relationshipTypes.map(relationshipType => (
+                    <>
+                        <dt className='col-sm-2 mb-sm-2 attribute-list-item-dt'>{relationshipType.humanName}</dt>
+                        <dd className='col-sm-10 mb-sm-10 attribute-list-item-dd'>
+                            <TermRelationshipView relationshipType={relationshipType} termId={termId}/>
+                        </dd>
+                    </>
+                ))}
+            </dl>
+        </div>
+    );
+};
+
+export default TermRelationshipListView;

--- a/source/org/zfin/ontology/GenericTerm.java
+++ b/source/org/zfin/ontology/GenericTerm.java
@@ -244,47 +244,7 @@ public class GenericTerm implements Term<GenericTermRelationship> {
             terms.addAll(parentTermRelationships);
 
         return terms;
-//        if (relationships != null){
-//            return relationships;
-//        }
-//
-//        relationships = new ArrayList<TermRelationship>();
-//        relationships.addAll(RepositoryFactory.getOntologyRepository().getTermRelationships(this));
-////        OntologyRepository ontologyRepository = RepositoryFactory.getOntologyRepository() ;
-////        Term t = ontologyRepository.getTermByOboID(getOboID());
-////        relationships.addAll(ontologyRepository.getTermRelationships(t));
-//        return relationships;
     }
-
-//    public List<TermRelationship> getRelatedTerms() {
-//        return relationships;
-//    }
-//
-//    @Override
-//    public void setRelatedTerms(List<TermRelationship> relationships) {
-//        this.relationships = relationships;
-//    }
-
-//    public List<Term> getChildrenTerms() {
-//        if (CollectionUtils.isNotEmpty(children))
-//            return children;
-//
-//        if (relationships == null)
-//            return null;
-//
-//        children = new ArrayList<Term>();
-//        for (TermRelationship rel : relationships) {
-//            Term relatedTerm = rel.getRelatedTerm(this);
-//            // the null check comes from the AO which has start and end relationship to stage terms which are not yet set
-//            // upon deserialization of the obo files.
-//
-//            // is a hibernate object and so expects to have a session
-//            // so need to explicitly be bound to it since we don't know how this object was retrieved (memory vs DB).
-//            if (relatedTerm != null && relatedTerm.equals(rel.getTermTwo()))
-//                children.add(relatedTerm);
-//        }
-//        return children;
-//    }
 
     public Set<Image> getImages() {
         return images;

--- a/source/org/zfin/ontology/presentation/OntologyTermDetailController.java
+++ b/source/org/zfin/ontology/presentation/OntologyTermDetailController.java
@@ -1,5 +1,6 @@
 package org.zfin.ontology.presentation;
 
+import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -10,22 +11,16 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.zfin.anatomy.presentation.AnatomySearchBean;
 import org.zfin.expression.Experiment;
 import org.zfin.expression.Figure;
-import org.zfin.framework.api.Pagination;
-import org.zfin.framework.featureflag.FeatureFlagEnum;
-import org.zfin.framework.featureflag.FeatureFlags;
 import org.zfin.framework.presentation.*;
 import org.zfin.gwt.root.dto.OntologyDTO;
 import org.zfin.gwt.root.dto.TermDTO;
 import org.zfin.gwt.root.server.DTOConversionService;
 import org.zfin.infrastructure.ActiveData;
 import org.zfin.infrastructure.seo.CanonicalLinkConfig;
-import org.zfin.marker.MarkerStatistic;
-import org.zfin.marker.presentation.HighQualityProbe;
 import org.zfin.mutant.Fish;
 import org.zfin.mutant.FishExperiment;
 import org.zfin.mutant.PhenotypeService;
 import org.zfin.mutant.PhenotypeStatementWarehouse;
-import org.zfin.mutant.presentation.FishModelDisplay;
 import org.zfin.ontology.*;
 import org.zfin.ontology.service.OntologyService;
 import org.zfin.profile.Person;
@@ -161,17 +156,15 @@ public class OntologyTermDetailController {
             }
         } else {
             // check if it is an OBO ID
-            if (Ontology.isOboID(termID))
+            if (Ontology.isOboID(termID)) {
                 term = RepositoryFactory.getOntologyRepository().getTermByOboID(termID);
+            }
         }
         if (term == null) {
             model.addAttribute(LookupStrings.ZDB_ID, termID);
             return LookupStrings.RECORD_NOT_FOUND_PAGE;
         }
 
-        List<RelationshipPresentation> termRelationships = OntologyService.getRelatedTermsWithoutStages(term);
-
-        form.setTermRelationships(termRelationships);
         form.setTerm(term);
         model.addAttribute(LookupStrings.FORM_BEAN, form);
         model.addAttribute(LookupStrings.DYNAMIC_TITLE, term.getOntology().getCommonName() + ": " + term.getTermName());

--- a/source/org/zfin/ontology/repository/OntologyRepository.java
+++ b/source/org/zfin/ontology/repository/OntologyRepository.java
@@ -160,6 +160,12 @@ public interface OntologyRepository {
 
     Map<String, TermDTO> getTermDTOsFromOntology(Ontology ontology);
 
+    Map<String, Long> getDirectlyRelatedRelationshipTypes(GenericTerm term, boolean forward);
+
+    List<GenericTermRelationship> getDirectlyRelatedRelationshipsByType(GenericTerm term, String relationshipType, boolean forward, Integer offset, Integer limit);
+
+    Integer getDirectlyRelatedRelationshipsCountByType(GenericTerm term, String relationshipType, boolean forward);
+
     EcoGoEvidenceCodeMapping getEcoEvidenceCode(GenericTerm term);
 
     Collection<TermDTO> getTermDTOsFromOntologyNoRelation(Ontology stage);

--- a/test/org/zfin/ontology/repository/OntologyRepositoryTest.java
+++ b/test/org/zfin/ontology/repository/OntologyRepositoryTest.java
@@ -85,6 +85,42 @@ public class OntologyRepositoryTest extends AbstractDatabaseTest {
     }
 
     @Test
+    public void getOntologyTermRelationshipTypes() {
+        String azamacrocycleID = "CHEBI:52898";
+        GenericTerm term = ontologyRepository.getTermByOboID(azamacrocycleID);
+        Set<String> parents = ontologyRepository.getDirectlyRelatedRelationshipTypes(term, true).keySet();
+        Set<String> children = ontologyRepository.getDirectlyRelatedRelationshipTypes(term, false).keySet();
+        assertNotNull(parents);
+        assertNotNull(children);
+        assertEquals(1, parents.size());
+        assertEquals(1, children.size());
+    }
+
+
+    @Test
+    public void getOntologyTermRelationshipsByTypes() {
+        String azamacrocycleID = "CHEBI:52898";
+        GenericTerm term = ontologyRepository.getTermByOboID(azamacrocycleID);
+        Map<String, Long> parents = ontologyRepository.getDirectlyRelatedRelationshipTypes(term, true);
+        Map<String, Long> children = ontologyRepository.getDirectlyRelatedRelationshipTypes(term, false);
+
+        for(String type : parents.keySet()) {
+            List<GenericTermRelationship> rels = ontologyRepository.getDirectlyRelatedRelationshipsByType(term, type, true, null, null);
+            assertTrue(rels.size() > 6000);
+        }
+
+        for(String type : children.keySet()) {
+            List<GenericTermRelationship> rels2 = ontologyRepository.getDirectlyRelatedRelationshipsByType(term, type, false, null, null);
+            assertTrue(rels2.size() > 0);
+        }
+
+        assertNotNull(parents);
+        assertNotNull(children);
+        assertEquals(1, parents.size());
+        assertEquals(1, children.size());
+    }
+
+    @Test
     public void goOntologyContainsAllGOTerms() {
         List<String> ignoreGoIDs = new ArrayList<>(getOntologyRepository()
             .getObsoleteAndSecondaryTerms()


### PR DESCRIPTION
- Create new React components for displaying term relationships
- Add API endpoints for retrieving relationship types and related terms
- Implement pagination and expandable views for relationship lists
- Replace JSP-based term relationship display with React components
- Add tests for new repository methods


https://github.com/user-attachments/assets/55584937-785c-4a7c-b2f1-20915c9120c5

