### PR TITLE
Make Pub page mesh terms sort order deterministic 

### DIFF
--- a/source/org/zfin/publication/Publication.java
+++ b/source/org/zfin/publication/Publication.java
@@ -104,7 +104,8 @@ public class Publication implements Comparable<Publication>, Serializable, Entit
     private Set<Person> people;
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "mh_pub_zdb_id")
-    private Set<MeshHeading> meshHeadings;
+    @org.hibernate.annotations.SortNatural
+    private SortedSet<MeshHeading> meshHeadings;
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "pnote_pub_zdb_id")
     @OrderBy("date desc")


### PR DESCRIPTION
by updating meshHeadings to use SortedSet for natural sorting.

Example of the random sort order between refreshes:


https://github.com/user-attachments/assets/3a040b4d-2f9d-4e40-96e8-17bcd346870a

