### PR TITLE
ZFIN-10122: Add Elastic APM and Metricbeat performance monitoring

### DIFF
--- a/docker/apm-server/Dockerfile
+++ b/docker/apm-server/Dockerfile
@@ -1,0 +1,16 @@
+ARG ELK_VERSION
+
+FROM docker.elastic.co/apm/apm-server:${ELK_VERSION}
+
+COPY ./apm-server.yml /usr/share/apm-server/apm-server.yml
+COPY ./traces-apm-template.json /usr/share/apm-server/traces-apm-template.json
+
+# Install curl for the setup script (run as root, then switch back)
+USER root
+RUN apt-get update -qq && apt-get install -y -qq curl > /dev/null 2>&1 && rm -rf /var/lib/apt/lists/*
+USER apm-server
+
+COPY --chmod=755 ./docker-entrypoint-wrapper.sh /usr/local/bin/docker-entrypoint-wrapper.sh
+
+ENTRYPOINT ["/usr/bin/tini", "--", "docker-entrypoint-wrapper.sh"]
+CMD ["--strict.perms=false"]

--- a/docker/apm-server/apm-server.yml
+++ b/docker/apm-server/apm-server.yml
@@ -1,0 +1,15 @@
+apm-server:
+  host: "0.0.0.0:8200"
+  data_streams:
+    wait_for_integration: false
+
+output.elasticsearch:
+  hosts: ["elasticsearch:9200"]
+  username: "elastic"
+  password: "${ELASTIC_PASSWORD}"
+
+kibana:
+  enabled: true
+  host: "kibana:5601"
+  username: "elastic"
+  password: "${ELASTIC_PASSWORD}"

--- a/docker/apm-server/docker-entrypoint-wrapper.sh
+++ b/docker/apm-server/docker-entrypoint-wrapper.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Loads the APM traces index template into Elasticsearch before starting apm-server.
+# This ensures that traces-apm* indices get proper keyword mappings instead of
+# Elasticsearch's default dynamic text+keyword mapping (which breaks APM UI aggregations).
+
+set -e
+
+ES_URL="http://elasticsearch:9200"
+TEMPLATE_FILE="/usr/share/apm-server/traces-apm-template.json"
+TEMPLATE_NAME="traces-apm-custom"
+
+echo "Waiting for Elasticsearch to be ready..."
+until curl -s -u "elastic:${ELASTIC_PASSWORD}" "${ES_URL}/_cluster/health" | grep -qE '"status":"(green|yellow)"'; do
+  sleep 2
+done
+echo "Elasticsearch is ready."
+
+echo "Loading index template '${TEMPLATE_NAME}'..."
+HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+  -X PUT "${ES_URL}/_index_template/${TEMPLATE_NAME}" \
+  -u "elastic:${ELASTIC_PASSWORD}" \
+  -H 'Content-Type: application/json' \
+  -d @"${TEMPLATE_FILE}")
+
+if [ "$HTTP_CODE" = "200" ]; then
+  echo "Index template '${TEMPLATE_NAME}' loaded successfully."
+else
+  echo "WARNING: Failed to load index template (HTTP ${HTTP_CODE}). APM UI aggregations may not work correctly."
+fi
+
+# Hand off to the original entrypoint
+exec /usr/local/bin/docker-entrypoint "$@"

--- a/docker/apm-server/traces-apm-template.json
+++ b/docker/apm-server/traces-apm-template.json
@@ -1,0 +1,136 @@
+{
+  "index_patterns": ["traces-apm*"],
+  "priority": 200,
+  "template": {
+    "settings": {
+      "index.lifecycle.name": "traces-apm-default_policy",
+      "index.mapping.total_fields.limit": 2000
+    },
+    "mappings": {
+      "dynamic_templates": [
+        {
+          "strings_as_keyword": {
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        }
+      ],
+      "properties": {
+        "@timestamp": { "type": "date" },
+        "span": {
+          "properties": {
+            "db": {
+              "properties": {
+                "statement": {
+                  "type": "text",
+                  "fields": { "keyword": { "type": "keyword", "ignore_above": 1024 } }
+                }
+              }
+            },
+            "duration": {
+              "properties": {
+                "us": { "type": "long" }
+              }
+            },
+            "composite": {
+              "properties": {
+                "count": { "type": "long" },
+                "sum": {
+                  "properties": {
+                    "us": { "type": "long" }
+                  }
+                }
+              }
+            },
+            "self_time": {
+              "properties": {
+                "count": { "type": "long" },
+                "sum": {
+                  "properties": {
+                    "us": { "type": "long" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "transaction": {
+          "properties": {
+            "duration": {
+              "properties": {
+                "us": { "type": "long" }
+              }
+            },
+            "span_count": {
+              "properties": {
+                "started": { "type": "long" },
+                "dropped": { "type": "long" }
+              }
+            },
+            "sampled": { "type": "boolean" }
+          }
+        },
+        "http": {
+          "properties": {
+            "request": {
+              "properties": {
+                "body": {
+                  "properties": {
+                    "original": {
+                      "type": "text",
+                      "fields": { "keyword": { "type": "keyword", "ignore_above": 1024 } }
+                    }
+                  }
+                }
+              }
+            },
+            "response": {
+              "properties": {
+                "status_code": { "type": "long" }
+              }
+            }
+          }
+        },
+        "url": {
+          "properties": {
+            "full": {
+              "type": "text",
+              "fields": { "keyword": { "type": "keyword", "ignore_above": 1024 } }
+            },
+            "original": {
+              "type": "text",
+              "fields": { "keyword": { "type": "keyword", "ignore_above": 1024 } }
+            }
+          }
+        },
+        "user_agent": {
+          "properties": {
+            "original": {
+              "type": "text",
+              "fields": { "keyword": { "type": "keyword", "ignore_above": 1024 } }
+            }
+          }
+        },
+        "process": {
+          "properties": {
+            "pid": { "type": "long" },
+            "ppid": { "type": "long" }
+          }
+        },
+        "source": {
+          "properties": {
+            "port": { "type": "long" }
+          }
+        },
+        "client": {
+          "properties": {
+            "port": { "type": "long" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docker/metricbeat/Dockerfile
+++ b/docker/metricbeat/Dockerfile
@@ -1,0 +1,10 @@
+ARG ELK_VERSION
+
+FROM docker.elastic.co/beats/metricbeat:${ELK_VERSION}
+
+USER root
+COPY ./metricbeat.yml /usr/share/metricbeat/metricbeat.yml
+COPY ./modules.d/ /usr/share/metricbeat/modules.d/
+
+RUN chmod go-w /usr/share/metricbeat/metricbeat.yml
+RUN chmod go-w /usr/share/metricbeat/modules.d/*.yml

--- a/docker/metricbeat/metricbeat.yml
+++ b/docker/metricbeat/metricbeat.yml
@@ -1,0 +1,8 @@
+metricbeat.config.modules:
+  path: ${path.config}/modules.d/*.yml
+  reload.enabled: false
+
+output.elasticsearch:
+  hosts: ["elasticsearch:9200"]
+  username: "elastic"
+  password: "${ELASTIC_PASSWORD}"

--- a/docker/metricbeat/modules.d/jolokia.yml
+++ b/docker/metricbeat/modules.d/jolokia.yml
@@ -1,0 +1,22 @@
+- module: jolokia
+  metricsets: ["jmx"]
+  period: 30s
+  hosts: ["tomcat:8778"]
+  namespace: "tomcat_jmx"
+  jmx.mappings:
+    - mbean: "Catalina:type=ThreadPool,name=*"
+      attributes:
+        - attr: currentThreadCount
+          field: thread_pool.current
+        - attr: currentThreadsBusy
+          field: thread_pool.busy
+        - attr: maxThreads
+          field: thread_pool.max
+    - mbean: "com.mchange.v2.c3p0:type=PooledDataSource,*"
+      attributes:
+        - attr: numConnectionsDefaultUser
+          field: c3p0.connections.total
+        - attr: numBusyConnectionsDefaultUser
+          field: c3p0.connections.busy
+        - attr: numIdleConnectionsDefaultUser
+          field: c3p0.connections.idle

--- a/docker/metricbeat/modules.d/postgresql.yml
+++ b/docker/metricbeat/modules.d/postgresql.yml
@@ -1,0 +1,9 @@
+- module: postgresql
+  metricsets:
+    - database
+    - bgwriter
+    - activity
+  period: 30s
+  hosts: ["postgres://db:5432?sslmode=disable"]
+  username: postgres
+  password: ""

--- a/docker/metricbeat/modules.d/system.yml
+++ b/docker/metricbeat/modules.d/system.yml
@@ -1,0 +1,12 @@
+- module: system
+  period: 30s
+  metricsets:
+    - cpu
+    - load
+    - memory
+    - network
+    - process
+    - process_summary
+  process.include_top_n:
+    by_cpu: 5
+    by_memory: 5

--- a/docker/tomcat/Dockerfile
+++ b/docker/tomcat/Dockerfile
@@ -22,6 +22,11 @@ RUN usermod  -aG zfishweb zfishweb
 RUN groupadd -g 1477 zfloadup
 RUN usermod  -aG zfloadup zfishweb
 
+# Download Elastic APM agent and Jolokia JVM agent
+ADD https://repo1.maven.org/maven2/co/elastic/apm/elastic-apm-agent/1.55.4/elastic-apm-agent-1.55.4.jar /opt/elastic-apm-agent.jar
+ADD https://repo1.maven.org/maven2/org/jolokia/jolokia-jvm/1.7.2/jolokia-jvm-1.7.2.jar /opt/jolokia-jvm.jar
+RUN chmod 444 /opt/elastic-apm-agent.jar /opt/jolokia-jvm.jar
+
 RUN echo 'CATALINA_OPTS="${CATALINA_OPTS} \
 -Duser.timezone=${TZ:-America/Los_Angeles} \
 -Dcom.sun.management.jmxremote \
@@ -31,6 +36,18 @@ RUN echo 'CATALINA_OPTS="${CATALINA_OPTS} \
 -Djava.rmi.server.hostname=$(hostname -i) \
 -Dcom.sun.management.jmxremote.rmi.port=9012 \
 -Dcom.sun.management.jmxremote.ssl=false"' > bin/setenv.sh
+
+# Elastic APM agent + Jolokia (only when ENABLE_APM=true)
+RUN echo 'if [ "$ENABLE_APM" = "true" ]; then' >> bin/setenv.sh && \
+    echo 'CATALINA_OPTS="${CATALINA_OPTS} \
+-javaagent:/opt/elastic-apm-agent.jar \
+-Delastic.apm.service_name=zfin-web \
+-Delastic.apm.server_urls=http://apm-server:8200 \
+-Delastic.apm.application_packages=org.zfin \
+-Delastic.apm.enable_log_correlation=true \
+-Delastic.apm.environment=docker \
+-javaagent:/opt/jolokia-jvm.jar=port=8778,host=0.0.0.0"' >> bin/setenv.sh && \
+    echo 'fi' >> bin/setenv.sh
 
 USER zfishweb
 

--- a/docs/performance-monitoring.md
+++ b/docs/performance-monitoring.md
@@ -1,0 +1,203 @@
+# Performance Monitoring for ZFIN
+
+## What This Is
+
+This adds tools to answer questions like:
+
+- **Which pages are slow?** See a ranked list of every URL endpoint with its average, median, and 95th-percentile response time.
+- **Why is a page slow?** Drill into a single request and see a waterfall timeline: how long was spent in the Java controller, in Hibernate queries, in PostgreSQL, etc.
+- **Is the server healthy?** View CPU usage, memory consumption, database connection pool saturation, and Tomcat thread pool utilization over time.
+- **What errors are happening?** See grouped exceptions with stack traces, frequency, and which endpoints they affect.
+
+Everything runs inside the existing Docker environment. No code changes are needed to the ZFIN application itself beyond what's included here — the monitoring agents attach to the running Java process automatically.
+
+## The Components
+
+### Elasticsearch (already existed)
+
+Elasticsearch is a search and analytics database. Think of it as a specialized database optimized for storing and querying time-series data like logs and metrics. It was already part of our Docker stack, used by Filebeat to store Apache HTTPD access logs. Now it also stores APM traces and Metricbeat metrics.
+
+### Kibana (already existed)
+
+Kibana is a web UI for exploring data stored in Elasticsearch. It provides dashboards, charts, and — most importantly for us — a built-in **APM UI** that visualizes application performance data without any dashboard setup required. Access it at `http://<host>:5601`.
+
+### APM Server (new)
+
+APM stands for **Application Performance Monitoring**. The APM Server is a lightweight service that receives performance data from the APM agent running inside Tomcat and forwards it to Elasticsearch. It's a pass-through — it doesn't do heavy processing, just validates and routes data.
+
+### Elastic APM Java Agent (new, runs inside Tomcat)
+
+This is the key piece. The APM agent is a `.jar` file that attaches to the Tomcat Java process at startup (via `-javaagent`). It automatically instruments:
+
+- **Spring MVC controllers** — records every HTTP request with the controller method name, URL, and response time
+- **Hibernate/JPA queries** — records every database query with its SQL and execution time
+- **JDBC connections** — tracks connection acquisition time
+- **HTTP client calls** — tracks outgoing HTTP requests (e.g., to Solr)
+
+It does this by bytecode instrumentation (modifying Java classes at load time), so **no application code changes are needed**. It sends all this data to the APM Server.
+
+### Jolokia (new, runs inside Tomcat)
+
+Jolokia is a tiny agent that exposes JMX (Java Management Extensions) data over HTTP. JMX is a standard Java mechanism for exposing internal metrics like thread counts and memory usage. Normally JMX uses a binary protocol that's hard to work with, but Jolokia makes it available as simple HTTP/JSON. Metricbeat reads from Jolokia to collect:
+
+- **Tomcat thread pool** — how many threads are active vs. available
+- **C3P0 connection pool** — how many database connections are in use vs. idle
+
+### Metricbeat (new)
+
+Metricbeat is a lightweight agent that collects system and service metrics on a schedule (every 30 seconds) and sends them to Elasticsearch. It collects three categories of data:
+
+| Category | What It Measures |
+|----------|-----------------|
+| **System** | Host CPU, memory, disk, network, top processes |
+| **Jolokia/JMX** | Tomcat thread pool utilization, C3P0 DB connection pool |
+| **PostgreSQL** | Active connections, transactions/sec, buffer cache hit ratio |
+
+## How It Fits Together
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Tomcat Container                                        │
+│  ┌────────────────┐  ┌─────────────┐  ┌──────────────┐  │
+│  │  ZFIN Web App  │  │  APM Agent  │  │   Jolokia    │  │
+│  │  (Spring MVC,  │  │  (auto-     │  │  (JMX over   │  │
+│  │   Hibernate)   │  │  instruments│  │   HTTP)      │  │
+│  └────────────────┘  └──────┬──────┘  └──────┬───────┘  │
+│                             │                │           │
+└─────────────────────────────┼────────────────┼───────────┘
+                              │                │
+                    traces &  │                │ JMX metrics
+                    spans     │                │ (every 30s)
+                              ▼                │
+                     ┌────────────────┐        │
+                     │   APM Server   │        │
+                     └───────┬────────┘        │
+                             │                 │
+                             ▼                 ▼
+                     ┌────────────────────────────────┐
+        ┌───────────▶│         Elasticsearch           │◀──── Metricbeat
+        │            └───────────────┬────────────────┘      (system, PG,
+        │                            │                        Jolokia)
+   Filebeat                          │
+   (Apache logs,                     ▼
+    already existed)        ┌─────────────────┐
+                            │     Kibana       │
+                            │  (APM UI, logs,  │
+                            │   dashboards)    │
+                            └─────────────────┘
+```
+
+## How to Enable It
+
+All monitoring services run under the Docker Compose `logging` profile and are **off by default**.
+
+### 1. Start the logging stack
+
+```bash
+docker compose --profile logging up -d
+```
+
+This starts Elasticsearch, Kibana, Filebeat, APM Server, and Metricbeat. Tomcat does **not** need to be restarted for these.
+
+### 2. Enable the APM agent in Tomcat
+
+Set `ENABLE_APM=true` in your `.env` file, then rebuild and restart Tomcat:
+
+```bash
+# In your .env file, set:
+# ENABLE_APM=true
+
+docker compose up -d --build tomcat
+```
+
+When `ENABLE_APM` is `false` (the default), the APM agent and Jolokia are **not loaded at all** — there is zero overhead.
+
+### 3. Open Kibana
+
+Navigate to:
+```
+http://<your-host>:5601
+```
+
+Log in with the `elastic` user and the password from `ELASTIC_PASSWORD` in your `.env` file.
+
+## Finding Slow Endpoints in Kibana
+
+1. Open Kibana and go to **Observability > APM** (left sidebar)
+2. Click on the **zfin-web** service
+3. The **Overview** tab shows:
+   - A table of endpoints ranked by latency (avg, p95)
+   - Throughput (requests/min) per endpoint
+   - Error rate over time
+4. Click any endpoint name to see:
+   - A **latency distribution** histogram
+   - A list of individual transaction **traces**
+5. Click a trace to see a **waterfall view**: a timeline showing exactly where time was spent (controller logic, Hibernate queries, PostgreSQL execution)
+
+### Example: Finding Why a Page Is Slow
+
+1. Go to APM > zfin-web > Transactions tab
+2. Sort by **Avg. duration** (descending)
+3. See that `PublicationViewController#showAllFigures` averages 13 seconds
+4. Click it, then click a sample trace
+5. The waterfall shows: 200ms in the controller, then 12.8 seconds across 47 Hibernate SELECT queries
+6. Now you know: the page is slow because of N+1 query problem, not slow Java code
+
+## Configuration Reference
+
+### Environment Variables
+
+These go in your `.env` file:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENABLE_APM` | `false` | Load APM + Jolokia agents in Tomcat |
+| `ELASTIC_PASSWORD` | (required) | Password for the `elastic` Elasticsearch user |
+| `KIBANA_SYSTEM_PASSWORD` | (required) | Password for Kibana's internal ES user |
+| `XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY` | (required) | Encryption key for Kibana saved objects (min 32 chars) |
+| `DOCKER_APM_SERVER_PORT` | `127.0.0.1:8200-8209` | Host port for APM Server |
+| `DOCKER_ELASTICSEARCH_PORT` | `127.0.0.1:9200-9209` | Host port for Elasticsearch |
+| `DOCKER_KIBANA_PORT` | `127.0.0.1:5601-5610` | Host port for Kibana |
+
+### Port Mappings
+
+All monitoring services bind to `127.0.0.1` by default (localhost only). To bind to a specific interface, override in `.env`:
+
+```bash
+# Bind to a specific local IP (useful for multi-instance setups)
+DOCKER_ELASTICSEARCH_PORT=127.0.0.2:9200
+DOCKER_KIBANA_PORT=127.0.0.2:5601
+DOCKER_APM_SERVER_PORT=127.0.0.2:8200
+```
+
+## Files Added/Modified
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `docker/apm-server/Dockerfile` | Builds the APM Server container; loads index template before starting |
+| `docker/apm-server/apm-server.yml` | APM Server configuration |
+| `docker/apm-server/traces-apm-template.json` | Elasticsearch index template that maps APM trace fields as `keyword` for proper aggregation support |
+| `docker/apm-server/docker-entrypoint-wrapper.sh` | Startup script that loads the index template into Elasticsearch before starting the APM Server |
+| `docker/metricbeat/Dockerfile` | Builds the Metricbeat container |
+| `docker/metricbeat/metricbeat.yml` | Metricbeat output configuration |
+| `docker/metricbeat/modules.d/system.yml` | System metrics collection (CPU, memory, etc.) |
+| `docker/metricbeat/modules.d/jolokia.yml` | JMX metrics via Jolokia (thread pool, connection pool) |
+| `docker/metricbeat/modules.d/postgresql.yml` | PostgreSQL metrics collection |
+
+### Modified Files
+
+| File | What Changed |
+|------|-------------|
+| `docker/docker-compose.yml` | Added `apm-server` and `metricbeat` services; added `ENABLE_APM` env var to Tomcat; standardized port mappings |
+| `docker/tomcat/Dockerfile` | Downloads APM agent + Jolokia JARs; conditionally loads them via `ENABLE_APM` |
+| `docker/environment_linux` | Added example port override variables for new services |
+| `source/.../AddRequestInfoToLog4j.java` | Added response time and status code tracking to request logs |
+| `home/WEB-INF/log4j2.xml` | Added `responseTimeMs`, `statusCode`, `trace.id`, `transaction.id` to JSON log output |
+
+## Log Correlation
+
+When APM is enabled, the APM agent injects `trace.id` and `transaction.id` into the Log4j2 thread context. These IDs appear in the JSON log file (`catalina.json`), which Filebeat ships to Elasticsearch. In Kibana, you can click a log line and jump directly to the corresponding APM transaction trace — or vice versa.
+
+The `responseTimeMs` and `statusCode` fields are always present (even without APM) and provide a lightweight way to track response times in logs.

--- a/home/WEB-INF/log4j2.xml
+++ b/home/WEB-INF/log4j2.xml
@@ -25,6 +25,10 @@
                 <KeyValuePair key="instance" value="$${env:INSTANCE:-unknown}"/>
                 <KeyValuePair key="date" value="$${date:yyyy-MM-dd HH:mm:ss}" />
                 <KeyValuePair key="cookie" value="$${ctx:cookie:-}" />
+                <KeyValuePair key="responseTimeMs" value="$${ctx:responseTimeMs:-}" />
+                <KeyValuePair key="statusCode" value="$${ctx:statusCode:-}" />
+                <KeyValuePair key="trace.id" value="$${ctx:trace.id:-}" />
+                <KeyValuePair key="transaction.id" value="$${ctx:transaction.id:-}" />
             </JsonLayout>
             <Policies>
                 <SizeBasedTriggeringPolicy size="50MB"/>
@@ -45,6 +49,7 @@
         <Logger name="org.hibernate.orm.deprecation" level="error"/>
         <Logger name="org.hibernate.engine.internal.StatefulPersistenceContext" level="error"/>
         <Logger name="org.zfin" level="warn"/>
+        <Logger name="org.zfin.framework.filter.AddRequestInfoToLog4j" level="info"/>
         <Logger name="org.zfin.ontology.OntologySerializationService" level="info"/>
         <Logger name="org.zfin.ontology.datatransfer.AbstractScriptWrapper" level="info" additivity="false">
             <AppenderRef ref="STDOUT"/>

--- a/source/org/zfin/framework/filter/AddRequestInfoToLog4j.java
+++ b/source/org/zfin/framework/filter/AddRequestInfoToLog4j.java
@@ -1,14 +1,17 @@
 package org.zfin.framework.filter;
 
+import lombok.extern.log4j.Log4j2;
 import org.apache.logging.log4j.ThreadContext;
 
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**
  * Add Request info to log4j MDC (mapped diagnostic context).
  */
