### PR TITLE
ZFIN-9914: Removing string added by Jenkins. (Encrypted empty string.)

### DIFF
--- a/server_apps/jenkins/config.xml
+++ b/server_apps/jenkins/config.xml
@@ -56,7 +56,7 @@
     <disableSslVerification>false</disableSslVerification>
     <logoutFromOpenidProvider>false</logoutFromOpenidProvider>
     <escapeHatchEnabled>false</escapeHatchEnabled>
-    <escapeHatchSecret>{AQAAABAAAABA6RfWZ4tAeuOTh8KEHCJ6WOYyc7kVKS8wtKxjBFVbCUI5Yg4ZjQZkjJ39VmLggf0HXhlMD5JgLIq/DrHKU6B+9laHssOw58dTdyXS4D7tyoM=}</escapeHatchSecret>
+    <escapeHatchSecret></escapeHatchSecret>
     <serverConfiguration class="org.jenkinsci.plugins.oic.OicServerWellKnownConfiguration">
       <wellKnownOpenIDConfigurationUrl>https://bouncer.zfin.org/realms/ZFIN/.well-known/openid-configuration</wellKnownOpenIDConfigurationUrl>
     </serverConfiguration>


### PR DESCRIPTION
Jenkins encrypts strings it considers secrets when it writes its config files. So it encrypted the empty string I had set for the escape hatch secret and then complains when it tries to read it back when deployed on another instance. Removing.