### PR TITLE
ZFIN-9784: Bugfix for isAntibody -> always returned true

### DIFF
--- a/source/org/zfin/marker/Marker.java
+++ b/source/org/zfin/marker/Marker.java
@@ -501,10 +501,7 @@ public class Marker extends SequenceFeature implements Serializable, Comparable,
         }
 
         public boolean isAntibody() {
-            for (Type markerType : values())
-                if (markerType.equals(Type.ATB))
-                    return true;
-            return false;
+            return this.equals(Type.ATB);
         }
 
         public List<Type> getConstructs() {


### PR DESCRIPTION
isAntibody previously would always return true no matter what type of gene was the source.