+@Log4j2
 public class AddRequestInfoToLog4j implements Filter {
 
     public static final String REQUEST_MAP = "requestMap";
@@ -17,6 +20,7 @@ public class AddRequestInfoToLog4j implements Filter {
     }
 
     public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws ServletException, IOException {
+        long startTime = System.currentTimeMillis();
         try {
             HttpServletRequest request = (HttpServletRequest) req;
             // add map to mapped diagnostic context so it gets picked up by the JSONEventLayout
@@ -34,7 +38,17 @@ public class AddRequestInfoToLog4j implements Filter {
             e.printStackTrace();
             // ignore error to make sure request does not fail..
         }
-        chain.doFilter(req, resp);
+        try {
+            chain.doFilter(req, resp);
+        } finally {
+            long duration = System.currentTimeMillis() - startTime;
+            ThreadContext.put("responseTimeMs", String.valueOf(duration));
+            if (resp instanceof HttpServletResponse) {
+                ThreadContext.put("statusCode", String.valueOf(((HttpServletResponse) resp).getStatus()));
+            }
+            log.info("Request completed");
+            ThreadContext.clearAll();
+        }
     }
 
     public void init(FilterConfig config) throws ServletException {


### PR DESCRIPTION
## Summary
- Add Elastic APM agent (1.55.4) + Jolokia JVM agent to Tomcat for auto-instrumented transaction tracing (Spring MVC, Hibernate, JDBC) and JMX metrics
- Add APM Server and Metricbeat services under `--profile logging`, collecting system, JMX (thread pool, C3P0 pool), and PostgreSQL metrics
- Enrich Log4j2 JSON logs with `responseTimeMs`, `statusCode`, `trace.id`, and `transaction.id` for APM log correlation
- Standardize all Docker Compose port mappings to use configurable environment variables (e.g. `DOCKER_DB_PORT`, `DOCKER_ELASTICSEARCH_PORT`)
- Gate APM/Jolokia agents behind `ENABLE_APM` env var so they only load when explicitly enabled

## Test plan
- `docker compose --profile logging build` succeeds
- `docker compose --profile logging up` starts all services (elasticsearch, kibana, apm-server, metricbeat, filebeat)
- Set `ENABLE_APM=true` in `.env` and rebuild tomcat; verify APM traces appear in Kibana APM UI
- Verify Metricbeat indices populate (`curl http://localhost:9200/metricbeat-*/_count`)
- Verify APM transaction traces at Kibana > APM > Services > zfin-web
- Verify no impact when running without `--profile logging` (APM agent not loaded)