### PR TITLE
ZFIN-10166: Marker assembly update fix

### DIFF
--- a/server_apps/data_transfer/NCBIGENE/markerAssemblyUpdate.sql
+++ b/server_apps/data_transfer/NCBIGENE/markerAssemblyUpdate.sql
@@ -7,14 +7,14 @@ from db_link as db
 where db.dblink_fdbcont_zdb_id = 'ZDB-FDBCONT-040412-1'
   and not exists(
         select *
-        from zfindb.public.sequence_feature_chromosome_location_generated
-        where db.dblink_linked_recid = sfclg_data_zdb_id
-          and sfclg_assembly = 'GRCz12tu'
+        from marker_assembly
+        where db.dblink_linked_recid = ma_mrkr_zdb_id
+          and ma_a_pk_id = 1
     )
   and exists(
         select *
         from gff3_ncbi
-        where gff_attributes like '%GeneID:' || db.dblink_acc_num || '%'
+        where regexp_like(gff_attributes, 'GeneID:' || db.dblink_acc_num || '(,|;|$)')
           AND gff_feature in ('gene', 'pseudogene')
     )
   and not exists(
@@ -60,7 +60,7 @@ from temp_new_gene,
      gff3_ncbi,
      gff3_ncbi_attribute
 where gna_key = 'Dbxref'
-  and (regexp_like(gna_value, '.*GeneID:' || accession || '$') OR regexp_like(gna_value, '.*GeneID:' || accession || ','))
+  and regexp_like(gna_value, 'GeneID:' || accession || '(,|$)')
   and gna_gff_pk_id = gff_pk_id
   and gff_feature in ('gene', 'pseudogene');
 
@@ -83,7 +83,7 @@ from temp_new_gene,
      gff3_ncbi,
      gff3_ncbi_attribute
 where gna_key = 'Dbxref'
-  and (regexp_like(gna_value, '.*GeneID:' || accession || '$') OR regexp_like(gna_value, '.*GeneID:' || accession || ','))
+  and regexp_like(gna_value, 'GeneID:' || accession || '(,|$)')
   and gna_gff_pk_id = gff_pk_id
   and gff_feature in ('gene', 'pseudogene');
 
@@ -97,7 +97,7 @@ from temp_new_gene,
      gff3_ncbi,
      gff3_ncbi_attribute
 where gna_key = 'Dbxref'
-  and (regexp_like(gna_value, '.*GeneID:' || accession || '$') OR regexp_like(gna_value, '.*GeneID:' || accession || ','))
+  and regexp_like(gna_value, 'GeneID:' || accession || '(,|$)')
   and gna_gff_pk_id = gff_pk_id
   and gff_feature in ('gene', 'pseudogene')
   ON CONFLICT (gna_pk_id) DO NOTHING; 
@@ -126,29 +126,3 @@ where gg.sfclg_assembly = 'GRCz11'
     )
 on conflict (ma_mrkr_zdb_id, ma_a_pk_id) do nothing;
 
--- another pass to catch any genes that have a GRCz12 association in gff3_ncbi but not in marker_assembly, and are not listed as "not in current annotation release set"
--- any gene that has an NCBI gene ID and is not marked as "not in current annotation release set" should be associated to GRCz12,
--- after all, GRCz12 is the current annotation release, and if it has an NCBI gene ID and it's in gff3_ncbi table, it should be in the GRCz12 set.
--- get that warning set:
-CREATE TEMP VIEW warning_report_current_not_z12 AS
-SELECT
-    mas_mrkr_zdb_id                          AS gene_zdb_id,
-    string_agg(DISTINCT dblink_acc_num, ',') AS gene_ncbi_id
-FROM marker_annotation_status
-         LEFT JOIN marker_assembly ON mas_mrkr_zdb_id = ma_mrkr_zdb_id
-         LEFT JOIN db_link         ON mas_mrkr_zdb_id = dblink_linked_recid
-    AND dblink_fdbcont_zdb_id = 'ZDB-FDBCONT-040412-1'
-WHERE mas_vt_pk_id = 12
-GROUP BY mas_mrkr_zdb_id
-HAVING string_agg(ma_a_pk_id::varchar, ',') NOT LIKE '%1%';
-
--- get the genes that have a GRCz12 association in gff3_ncbi but also show up in the warning report
-create temp view new_inserts as
-select * from warning_report_current_not_z12
-    join gff3_ncbi
-    on gff_attributes like '%Dbxref=GeneID:' || gene_ncbi_id || ',%'
-    and gff_attributes like '%gbkey=Gene%';
-
-insert into marker_assembly (ma_mrkr_zdb_id, ma_a_pk_id)
-select gene_zdb_id, 1 from new_inserts
-on conflict (ma_mrkr_zdb_id, ma_a_pk_id) do nothing;

