### PR TITLE
ZFIN-10106: Fix smoke tests to authenticate before accessing captcha-protected pages

### DIFF
--- a/test/org/zfin/AbstractSecureSmokeTest.java
+++ b/test/org/zfin/AbstractSecureSmokeTest.java
@@ -6,23 +6,27 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import org.apache.logging.log4j.LogManager; import org.apache.logging.log4j.Logger;
+import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.zfin.framework.HibernateUtil;
 import org.zfin.infrastructure.ActiveSource;
 import org.zfin.profile.AccountInfo;
+import org.zfin.profile.EmailPrivacyPreference;
 import org.zfin.profile.Person;
 import org.zfin.repository.RepositoryFactory;
 
 import java.util.Date;
+import java.util.UUID;
 
 /**
- * This class uses the more raw HtmlUnit protocols.
+ * Base class for smoke tests that require an authenticated user.
+ * Creates a unique test user before each test and deletes it after.
  */
 public class AbstractSecureSmokeTest extends AbstractSmokeTest {
 
     protected Person person;
-    protected String password = "veryeasypass";
+    protected String password = UUID.randomUUID().toString();
     private final Logger logger = LogManager.getLogger(AbstractSecureSmokeTest.class);
 
     public AbstractSecureSmokeTest(WebClient webClient) {
@@ -37,75 +41,67 @@ public class AbstractSecureSmokeTest extends AbstractSmokeTest {
     @Before
     public void setUp() throws Exception {
         super.setUp();
+        createTestPersonObject();
         insertTestPersonIntoDatabase();
         login(webClient);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void cleanUp() {
         deletePerson();
-        super.tearDown();
     }
 
-    @BeforeClass
-    public static void setUpGLobal() {
-
-    }
-
-
-        private void createTestPersonObject() {
+    private void createTestPersonObject() {
+        String uniqueLogin = "testUser_" + UUID.randomUUID().toString().substring(0, 8);
+        String uniqueCookie = "cookie_" + UUID.randomUUID();
 
         person = new Person();
-
         person.setFirstName("Test");
         person.setLastName("Person");
         person.generateNameVariations();
-        person.setEmail("Email Address Test");
-        AccountInfo accountInfo = new AccountInfo();
-        accountInfo.setLogin("newUser");
-        accountInfo.setRole("root");
+        person.setEmail("test_" + uniqueLogin + "@test.com");
 
-        String saltedPassword = "ABCDEFGH";
-        accountInfo.setPassword(saltedPassword);
+        EmailPrivacyPreference emailPrivacyPreference = new EmailPrivacyPreference();
+        emailPrivacyPreference.setId(3L);
+        emailPrivacyPreference.setName(EmailPrivacyPreference.Name.HIDDEN.toString());
+        person.setEmailPrivacyPreference(emailPrivacyPreference);
+
+        AccountInfo accountInfo = new AccountInfo();
+        accountInfo.setLogin(uniqueLogin);
+        accountInfo.setRole("root");
+        accountInfo.setPassword(new BCryptPasswordEncoder().encode(password));
         accountInfo.setName("Test Person");
         accountInfo.setLoginDate(new Date());
         accountInfo.setAccountCreationDate(new Date());
-        accountInfo.setCookie("somecookie");
+        accountInfo.setCookie(uniqueCookie);
+        accountInfo.setPerson(person);
         person.setAccountInfo(accountInfo);
-
     }
 
-    protected void insertTestPersonIntoDatabase() {
-        createTestPersonObject();
-        Person existingPerson = RepositoryFactory.getProfileRepository().getPersonByName(person.getAccountInfo().getLogin());
-        if(existingPerson != null && existingPerson.getAccountInfo() != null && existingPerson.getAccountInfo().getLogin() != null){
-            person = existingPerson;
-            return;
-        }
+    private void insertTestPersonIntoDatabase() {
         HibernateUtil.createTransaction();
         HibernateUtil.currentSession().save(person);
         HibernateUtil.currentSession().flush();
-
-        // need to evict object so that it can be reloaded later
         HibernateUtil.currentSession().evict(person);
 
-        // because persons add active source is added with person, need to evict it, too
         ActiveSource activeSource = RepositoryFactory.getInfrastructureRepository().getActiveSource(person.getZdbID());
         assertNotNull(activeSource);
         HibernateUtil.currentSession().evict(activeSource);
         HibernateUtil.flushAndCommitCurrentSession();
     }
 
-    protected void deletePerson() {
-        ActiveSource activeSource = RepositoryFactory.getInfrastructureRepository().getActiveSource(person.getZdbID());
-        HibernateUtil.createTransaction();
-        HibernateUtil.currentSession().delete(person);
-        if (activeSource != null) {
-            HibernateUtil.currentSession().delete(activeSource);
-        } else {
-            logger.error("unable to delete user: " + person.getZdbID() + " " + person.getShortName());
+    private void deletePerson() {
+        try {
+            ActiveSource activeSource = RepositoryFactory.getInfrastructureRepository().getActiveSource(person.getZdbID());
+            HibernateUtil.createTransaction();
+            HibernateUtil.currentSession().delete(person);
+            if (activeSource != null) {
+                HibernateUtil.currentSession().delete(activeSource);
+            }
+            HibernateUtil.flushAndCommitCurrentSession();
+        } catch (Exception e) {
+            logger.error("Failed to clean up test user: " + person.getZdbID(), e);
         }
-        HibernateUtil.flushAndCommitCurrentSession();
     }
 
     public void login(WebClient webClient) throws Exception {

--- a/test/org/zfin/anatomy/AnatomySmokeTest.java
+++ b/test/org/zfin/anatomy/AnatomySmokeTest.java
@@ -9,7 +9,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.zfin.AbstractSmokeTest;
+import org.zfin.AbstractSecureSmokeTest;
 
 import java.io.IOException;
 import java.util.List;
@@ -18,7 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @RunWith(Parameterized.class)
-public class AnatomySmokeTest extends AbstractSmokeTest {
+public class AnatomySmokeTest extends AbstractSecureSmokeTest {
 
     public AnatomySmokeTest(WebClient webClient) {
         super(webClient);
@@ -26,7 +26,7 @@ public class AnatomySmokeTest extends AbstractSmokeTest {
 
     @Test
     public void testAnatomyLookupFormExists() throws IOException {
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/ontology/search");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/ontology/search");
         webClient.waitForBackgroundJavaScriptStartingBefore(2000);
         assertEquals("ZFIN AO / GO Search", page.getTitleText());
         List<?> byXPath = page.getByXPath("//label[. = 'Term:']");
@@ -45,7 +45,7 @@ public class AnatomySmokeTest extends AbstractSmokeTest {
 
     @Test
     public void testAnatomySearchMultipleResults() throws IOException {
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/ontology/term-detail/term?name=emb*");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/ontology/term-detail/term?name=emb*");
         assertEquals("ZFIN Ontology Search", page.getTitleText());
         // check that embryonic structure is listed
         List caption = page.getByXPath("//a[@name = 'embryonic structure']");
@@ -54,7 +54,7 @@ public class AnatomySmokeTest extends AbstractSmokeTest {
 
     @Test
     public void testAllAnatomyTerms() throws IOException {
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/ontology/show-all-anatomy-terms");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/ontology/show-all-anatomy-terms");
         assertEquals("ZFIN", page.getTitleText());
         // check that embryonic structure is listed
         List caption = page.getByXPath("//a[@name = 'embryonic structure']");
@@ -64,7 +64,7 @@ public class AnatomySmokeTest extends AbstractSmokeTest {
 
     @Test
     public void testAnatomyDetailPageByAnatId() throws IOException {
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/ontology/term/ZDB-ANAT-010921-415");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/ontology/term/ZDB-ANAT-010921-415");
         assertEquals("ZFIN Anatomy Ontology: brain", page.getTitleText());
         assertNotNull(page.getByXPath("//span[. = 'Phenotype']").get(0));
     }
@@ -72,7 +72,7 @@ public class AnatomySmokeTest extends AbstractSmokeTest {
     // liver page
     @Test
     public void testAnatomyDetailPageByTermId() throws IOException {
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/ontology/term/ZDB-TERM-100331-116");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/ontology/term/ZDB-TERM-100331-116");
         assertEquals("ZFIN Anatomy Ontology: liver", page.getTitleText());
         assertNotNull(page.getByXPath("//span[. = 'Phenotype']").get(0));
     }
@@ -81,7 +81,7 @@ public class AnatomySmokeTest extends AbstractSmokeTest {
     @Test
     public void testAnatomyDetailPageByOboId() throws IOException {
         webClient.waitForBackgroundJavaScriptStartingBefore(1);
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/ontology/term/ZFA:0000123");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/ontology/term/ZFA:0000123");
         assertEquals("ZFIN Anatomy Ontology: liver", page.getTitleText());
         assertNotNull(page.getByXPath("//span[. = 'Phenotype']").get(0));
     }
@@ -91,7 +91,7 @@ public class AnatomySmokeTest extends AbstractSmokeTest {
     // ignore for now until autocomplete is re-written
     @Ignore
     public void testAnatomyDetailPageByName() throws IOException {
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/ontology/term/term?name=liver");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/ontology/term/term?name=liver");
         assertNotNull(page);
         assertEquals("ZFIN Anatomy Ontology: liver", page.getTitleText());
         assertNotNull(page.getByXPath("//span[. = 'Phenotype']").get(0));
@@ -101,7 +101,7 @@ public class AnatomySmokeTest extends AbstractSmokeTest {
     @Ignore // test often fails as the test times out for the response
     // brain
     public void testShowAllMutantMorpholinos() throws IOException {
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/ontology/show-all-clean-fish/ZDB-TERM-100331-8");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/ontology/show-all-clean-fish/ZDB-TERM-100331-8");
         assertTrue(page.getTitleText().startsWith("ZFIN"));
         assertNotNull(page.getByXPath("//a[@id = 'ZDB-GENE-070521-2']").get(0));
     }
@@ -113,7 +113,7 @@ public class AnatomySmokeTest extends AbstractSmokeTest {
         // vhl^hu2081/+;vhl^hu2117/+;Tg(kdrl:EGFP)s843
         String genoID = "ZDB-GENO-100524-4";
         // mutants in retina
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/ontology/show-all-clean-fish/ZDB-TERM-100331-1770");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/ontology/show-all-clean-fish/ZDB-TERM-100331-1770");
         assertTrue(page.getTitleText().startsWith("ZFIN"));
         assertThat(page.getAnchorByText("vhlhu2081/+; vhlhu2117/+; s843Tg"), is(notNullValue()));
     }
@@ -124,7 +124,7 @@ public class AnatomySmokeTest extends AbstractSmokeTest {
     @Test
     public void testAnatomyDetailPageExpressedGenes() throws IOException {
         // 	telencephalic ventricle [ZDB-TERM-100331-665]
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/ontology/show-expressed-genes/ZDB-TERM-100331-665");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/ontology/show-expressed-genes/ZDB-TERM-100331-665");
         // gene creb1a with 3 figures
         assertNotNull(page.getByXPath("//a[@id='ZDB-GENE-040426-750']").get(0));
     }
@@ -136,7 +136,7 @@ public class AnatomySmokeTest extends AbstractSmokeTest {
     public void testAnatomyDetailPageAntibodies() throws IOException {
         webClient.waitForBackgroundJavaScriptStartingBefore(1);
         // 	brain [ZDB-TERM-100331-8]
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/ontology/show-labeled-antibodies/ZDB-TERM-100331-8");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/ontology/show-labeled-antibodies/ZDB-TERM-100331-8");
         // antibody Ab1-5-hmC
         assertNotNull("Could not find antibody Ab1-5-hmc", page.getByXPath("//a[@id='ab1-5-hmc']").get(0));
     }
@@ -148,7 +148,7 @@ public class AnatomySmokeTest extends AbstractSmokeTest {
     public void testAnatomyDetailPageInSituProbe() throws IOException {
         webClient.waitForBackgroundJavaScriptStartingBefore(1);
         // 	brain [ZDB-TERM-100331-8]
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/ontology/show-expressed-insitu-probes/ZDB-TERM-100331-8");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/ontology/show-expressed-insitu-probes/ZDB-TERM-100331-8");
         // gene crhbp with 3 figures
         assertNotNull(page.getByXPath("//a[@id='ZDB-GENE-040801-196']").get(0));
     }
@@ -160,7 +160,7 @@ public class AnatomySmokeTest extends AbstractSmokeTest {
     public void testShowGenotypesPerAOSubstructures() throws IOException {
         webClient.waitForBackgroundJavaScriptStartingBefore(1000);
         // 	actinotrichium [ZDB-TERM-100614-30]
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/ontology/show-all-clean-fish-include-substructures/ZDB-TERM-100614-30");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/ontology/show-all-clean-fish-include-substructures/ZDB-TERM-100614-30");
         // Genotype Df(Chr03:sox8,sox9b)b971/b971
         assertThat(page.getAnchorByText("AB + MO1-plod1a"), is(notNullValue()));
     }

--- a/test/org/zfin/antibody/smoketest/AntibodySmokeTest.java
+++ b/test/org/zfin/antibody/smoketest/AntibodySmokeTest.java
@@ -5,7 +5,7 @@ import com.gargoylesoftware.htmlunit.html.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.zfin.AbstractSmokeTest;
+import org.zfin.AbstractSecureSmokeTest;
 
 import java.io.IOException;
 import java.util.List;
@@ -14,7 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @RunWith(Parameterized.class)
-public class AntibodySmokeTest extends AbstractSmokeTest {
+public class AntibodySmokeTest extends AbstractSecureSmokeTest {
 
     public AntibodySmokeTest(WebClient webClient) {
         super(webClient);
@@ -26,7 +26,7 @@ public class AntibodySmokeTest extends AbstractSmokeTest {
      */
     @Test
     public void testAntibodySearchPageOk() throws IOException {
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/antibody/search");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/antibody/search");
         assertEquals("ZFIN Antibody search", "ZFIN Antibody Search", page.getTitleText());
     }
 
@@ -37,7 +37,7 @@ public class AntibodySmokeTest extends AbstractSmokeTest {
     @Test
     public void testSearchZn1() throws IOException {
         String uri = "/action/antibody/antibody-do-search?antibodyCriteria.antibodyNameFilterType=contains&antibodyCriteria.name=zn1&maxDisplayRecords=25";
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + uri);
+        HtmlPage page = webClient.getPage(secureUrlDomain + uri);
         List<?> relatedTerms = page.getByXPath("//a[@id='zn-1']");
         assertEquals(1, relatedTerms.size());
         relatedTerms = page.getByXPath("//a[@id='zn-13']");
@@ -49,7 +49,7 @@ public class AntibodySmokeTest extends AbstractSmokeTest {
         // name
         String zdbID = "ZDB-ATB-081002-3";
         String uri = "/" + zdbID;
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + uri);
+        HtmlPage page = webClient.getPage(secureUrlDomain + uri);
         HtmlSpan markerId = (HtmlSpan) page.getElementById("marker-id");
         assertNotNull("find the ID on the page", markerId);
         assertTrue(markerId.getTextContent().contains(zdbID));
@@ -65,7 +65,7 @@ public class AntibodySmokeTest extends AbstractSmokeTest {
     @Test
     public void testSearchAb_2() throws IOException {
         String uri = "/action/antibody/antibody-do-search?antibodyCriteria.antibodyNameFilterType=contains&antibodyCriteria.name=ab-2&maxDisplayRecords=25";
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + uri);
+        HtmlPage page = webClient.getPage(secureUrlDomain + uri);
         List<?> relatedTerms = page.getByXPath("//a[@id='ab-2f11']");
         assertEquals(1, relatedTerms.size());
         HtmlAnchor link = (HtmlAnchor) relatedTerms.get(0);
@@ -80,7 +80,7 @@ public class AntibodySmokeTest extends AbstractSmokeTest {
         // nucleus
         String termID = "ZDB-TERM-091209-4086";
         String uri = "/action/antibody/antibody-do-search?antibodyCriteria.includeSubstructures=true&antibodyCriteria.anatomyTermNames=nuclear%20body&antibodyCriteria.anatomyTermIDs=" + termID + "&action=SEARCH";
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + uri);
+        HtmlPage page = webClient.getPage(secureUrlDomain + uri);
         List<?> relatedTerms = page.getByXPath("//a[@id='Ab-Pax7']");
         assertEquals(1, relatedTerms.size());
         HtmlAnchor link = (HtmlAnchor) relatedTerms.get(0);
@@ -95,7 +95,7 @@ public class AntibodySmokeTest extends AbstractSmokeTest {
     @Test
     public void testSearchZn5() throws IOException {
         String uri = "/action/antibody/antibody-do-search?antibodyCriteria.antibodyNameFilterType=contains&antibodyCriteria.name=zn5&maxDisplayRecords=25";
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + uri);
+        HtmlPage page = webClient.getPage(secureUrlDomain + uri);
         assertThat("Should have page title for detail page",
                 page.getTitleText(), is("ZFIN Antibody: zn-5"));
 
@@ -140,7 +140,7 @@ public class AntibodySmokeTest extends AbstractSmokeTest {
      */
     @Test
     public void testAntibodyFigureSummaryPageSupertermAllFigures() throws IOException {
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/antibody/antibody-figure-summary?antibodyID=ZDB-ATB-081017-1&superTermID=ZDB-TERM-100331-1053&subTermID=&startStageID=ZDB-STAGE-010723-10&endStageID=ZDB-STAGE-010723-10&figuresWithImg=false");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/antibody/antibody-figure-summary?antibodyID=ZDB-ATB-081017-1&superTermID=ZDB-TERM-100331-1053&subTermID=&startStageID=ZDB-STAGE-010723-10&endStageID=ZDB-STAGE-010723-10&figuresWithImg=false");
         assertEquals("Antibody figure summary page is not coming up", "ZFIN Antibody figure summary: Ab1-en", page.getTitleText());
         // check that Pub Zhou et al is present.
         assertNotNull(page.getElementById("ZDB-PUB-090407-2"));
@@ -151,7 +151,7 @@ public class AntibodySmokeTest extends AbstractSmokeTest {
      */
     @Test
     public void testAntibodyFigureSummaryPageSupertermAllFiguresNoStageInfo() throws IOException {
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/antibody/antibody-figure-summary?antibodyID=ZDB-ATB-081017-1&superTermID=ZDB-TERM-100331-1053&subTermID=&startStageID=ZDB-STAGE-010723-10&endStageID=ZDB-STAGE-010723-10");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/antibody/antibody-figure-summary?antibodyID=ZDB-ATB-081017-1&superTermID=ZDB-TERM-100331-1053&subTermID=&startStageID=ZDB-STAGE-010723-10&endStageID=ZDB-STAGE-010723-10");
         assertEquals("Antibody figure summary page is not coming up", "ZFIN Antibody figure summary: Ab1-en", page.getTitleText());
         // check that Pub Zhou et al is present.
         assertNotNull(page.getElementById("ZDB-PUB-090407-2"));
@@ -162,7 +162,7 @@ public class AntibodySmokeTest extends AbstractSmokeTest {
      */
     @Test
     public void testAntibodyFigureSummaryPageSupertermOnlyFiguresWithImages() throws IOException {
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/antibody/antibody-figure-summary?antibodyID=ZDB-ATB-081017-1&superTermID=ZDB-TERM-100331-1053&subTermID=&startStageID=ZDB-STAGE-010723-10&endStageID=ZDB-STAGE-010723-10&figuresWithImg=true");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/antibody/antibody-figure-summary?antibodyID=ZDB-ATB-081017-1&superTermID=ZDB-TERM-100331-1053&subTermID=&startStageID=ZDB-STAGE-010723-10&endStageID=ZDB-STAGE-010723-10&figuresWithImg=true");
         assertEquals("Antibody figure summary page is not coming up", "ZFIN Antibody figure summary: Ab1-en", page.getTitleText());
     }
 
@@ -171,7 +171,7 @@ public class AntibodySmokeTest extends AbstractSmokeTest {
      */
     @Test
     public void testAntibodyFigureSummaryPageSupertermSubtermFiguresWithImages() throws IOException {
-        HtmlPage page = webClient.getPage(nonSecureUrlDomain + "/action/antibody/antibody-figure-summary?antibodyID=ZDB-ATB-081017-1&superTermID=ZDB-TERM-100331-1053&subTermID=ZDB-TERM-091209-4086&startStageID=ZDB-STAGE-010723-10&endStageID=ZDB-STAGE-010723-10&figuresWithImg=false");
+        HtmlPage page = webClient.getPage(secureUrlDomain + "/action/antibody/antibody-figure-summary?antibodyID=ZDB-ATB-081017-1&superTermID=ZDB-TERM-100331-1053&subTermID=ZDB-TERM-091209-4086&startStageID=ZDB-STAGE-010723-10&endStageID=ZDB-STAGE-010723-10&figuresWithImg=false");
         assertEquals("Antibody search", "ZFIN Antibody figure summary: Ab1-en", page.getTitleText());
         // check that pub Liu et al is present.
         assertNotNull(page.getElementById("ZDB-PUB-091005-5"));


### PR DESCRIPTION
Anatomy and Antibody smoke tests now extend AbstractSecureSmokeTest to log in before each test. AbstractSecureSmokeTest creates a unique test user with BCrypt-encoded random password, proper Hibernate back-references, and cleans up the user after each test.