### PR TITLE
ZFIN-9705: Add java helper to analyze before/after state captures of data…

### DIFF
--- a/console.gradle
+++ b/console.gradle
@@ -201,3 +201,29 @@ task checkFilePermissionsTask(type: JavaExec) {
     main = 'org.zfin.task.CheckFilePermissionsTask'
 }
 
+task csvMerge(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'org.zfin.datatransfer.util.CSVMerge'
+
+    // Get arguments from the command line
+    // So this can be called like so:
+    // gradle csvMergerTask --args="before_db_link.csv before_recattrib.csv dblink_zdb_id recattrib_data_zdb_id recattrib_source_zdb_id /tmp/combined.csv"
+}
+
+task csvDiff(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'org.zfin.datatransfer.util.CSVDiff'
+
+    // Get arguments from the command line
+    // So this can be called like so:
+    // gradle csvDiffTask --args="dblink_cmp_ before_combined.csv after_combined.csv dblink_linked_recid,dblink_acc_num,dblink_fdbcont_zdb_id,recattrib_source_zdb_id dblink_info,dblink_zdb_id"
+}
+
+task ncbiCharacterize(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'org.zfin.datatransfer.ncbi.NCBICharacterizationProcess'
+
+    // Get arguments from the command line
+    // So this can be called like so:
+    // gradle ncbiCharacterize --args="$TARGETROOT/server_apps/datatransfer/NCBIGENE"
+}

--- a/source/org/zfin/datatransfer/ncbi/NCBICharacterizationProcess.java
+++ b/source/org/zfin/datatransfer/ncbi/NCBICharacterizationProcess.java
@@ -1,0 +1,102 @@
+package org.zfin.datatransfer.ncbi;
+
+import org.apache.logging.log4j.core.util.FileUtils;
+import org.zfin.datatransfer.util.CSVDiff;
+import org.zfin.datatransfer.util.CSVMerge;
+import org.zfin.util.DateUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import static org.zfin.util.FileUtil.createZipArchive;
+
+class NCBICharacterizationProcess {
+    private final String path;
+
+    public NCBICharacterizationProcess(String path) {
+        this.path = path;
+    }
+
+    public static void main(String[] args) throws IOException {
+        if (args.length != 1) {
+            System.err.println("Usage: NCBICharacterizationProcess <pathToNCBIBeforeAfterFiles>");
+            System.err.println("Example: NCBICharacterizationProcess $TARGETROOT/server_apps/datatransfer/NCBIGENE");
+            System.err.println("Expect the path to the directory containing the NCBI files to include before_db_link.csv, after_db_link.csv, before_recattrib.csv, and after_recattrib.csv");
+            System.err.println("When finished, details are saved to before_after.zip in the provided path");
+            System.exit(1);
+        }
+        NCBICharacterizationProcess tester = new NCBICharacterizationProcess(args[0]);
+        tester.run();
+    }
+
+    private void run() throws IOException {
+        assertNCBIFilesExist();
+
+        File parentDir = tempDirName();
+        FileUtils.mkdir(parentDir, true);
+
+        System.out.println("Writing to " + parentDir);
+
+        File beforeFile = new File(parentDir, "combined_before.csv");
+        File afterFile = new File(parentDir, "combined_after.csv");
+
+        //merge the db_link and recattrib table dumps into a single table dump that looks like db_link but with attributions
+        CSVMerge merger1 = new CSVMerge(
+                new File(path, "before_db_link.csv"),
+                new File(path, "before_recattrib.csv"),
+                "dblink_zdb_id",
+                "recattrib_data_zdb_id",
+                "recattrib_source_zdb_id",
+                beforeFile
+        );
+        merger1.run();
+
+        CSVMerge merger2 = new CSVMerge(
+                new File(path, "after_db_link.csv"),
+                new File(path, "after_recattrib.csv"),
+                "dblink_zdb_id",
+                "recattrib_data_zdb_id",
+                "recattrib_source_zdb_id",
+                afterFile
+        );
+        merger2.run();
+
+        //now that we have the combined before and after tables (as csv files), break down changes into subsets
+        String outputPrefix = new File(parentDir, "ncbi_compare_").toString();
+        CSVDiff diff = new CSVDiff(outputPrefix,
+                new String[]{"dblink_linked_recid","dblink_acc_num","dblink_fdbcont_zdb_id","recattrib_source_zdb_id"},
+                new String[]{"dblink_info","dblink_zdb_id"});
+
+        List<File> subsets = diff.process(beforeFile.getAbsolutePath(), afterFile.getAbsolutePath());
+        createZipArchive(new File(path, "before_after.zip"), subsets);
+
+        //cleanup:
+        for(File file : subsets) {
+            file.delete();
+        }
+        beforeFile.delete();
+        afterFile.delete();
+        parentDir.delete();
+    }
+
+    private File tempDirName() {
+        return new File("/tmp/ncbi_temp_" + DateUtil.nowToString("yyyy-MM-dd_HH-mm-ss"));
+    }
+
+    private void assertNCBIFilesExist() {
+        assertFileExists("before_db_link.csv");
+        assertFileExists("after_db_link.csv");
+        assertFileExists("before_recattrib.csv");
+        assertFileExists("after_recattrib.csv");
+    }
+
+    private void assertFileExists(String filename) {
+        if (!new File(path, filename).exists()) {
+            System.err.println(filename + " does not exist");
+            System.exit(1);
+        }
+    }
+
+
+}

