### PR TITLE
Increase timeout for file copy process

### DIFF
--- a/buildSrc/src/main/groovy/SimpleDirectoryCopyTask.groovy
+++ b/buildSrc/src/main/groovy/SimpleDirectoryCopyTask.groovy
@@ -169,7 +169,7 @@ class SimpleDirectoryCopyTask extends DefaultTask {
             def sout = new StringBuilder(), serr = new StringBuilder()
             def proc = ["cp", source, destination].execute()
             proc.consumeProcessOutput(sout, serr)
-            proc.waitForOrKill(3600)
+            proc.waitForOrKill(30000)
             if (proc.exitValue() != 0) {
                 println "Error"
                 println "$serr"


### PR DESCRIPTION
Increased the timeout for the file copy process from 3600 seconds to 30000 seconds.