### PR TITLE
Trunk Test Failing: Fix failing test getAnatomyForMarker

### DIFF
--- a/test/org/zfin/expression/repository/ExpressionRepositoryTest.java
+++ b/test/org/zfin/expression/repository/ExpressionRepositoryTest.java
@@ -399,6 +399,7 @@ public class ExpressionRepositoryTest extends AbstractDatabaseTest {
                 AND fish_zdb_id  = genox_fish_zdb_id
                 AND fish_genotype_zdb_id  = geno_zdb_id
                 AND geno_is_wildtype = :wildType
+                AND genox_is_standard = true
                 ORDER BY term_name asc
                 """;
         List<Object[]> termZdbIds = (List<Object[]>) HibernateUtil.currentSession().createNativeQuery(sql)


### PR DESCRIPTION
I did some debugging and compared the SQL in the test to the SQL that gets generated by the method under test (getWildTypeAnatomyExpressionForMarker).

Here's a screenshot of the diff (after using pg_format):

<img width="3014" height="1116" alt="image" src="https://github.com/user-attachments/assets/25a2f040-892d-43de-8489-8d53a4d6283a" />

You can see that the effective difference is that the hql query includes the qualifier "AND genox_is_standard = TRUE".  
I updated the test sql to include that clause and it fixes the test. That said, I'm not sure how valuable this test is since it seems to just test if the hql matches the expected sql--but it's not clear to me which one is the correct one if they differ.
