### PR TITLE
ZFIN-9813: Revert "Peg tomcat to specific version"

### DIFF
--- a/docker/tomcat/Dockerfile
+++ b/docker/tomcat/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:10.1.40-jdk17
+FROM tomcat:10-jdk17
 
 #Add imagemagick for generating thumbnails
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Now using "tomcat:10-jdk17" instead of "tomcat:10.1.40-jdk17"

This reverts commit bf8a183cc533e62ed9db064bb41471a32d4bfc55.