--- a/server_apps/data_transfer/NCBIGENE/markerAssemblyUpdate.sql
+++ b/server_apps/data_transfer/NCBIGENE/markerAssemblyUpdate.sql
@@ -125,3 +125,30 @@ where gg.sfclg_assembly = 'GRCz11'
           and g.ma_a_pk_id =3
     )
 on conflict (ma_mrkr_zdb_id, ma_a_pk_id) do nothing;
+
+-- another pass to catch any genes that have a GRCz12 association in gff3_ncbi but not in marker_assembly, and are not listed as "not in current annotation release set"
+-- any gene that has an NCBI gene ID and is not marked as "not in current annotation release set" should be associated to GRCz12,
+-- after all, GRCz12 is the current annotation release, and if it has an NCBI gene ID and it's in gff3_ncbi table, it should be in the GRCz12 set.
+-- get that warning set:
+CREATE TEMP VIEW warning_report_current_not_z12 AS
+SELECT
+    mas_mrkr_zdb_id                          AS gene_zdb_id,
+    string_agg(DISTINCT dblink_acc_num, ',') AS gene_ncbi_id
+FROM marker_annotation_status
+         LEFT JOIN marker_assembly ON mas_mrkr_zdb_id = ma_mrkr_zdb_id
+         LEFT JOIN db_link         ON mas_mrkr_zdb_id = dblink_linked_recid
+    AND dblink_fdbcont_zdb_id = 'ZDB-FDBCONT-040412-1'
+WHERE mas_vt_pk_id = 12
+GROUP BY mas_mrkr_zdb_id
+HAVING string_agg(ma_a_pk_id::varchar, ',') NOT LIKE '%1%';
+
+-- get the genes that have a GRCz12 association in gff3_ncbi but also show up in the warning report
+create temp view new_inserts as
+select * from warning_report_current_not_z12
+    join gff3_ncbi
+    on gff_attributes like '%Dbxref=GeneID:' || gene_ncbi_id || ',%'
+    and gff_attributes like '%gbkey=Gene%';
+
+insert into marker_assembly (ma_mrkr_zdb_id, ma_a_pk_id)
+select gene_zdb_id, 1 from new_inserts
+on conflict (ma_mrkr_zdb_id, ma_a_pk_id) do nothing;


### PR DESCRIPTION
Improvements to GeneID matching and data consistency (markerAssemblyUpdate.sql):

**Regular Expression Updates for GeneID Matching:**
* Simplified and unified the regular expressions in multiple queries to use `regexp_like(..., 'GeneID:' || accession || '(,|$)')`, ensuring more accurate matching of GeneIDs at the end of the string or before a comma, and removing unnecessary wildcard patterns. 
* Updated the GFF3 attribute matching to use `regexp_like(gff_attributes, 'GeneID:' || db.dblink_acc_num || '(,|;|$)')`, improving the specificity of the match and handling both comma and semicolon delimiters.

**Table Usage and Data Consistency:**
* Modified the subquery for checking existing records to use the `marker_assembly` table instead of `sequence_feature_chromosome_location_generated`, ensuring consistency with the intended data model and preventing duplicate entries.

**More Details**
* The temp_new_gene query was filtering on sfclg (location records) instead
of marker_assembly, causing genes with existing locations but missing
assembly records to be skipped. This required a second cleanup pass to
catch them. Fix the upstream filter to check marker_assembly directly,
simplify regex patterns, and remove the now-unnecessary second pass.