--- a/source/org/zfin/datatransfer/util/CSVDiff.java
+++ b/source/org/zfin/datatransfer/util/CSVDiff.java
@@ -1,0 +1,456 @@
+package org.zfin.datatransfer.util;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.CSVRecord;
+
+import java.io.*;
+import java.util.*;
+
+/**
+ * Utility class to compare two CSV files and generate breakdown reports of their differences.
+ * command line args are:
+ * CSVDifferenceUtility <outputPrefix> <file1Path> <file2Path> <keyColumn1,keyColumn2,...> [ignoreColumn1,ignoreColumn2,...]
+ * The CSV files must have the same headers.
+ * This class generates the following output files:
+ * 1. PREFIX_retained.csv - rows common to both files (exact match on all columns)
+ * 2. PREFIX_updates_ignored_1.csv - rows with matching keys but different values, though the values are in ignore columns (from file1)
+ * 3. PREFIX_updates_ignored_2.csv - rows with matching keys but different values, though the values are in ignore columns (from file2)
+ * 4. PREFIX_updated_1.csv - rows with matching keys but different values (from file1)
+ * 5. PREFIX_updated_2.csv - rows with matching keys but different values (from file2)
+ * 6. PREFIX_deletes.csv - rows in file1 but not in file2 (based on key columns)
+ * 7. PREFIX_adds.csv - rows in file2 but not in file1 (based on key columns)
+ *
+ * All files exclude entries from earlier steps
+ */
+public class CSVDiff {
+    private String outputPrefix;
+    private String[] keyColumns;
+    private String[] ignoreColumns;
+    private List<CSVRecord> file1Records = new ArrayList<>();
+    private List<CSVRecord> file2Records = new ArrayList<>();
+    private List<String> headers = new ArrayList<>();
+
+    /**
+     * Constructor for the CSV Difference Utility.
+     *
+     * @param outputPrefix The prefix to use for output files
+     * @param keyColumns Array of column names to use as composite key for comparison
+     * @param ignoreColumns Array of column names to ignore during comparison (optional)
+     */
+    public CSVDiff(String outputPrefix, String[] keyColumns, String[] ignoreColumns) {
+        this.outputPrefix = outputPrefix;
+        this.keyColumns = keyColumns;
+        this.ignoreColumns = ignoreColumns != null ? ignoreColumns : new String[0];
+    }
+
+    /**
+     * Process the two CSV files and generate the difference reports.
+     *
+     * @param file1Path Path to the first CSV file
+     * @param file2Path Path to the second CSV file
+     * @return
+     * @throws IOException If there is an error reading or writing files
+     */
+    public List<File> process(String file1Path, String file2Path) throws IOException {
+        List<File> generatedFiles = new ArrayList<>();
+
+        // Read the CSV files
+        readCSVFiles(file1Path, file2Path);
+
+        System.out.println("Loaded " + file1Records.size() + " records from " + file1Path);
+        System.out.println("Loaded " + file2Records.size() + " records from " + file2Path);
+
+        // Make working copies of the data
+        List<CSVRecord> file1Copy = new ArrayList<>(file1Records);
+        List<CSVRecord> file2Copy = new ArrayList<>(file2Records);
+
+        // Find records that are exactly the same (all columns match)
+        List<CSVRecord> retainedRecords = findRetainedRecords(file1Copy, file2Copy);
+        writeCSVFile(outputPrefix + "_retained.csv", retainedRecords, headers);
+        System.out.println("Wrote " + retainedRecords.size() + " records to " + outputPrefix + "_retained.csv");
+        generatedFiles.add(new File(outputPrefix + "_retained.csv"));
+
+        // Remove retained records from both sets
+        removeRecordsFromLists(retainedRecords, file1Copy, file2Copy, true);
+
+        // Find records with changes only in ignored columns
+        Map<String, List<CSVRecord>> ignoredUpdatedRecords = findUpdatedRecordsOnlyInIgnoredColumns(file1Copy, file2Copy);
+        List<CSVRecord> ignoredUpdated1 = ignoredUpdatedRecords.get("file1");
+        List<CSVRecord> ignoredUpdated2 = ignoredUpdatedRecords.get("file2");
+
+        writeCSVFile(outputPrefix + "_updates_ignored_1.csv", ignoredUpdated1, headers);
+        writeCSVFile(outputPrefix + "_updates_ignored_2.csv", ignoredUpdated2, headers);
+        System.out.println("Wrote " + ignoredUpdated1.size() + " records to " + outputPrefix + "_updates_ignored_1.csv");
+        System.out.println("Wrote " + ignoredUpdated2.size() + " records to " + outputPrefix + "_updates_ignored_2.csv");
+        generatedFiles.add(new File(outputPrefix + "_updates_ignored_1.csv"));
+        generatedFiles.add(new File(outputPrefix + "_updates_ignored_2.csv"));
+
+        // Remove records with only ignored column changes from both sets
+        removeRecordsFromLists(ignoredUpdated1, file1Copy, null, false);
+        removeRecordsFromLists(ignoredUpdated2, null, file2Copy, false);
+
+        // Find records with matching keys but different values in non-ignored columns
+        Map<String, List<CSVRecord>> updatedRecords = findUpdatedRecords(file1Copy, file2Copy);
+        List<CSVRecord> updated1 = updatedRecords.get("file1");
+        List<CSVRecord> updated2 = updatedRecords.get("file2");
+
+        writeCSVFile(outputPrefix + "_updated_1.csv", updated1, headers);
+        writeCSVFile(outputPrefix + "_updated_2.csv", updated2, headers);
+        System.out.println("Wrote " + updated1.size() + " records to " + outputPrefix + "_updated_1.csv");
+        System.out.println("Wrote " + updated2.size() + " records to " + outputPrefix + "_updated_2.csv");
+        generatedFiles.add(new File(outputPrefix + "_updated_1.csv"));
+        generatedFiles.add(new File(outputPrefix + "_updated_2.csv"));
+
+        // Remove updated records from both sets
+        removeRecordsFromLists(updated1, file1Copy, null, false);
+        removeRecordsFromLists(updated2, null, file2Copy, false);
+
+        // Write deletes (in file1 but not in file2)
+        writeCSVFile(outputPrefix + "_deletes.csv", file1Copy, headers);
+        System.out.println("Wrote " + file1Copy.size() + " records to " + outputPrefix + "_deletes.csv");
+        generatedFiles.add(new File(outputPrefix + "_deletes.csv"));
+
+        // Write adds (in file2 but not in file1)
+        writeCSVFile(outputPrefix + "_adds.csv", file2Copy, headers);
+        System.out.println("Wrote " + file2Copy.size() + " records to " + outputPrefix + "_adds.csv");
+        generatedFiles.add(new File(outputPrefix + "_adds.csv"));
+
+        return generatedFiles;
+    }
+
+    /**
+     * Read the CSV files and store the records and headers.
+     *
+     * @param file1Path Path to the first CSV file
+     * @param file2Path Path to the second CSV file
+     * @throws IOException If there is an error reading the files
+     */
+    private void readCSVFiles(String file1Path, String file2Path) throws IOException {
+        // Read file1
+        try (Reader reader = new FileReader(file1Path);
+             CSVParser csvParser = CSVFormat.DEFAULT.withFirstRecordAsHeader().parse(reader)) {
+
+            headers = new ArrayList<>(csvParser.getHeaderNames());
+            validateHeaders(headers);
+
+            for (CSVRecord record : csvParser) {
+                file1Records.add(record);
+            }
+        }
+
+        // Read file2
+        try (Reader reader = new FileReader(file2Path);
+             CSVParser csvParser = CSVFormat.DEFAULT.withFirstRecordAsHeader().parse(reader)) {
+
+            List<String> file2Headers = new ArrayList<>(csvParser.getHeaderNames());
+            validateHeaders(file2Headers);
+
+            // Ensure headers are identical between files
+            if (!headers.equals(file2Headers)) {
+                throw new IllegalArgumentException("Headers in both files must be identical");
+            }
+
+            for (CSVRecord record : csvParser) {
+                file2Records.add(record);
+            }
+        }
+    }
+
+    /**
+     * Validate that all key columns exist in the headers.
+     *
+     * @param fileHeaders The headers from the CSV file
+     * @throws IllegalArgumentException If a key column is not found in the headers
+     */
+    private void validateHeaders(List<String> fileHeaders) {
+        for (String keyColumn : keyColumns) {
+            if (!fileHeaders.contains(keyColumn)) {
+                throw new IllegalArgumentException("Key column '" + keyColumn + "' not found in file headers");
+            }
+        }
+
+        for (String ignoreColumn : ignoreColumns) {
+            if (!fileHeaders.contains(ignoreColumn)) {
+                throw new IllegalArgumentException("Ignore column '" + ignoreColumn + "' not found in file headers");
+            }
+        }
+    }
+
+    /**
+     * Generates a composite key for a record based on the specified key columns.
+     *
+     * @param record The CSV record
+     * @return A string representing the composite key
+     */
+    private String generateCompositeKey(CSVRecord record) {
+        StringBuilder key = new StringBuilder();
+        for (String keyColumn : keyColumns) {
+            key.append(record.get(keyColumn)).append("|");
+        }
+        return key.toString();
+    }
+
+    /**
+     * Generates a string representation of all values in the record.
+     *
+     * @param record The CSV record
+     * @return A string representing all values in the record
+     */
+    private String generateFullRecordKey(CSVRecord record) {
+        StringBuilder key = new StringBuilder();
+        for (String header : headers) {
+            key.append(record.get(header)).append("|");
+        }
+        return key.toString();
+    }
+
+    /**
+     * Find records that have identical values across all columns.
+     *
+     * @param list1 The first list of records
+     * @param list2 The second list of records
+     * @return A list of records that are identical in both files
+     */
+    private List<CSVRecord> findRetainedRecords(List<CSVRecord> list1, List<CSVRecord> list2) {
+        Map<String, CSVRecord> recordsMap = new HashMap<>();
+        List<CSVRecord> retained = new ArrayList<>();
+
+        // Create a map of full record keys to records for the second list
+        for (CSVRecord record : list2) {
+            recordsMap.put(generateFullRecordKey(record), record);
+        }
+
+        // Find matches from the first list
+        for (CSVRecord record : list1) {
+            String fullKey = generateFullRecordKey(record);
+            if (recordsMap.containsKey(fullKey)) {
+                retained.add(record);
+            }
+        }
+
+        return retained;
+    }
+
+    /**
+     * Find records that have matching keys but different values in non-ignored columns.
+     *
+     * @param list1 The first list of records
+     * @param list2 The second list of records
+     * @return A map containing updated records from both files
+     */
+    private Map<String, List<CSVRecord>> findUpdatedRecords(List<CSVRecord> list1, List<CSVRecord> list2) {
+        Map<String, CSVRecord> file1KeyMap = new HashMap<>();
+        Map<String, CSVRecord> file2KeyMap = new HashMap<>();
+        List<CSVRecord> updated1 = new ArrayList<>();
+        List<CSVRecord> updated2 = new ArrayList<>();
+
+        // Create maps of composite keys to records
+        for (CSVRecord record : list1) {
+            file1KeyMap.put(generateCompositeKey(record), record);
+        }
+
+        for (CSVRecord record : list2) {
+            file2KeyMap.put(generateCompositeKey(record), record);
+        }
+
+        // Get the set of columns to compare (all headers except key columns)
+        Set<String> comparisonColumns = new HashSet<>(headers);
+        for (String keyColumn : keyColumns) {
+            comparisonColumns.remove(keyColumn);
+        }
+
+        // For each key that exists in both files
+        for (String key : file1KeyMap.keySet()) {
+            if (file2KeyMap.containsKey(key)) {
+                CSVRecord record1 = file1KeyMap.get(key);
+                CSVRecord record2 = file2KeyMap.get(key);
+
+                // Check if there are differences in non-key columns
+                boolean hasDifferences = false;
+                for (String column : comparisonColumns) {
+                    if (!Objects.equals(record1.get(column), record2.get(column))) {
+                        // If the column is not in the ignore list, it's a meaningful difference
+                        if (!Arrays.asList(ignoreColumns).contains(column)) {
+                            hasDifferences = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (hasDifferences) {
+                    updated1.add(record1);
+                    updated2.add(record2);
+                }
+            }
+        }
+
+        Map<String, List<CSVRecord>> result = new HashMap<>();
+        result.put("file1", updated1);
+        result.put("file2", updated2);
+        return result;
+    }
+
+    /**
+     * Remove records from the specified lists.
+     *
+     * @param recordsToRemove The records to remove
+     * @param list1 The first list (can be null)
+     * @param list2 The second list (can be null)
+     * @param useFullKey Whether to use the full record key or just the composite key
+     */
+    private void removeRecordsFromLists(List<CSVRecord> recordsToRemove, List<CSVRecord> list1, List<CSVRecord> list2, boolean useFullKey) {
+        if (recordsToRemove.isEmpty()) {
+            return;
+        }
+
+        Set<String> keys = new HashSet<>();
+        for (CSVRecord record : recordsToRemove) {
+            if (useFullKey) {
+                keys.add(generateFullRecordKey(record));
+            } else {
+                keys.add(generateCompositeKey(record));
+            }
+        }
+
+        if (list1 != null) {
+            list1.removeIf(record -> {
+                String key = useFullKey ? generateFullRecordKey(record) : generateCompositeKey(record);
+                return keys.contains(key);
+            });
+        }
+
+        if (list2 != null) {
+            list2.removeIf(record -> {
+                String key = useFullKey ? generateFullRecordKey(record) : generateCompositeKey(record);
+                return keys.contains(key);
+            });
+        }
+    }
+
+    /**
+     * Write records to a CSV file.
+     *
+     * @param filePath The path to the output file
+     * @param records The records to write
+     * @param headers The headers for the CSV file
+     * @throws IOException If there is an error writing the file
+     */
+    private void writeCSVFile(String filePath, List<CSVRecord> records, List<String> headers) throws IOException {
+        try (Writer writer = new FileWriter(filePath);
+             CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.withHeader(headers.toArray(new String[0])))) {
+
+            for (CSVRecord record : records) {
+                List<String> values = new ArrayList<>();
+                for (String header : headers) {
+                    values.add(record.get(header));
+                }
+                csvPrinter.printRecord(values);
+            }
+
+            csvPrinter.flush();
+        }
+    }
+
+    /**
+     * Main method to demonstrate usage of the CSVDifferenceUtility.
+     *
+     * @param args Command line arguments: outputPrefix file1Path file2Path keyColumns [ignoreColumns]
+     */
+    public static void main(String[] args) {
+        if (args.length < 4) {
+            System.err.println("Usage: CSVDifferenceUtility <outputPrefix> <file1Path> <file2Path> <keyColumn1,keyColumn2,...> [ignoreColumn1,ignoreColumn2,...]");
+            System.exit(1);
+        }
+
+        String outputPrefix = args[0];
+        String file1Path = args[1];
+        String file2Path = args[2];
+        String[] keyColumns = args[3].split(",");
+        String[] ignoreColumns = new String[0];
+        if (args.length >= 5) {
+            ignoreColumns = args[4].split(",");
+        }
+
+        CSVDiff utility = new CSVDiff(outputPrefix, keyColumns, ignoreColumns);
+
+        try {
+            utility.process(file1Path, file2Path);
+        } catch (Exception e) {
+            System.err.println("Error: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Find records that have matching keys but only have differences in the ignored columns.
+     *
+     * @param list1 The first list of records
+     * @param list2 The second list of records
+     * @return A map containing updated records from both files with only ignored column differences
+     */
+    private Map<String, List<CSVRecord>> findUpdatedRecordsOnlyInIgnoredColumns(List<CSVRecord> list1, List<CSVRecord> list2) {
+        Map<String, CSVRecord> file1KeyMap = new HashMap<>();
+        Map<String, CSVRecord> file2KeyMap = new HashMap<>();
+        List<CSVRecord> onlyIgnoredUpdates1 = new ArrayList<>();
+        List<CSVRecord> onlyIgnoredUpdates2 = new ArrayList<>();
+
+        // Create maps of composite keys to records
+        for (CSVRecord record : list1) {
+            file1KeyMap.put(generateCompositeKey(record), record);
+        }
+
+        for (CSVRecord record : list2) {
+            file2KeyMap.put(generateCompositeKey(record), record);
+        }
+
+        // Get the set of columns to compare (all headers except key columns and ignore columns)
+        Set<String> comparisonColumns = new HashSet<>(headers);
+        for (String keyColumn : keyColumns) {
+            comparisonColumns.remove(keyColumn);
+        }
+        for (String ignoreColumn : ignoreColumns) {
+            comparisonColumns.remove(ignoreColumn);
+        }
+
+        // For each key that exists in both files
+        for (String key : file1KeyMap.keySet()) {
+            if (file2KeyMap.containsKey(key)) {
+                CSVRecord record1 = file1KeyMap.get(key);
+                CSVRecord record2 = file2KeyMap.get(key);
+
+                // Check if all non-key, non-ignored columns match
+                boolean allComparisonColumnsMatch = true;
+                for (String column : comparisonColumns) {
+                    if (!Objects.equals(record1.get(column), record2.get(column))) {
+                        allComparisonColumnsMatch = false;
+                        break;
+                    }
+                }
+
+                // Check if at least one ignored column is different
+                boolean atLeastOneIgnoredColumnDiffers = false;
+                for (String column : ignoreColumns) {
+                    if (!Objects.equals(record1.get(column), record2.get(column))) {
+                        atLeastOneIgnoredColumnDiffers = true;
+                        break;
+                    }
+                }
+
+                // If only ignored columns differ (and at least one does), add to the result
+                if (allComparisonColumnsMatch && atLeastOneIgnoredColumnDiffers) {
+                    onlyIgnoredUpdates1.add(record1);
+                    onlyIgnoredUpdates2.add(record2);
+                }
+            }
+        }
+
+        Map<String, List<CSVRecord>> result = new HashMap<>();
+        result.put("file1", onlyIgnoredUpdates1);
+        result.put("file2", onlyIgnoredUpdates2);
+        return result;
+    }
+
+}

--- a/source/org/zfin/datatransfer/util/CSVMerge.java
+++ b/source/org/zfin/datatransfer/util/CSVMerge.java
@@ -1,0 +1,86 @@
+package org.zfin.datatransfer.util;
+import org.apache.commons.csv.*;
+
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+import java.util.stream.Stream;
+
+public class CSVMerge {
+    private final File file1;
+    private final File file2;
+    private final String joinCol1;
+    private final String joinCol2;
+    private final String valueCol2;
+    private final File outputFile;
+
+    public CSVMerge(File file1, File file2, String joinCol1, String joinCol2, String valueCol2, File outputFile) {
+        this.file1 = file1;
+        this.file2 = file2;
+        this.joinCol1 = joinCol1;
+        this.joinCol2 = joinCol2;
+        this.valueCol2 = valueCol2;
+        this.outputFile = outputFile;
+    }
+
+    public static void main(String[] args) throws IOException {
+        if (args.length < 6) {
+            System.out.println(args.length);
+            System.err.println("Usage: java CSVMerger <file1> <file2> <joinCol1> <joinCol2> <valueCol2> <outputFile>");
+            System.exit(1);
+        }
+
+        String file1 = args[0];
+        String file2 = args[1];
+
+        String joinCol1 = args[2];
+        String joinCol2 = args[3];
+        String valueCol2 = args[4];
+        String outputFile = args[5];
+
+        CSVMerge merger = new CSVMerge(new File(file1), new File(file2), joinCol1, joinCol2, valueCol2, new File(outputFile));
+        merger.run();
+        System.out.println("Merged CSV written to " + outputFile);
+    }
+
+    public void run() throws IOException {
+        // Build map from file2: joinCol2 -> list of valueCol2
+        Map<String, List<String>> joinMap = new HashMap<>();
+        try (
+                Reader in2 = Files.newBufferedReader(file2.toPath());
+                CSVParser parser2 = CSVFormat.DEFAULT.withFirstRecordAsHeader().parse(in2)
+        ) {
+            for (CSVRecord record : parser2) {
+                String joinKey = record.get(joinCol2);
+                String value = record.get(valueCol2);
+                joinMap.computeIfAbsent(joinKey, k -> new ArrayList<>()).add(value);
+            }
+        }
+
+        // Read file1 and write merged output
+        try (
+                Reader in1 = Files.newBufferedReader(file1.toPath());
+                CSVParser parser1 = CSVFormat.DEFAULT.withFirstRecordAsHeader().parse(in1);
+                Writer out = Files.newBufferedWriter(outputFile.toPath());
+                CSVPrinter printer = CSVFormat.DEFAULT
+                        .withHeader(Stream.concat(parser1.getHeaderNames().stream(), Stream.of(valueCol2 )).toArray(String[]::new))
+                        .print(out)
+        ) {
+            List<String> headers = parser1.getHeaderNames();
+            for (CSVRecord record : parser1) {
+                String joinKey = record.get(joinCol1);
+                List<String> values = joinMap.getOrDefault(joinKey, Collections.emptyList());
+                values.sort(Comparator.naturalOrder());
+                String joinedValues = String.join("|", values);
+
+                List<String> row = new ArrayList<>();
+                for (String col : headers) {
+                    row.add(record.get(col));
+                }
+                row.add(joinedValues);
+
+                printer.printRecord(row);
+            }
+        }
+    }
+}

--- a/source/org/zfin/datatransfer/util/CSVMerge.java
+++ b/source/org/zfin/datatransfer/util/CSVMerge.java
@@ -6,6 +6,14 @@ import java.nio.file.*;
 import java.util.*;
 import java.util.stream.Stream;
 
+/**
+ * Utility class for merging two CSV files based on join columns.
+ *
+ * This class merges data from two CSV files where values from the second file
+ * are added to the first file based on matching keys in specified join columns.
+ * The values from the second file are aggregated and joined with a pipe (|) delimiter.
+ *
+ */
 public class CSVMerge {
     private final File file1;
     private final File file2;
@@ -14,6 +22,16 @@ public class CSVMerge {
     private final String valueCol2;
     private final File outputFile;
 
+    /**
+     * Constructs a new CSVMerge instance with specified parameters.
+     *
+     * @param file1      The primary CSV file whose structure forms the basis of the merged file
+     * @param file2      The secondary CSV file containing values to be merged into the primary file
+     * @param joinCol1   The column name in file1 used for joining
+     * @param joinCol2   The column name in file2 used for joining
+     * @param valueCol2  The column name in file2 whose values will be merged into the output
+     * @param outputFile The destination file where the merged CSV will be written
+     */
     public CSVMerge(File file1, File file2, String joinCol1, String joinCol2, String valueCol2, File outputFile) {
         this.file1 = file1;
         this.file2 = file2;
@@ -23,6 +41,20 @@ public class CSVMerge {
         this.outputFile = outputFile;
     }
 
+    /**
+     * Main entry point for the CSVMerge utility.
+     *
+     * Processes command line arguments and executes the merge operation.
+     *
+     * @param args Command line arguments in the following order:
+     *             1. file1 - Path to the primary CSV file
+     *             2. file2 - Path to the secondary CSV file
+     *             3. joinCol1 - Column name in file1 for joining
+     *             4. joinCol2 - Column name in file2 for joining
+     *             5. valueCol2 - Column name in file2 whose values will be merged
+     *             6. outputFile - Path where the merged CSV will be written
+     * @throws IOException If an I/O error occurs during file operations
+     */
     public static void main(String[] args) throws IOException {
         if (args.length < 6) {
             System.out.println(args.length);
@@ -43,6 +75,17 @@ public class CSVMerge {
         System.out.println("Merged CSV written to " + outputFile);
     }
 
+    /**
+     * Executes the CSV merge operation.
+     *
+     * This method performs the following steps:
+     * 1. Creates a mapping from join keys in file2 to lists of corresponding values
+     * 2. Reads records from file1
+     * 3. For each record in file1, looks up matching values from file2 using the join key
+     * 4. Appends the joined values (sorted and pipe-delimited) to the output
+     *
+     * @throws IOException If an error occurs while reading from or writing to files
+     */
     public void run() throws IOException {
         // Build map from file2: joinCol2 -> list of valueCol2
         Map<String, List<String>> joinMap = new HashMap<>();

--- a/source/org/zfin/util/FileUtil.java
+++ b/source/org/zfin/util/FileUtil.java
@@ -23,6 +23,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.List;
 import java.util.Set;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -568,6 +569,35 @@ public final class FileUtil {
         }
         if (!errorOutput.isEmpty()) {
             throw new IOException(errorOutput.toString());
+        }
+    }
+
+    public static void createZipArchive(File outputZipFile, List<File> inputFiles) throws IOException {
+        try (FileOutputStream fos = new FileOutputStream(outputZipFile);
+             ZipOutputStream zos = new ZipOutputStream(fos)) {
+
+            byte[] buffer = new byte[1024];
+
+            for (File inputFile : inputFiles) {
+                if (!inputFile.exists()) {
+                    continue; // Skip files that don't exist
+                }
+
+                // Create a new ZIP entry
+                ZipEntry zipEntry = new ZipEntry(inputFile.getName());
+                zos.putNextEntry(zipEntry);
+
+                // Read the file and write it to the ZIP output stream
+                try (FileInputStream fis = new FileInputStream(inputFile)) {
+                    int length;
+                    while ((length = fis.read(buffer)) > 0) {
+                        zos.write(buffer, 0, length);
+                    }
+                }
+
+                // Close the ZIP entry
+                zos.closeEntry();
+            }
         }
     }
 


### PR DESCRIPTION
ZFIN-9705:

Add NCBI load characterization and CSV comparison tools

This commit introduces some tools and enhancements to the NCBI gene load process, enabling detailed characterization of database changes.

Key additions and modifications:

* **NCBI Load Script (`NCBI_gene_load.pl`):**
    * Integrated functions to capture `db_link` and `record_attribution` table states into CSV files before and after the load (`captureBeforeState`, `captureAfterState`).
    * Refactored email sending logic for reports, now using script-defined variables for email addresses.
    * Ensured `$instance` environment variable has a default value.
    * Minor refactoring of SQL queries for db_link statistics.

* **Java CSV Utilities:**
    * Introduced `CSVDiff.java`: A new tool to compare two CSV files, identifying and categorizing differences into additions, deletions, updates (including those only in ignored columns), and retained rows.
    * Introduced `CSVMerge.java`: A new tool to merge two CSV files based on specified key columns.
    * Added `NCBICharacterizationProcess.java`: A Java application that uses `CSVMerge` to combine before/after `db_link` and `record_attribution` CSVs, then uses `CSVDiff` to analyze the changes, and finally zips the resulting comparison files.

* **Gradle Tasks (`console.gradle`):**
    * Added new tasks: `csvMerge`, `csvDiff`, and `ncbiCharacterize` to execute the corresponding Java utilities.

* **Perl Modules (`ZFINPerlModules.pm`):**
    * Improved `sendMailWithAttachedReport` by adding an option to write emails to a file (controlled by the `EMAIL_TO_FILE` environment variable) instead of sending, useful for development and testing.

This work finalizes the efforts for CSV comparison tools and integrates them into a characterization process for NCBI loads, providing better insight into data modifications.
