### PR TITLE
icon-fix: do not display the external link indicator on blog lists

### DIFF
--- a/home/javascript/react/components/WikiBlogPostList.js
+++ b/home/javascript/react/components/WikiBlogPostList.js
@@ -56,7 +56,7 @@ class WikiBlogPostList extends Component {
                 <LoadingSpinner loading={loading} />
                 <div className='wiki-list-controls'>
                     <span>{ next && <a href='#' onClick={this.loadNext}>Load More</a> }</span>
-                    <span>{ showAll && <a href={`https://${process.env.WIKI_HOST}${showAll}`}>See All <i className='fas fa-chevron-right' /></a>}</span>
+                    <span>{ showAll && <a className='no-icon' href={`https://${process.env.WIKI_HOST}${showAll}`}>See All <i className='fas fa-chevron-right' /></a>}</span>
                 </div>
             </div>
         );

--- a/home/javascript/react/components/WikiBlogPostList.js
+++ b/home/javascript/react/components/WikiBlogPostList.js
@@ -49,14 +49,14 @@ class WikiBlogPostList extends Component {
                                 minute: '2-digit',
                                 year: 'numeric'
                             })}</small>
-                            <p><a href={`https://${process.env.WIKI_HOST}${post._links.webui}`}>{post.title}</a></p>
+                            <p><a href={`https://wiki.zfin.org${post._links.webui}`}>{post.title}</a></p>
                         </li>
                     ))}
                 </ul>
                 <LoadingSpinner loading={loading} />
                 <div className='wiki-list-controls'>
                     <span>{ next && <a href='#' onClick={this.loadNext}>Load More</a> }</span>
-                    <span>{ showAll && <a className='no-icon' href={`https://${process.env.WIKI_HOST}${showAll}`}>See All <i className='fas fa-chevron-right' /></a>}</span>
+                    <span>{ showAll && <a className='no-icon' href={`https://wiki.zfin.org${showAll}`}>See All <i className='fas fa-chevron-right' /></a>}</span>
                 </div>
             </div>
         );

--- a/home/javascript/react/components/WikiPostList.js
+++ b/home/javascript/react/components/WikiPostList.js
@@ -35,7 +35,7 @@ class WikiPostList extends Component {
                 <div className='wiki-list-controls'>
                     <span/>
                     <span>{showAll &&
-                    <a href={`https://zfin.atlassian.net/wiki${showAll}`}>See All <i className='fas fa-chevron-right'/></a>}</span>
+                    <a className='no-icon' href={`https://zfin.atlassian.net/wiki${showAll}`}>See All <i className='fas fa-chevron-right'/></a>}</span>
                 </div>
             </div>
         );


### PR DESCRIPTION
<img width="1454" height="2006" alt="image" src="https://github.com/user-attachments/assets/47788282-859b-4f42-98e2-6afdb0769f9f" />
