### PR TITLE
ZFIN-10106: Replace captcha boilerplate with @RequiresCaptcha interceptor

### DIFF
--- a/source/org/zfin/antibody/presentation/AntibodySearchController.java
+++ b/source/org/zfin/antibody/presentation/AntibodySearchController.java
@@ -17,8 +17,7 @@ import org.zfin.util.FilterType;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import java.util.Optional;
-import org.zfin.infrastructure.captcha.CaptchaService;
+import org.zfin.infrastructure.captcha.RequiresCaptcha;
 
 /**
  * This class serves the antibody search page.
@@ -60,15 +59,11 @@ public class AntibodySearchController {
     @Autowired
     HttpServletRequest request;
 
+    @RequiresCaptcha
     @RequestMapping(value = "/antibody-do-search", method = RequestMethod.GET)
     public String doSearch(Model model,
                            @Valid @ModelAttribute("formBean") AntibodySearchFormBean antibodySearchFormBean,
                            HttpServletRequest request) throws Exception {
-        Optional<String> captchaRedirectUrl = CaptchaService.getRedirectUrlIfNeeded(request);
-        if (captchaRedirectUrl.isPresent()) {
-            return "redirect:" + captchaRedirectUrl.get();
-        }
-
         AntibodySearchCriteria antibodySearchCriteria = antibodySearchFormBean.getAntibodyCriteria();
         antibodySearchCriteria.setPaginationBean(antibodySearchFormBean);
         model.addAttribute(LookupStrings.FORM_BEAN, antibodySearchFormBean);

--- a/source/org/zfin/expression/presentation/ExpressionSearchController.java
+++ b/source/org/zfin/expression/presentation/ExpressionSearchController.java
@@ -26,11 +26,10 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.SortedMap;
 import java.util.stream.Collectors;
 
-import org.zfin.infrastructure.captcha.CaptchaService;
+import org.zfin.infrastructure.captcha.RequiresCaptcha;
 
 @Controller
 @RequestMapping("/expression")
@@ -81,13 +80,9 @@ public class ExpressionSearchController {
     }
 
 
+    @RequiresCaptcha
     @RequestMapping("/results")
     public String results(Model model, @ModelAttribute("criteria") ExpressionSearchCriteria criteria, HttpServletRequest request) {
-        Optional<String> captchaRedirectUrl = CaptchaService.getRedirectUrlIfNeeded(request);
-        if (captchaRedirectUrl.isPresent()) {
-            return "redirect:" + captchaRedirectUrl.get();
-        }
-
         if (StringUtils.isNotEmpty(criteria.getGeneZdbID())) {
             criteria.setGene(markerRepository.getMarkerByID(criteria.getGeneZdbID()));
             populateFigureResults(criteria);

--- a/source/org/zfin/fish/presentation/FishSearchController.java
+++ b/source/org/zfin/fish/presentation/FishSearchController.java
@@ -23,9 +23,8 @@ import org.zfin.repository.RepositoryFactory;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import java.util.Optional;
 import java.util.Set;
-import org.zfin.infrastructure.captcha.CaptchaService;
+import org.zfin.infrastructure.captcha.RequiresCaptcha;
 
 /**
  * This class serves the antibody search page.
@@ -54,16 +53,12 @@ public class FishSearchController {
      * @param result   BindingResult
      * @return view page
      */
+    @RequiresCaptcha
     @RequestMapping(value = "/do-search", method = RequestMethod.GET)
     protected String search(Model model,
                             @Valid @ModelAttribute("formBean")
                             FishSearchFormBean formBean, BindingResult result,
                             HttpServletRequest request) {
-        Optional<String> captchaRedirectUrl = CaptchaService.getRedirectUrlIfNeeded(request);
-        if (captchaRedirectUrl.isPresent()) {
-            return "redirect:" + captchaRedirectUrl.get();
-        }
-
         //fishSearchFormValidator.validate(formBean, result);
 
         if (result.getErrorCount() > 0){

--- a/source/org/zfin/framework/ZfinWebConfigConfiguration.java
+++ b/source/org/zfin/framework/ZfinWebConfigConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.config.annotation.*;
+import org.zfin.infrastructure.captcha.CaptchaInterceptor;
 import org.zfin.wiki.presentation.PaginationArgumentResolver;
 
 import java.util.List;
@@ -76,7 +77,7 @@ public class ZfinWebConfigConfiguration implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry interceptorRegistry) {
-
+        interceptorRegistry.addInterceptor(new CaptchaInterceptor());
     }
 
     @Override

--- a/source/org/zfin/infrastructure/captcha/CaptchaInterceptor.java
+++ b/source/org/zfin/infrastructure/captcha/CaptchaInterceptor.java
@@ -1,0 +1,27 @@
+package org.zfin.infrastructure.captcha;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.Optional;
+
+public class CaptchaInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (!(handler instanceof HandlerMethod handlerMethod)) {
+            return true;
+        }
+        if (!handlerMethod.hasMethodAnnotation(RequiresCaptcha.class)) {
+            return true;
+        }
+        Optional<String> redirectUrl = CaptchaService.getRedirectUrlIfNeeded(request);
+        if (redirectUrl.isPresent()) {
+            response.sendRedirect(redirectUrl.get());
+            return false;
+        }
+        return true;
+    }
+}

--- a/source/org/zfin/nomenclature/presentation/NomenclatureSubmissionController.java
+++ b/source/org/zfin/nomenclature/presentation/NomenclatureSubmissionController.java
@@ -1,6 +1,5 @@
 package org.zfin.nomenclature.presentation;
 
-import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -17,7 +16,7 @@ import org.zfin.framework.presentation.LookupStrings;
 import org.zfin.gwt.root.dto.PublicationDTO;
 import org.zfin.gwt.root.server.DTOConversionService;
 import org.zfin.infrastructure.PublicationAttribution;
-import org.zfin.infrastructure.captcha.CaptchaService;
+import org.zfin.infrastructure.captcha.RequiresCaptcha;
 import org.zfin.infrastructure.seo.CanonicalLinkConfig;
 import org.zfin.marker.Marker;
 import org.zfin.marker.MarkerHistory;
@@ -71,13 +70,9 @@ public class NomenclatureSubmissionController {
         return "nomenclature/event-view";
     }
 
+    @RequiresCaptcha
     @RequestMapping(value = "/gene-name", method = RequestMethod.GET)
-    public String newGeneNameForm(Model model, HttpServletRequest request) {
-        //TODO: This would read better if it was an annotation on the method (eg. `@RequiresCaptcha`)
-        Optional<String> captchaRedirectUrl = CaptchaService.getRedirectUrlIfNeeded(request);
-        if (captchaRedirectUrl.isPresent()) {
-            return "redirect:" + captchaRedirectUrl.get();
-        }
+    public String newGeneNameForm(Model model) {
         GeneNameSubmission submission = new GeneNameSubmission();
         submission.setHomologyInfoList(Arrays.asList(new HomologyInfo()));
         model.addAttribute("submission", submission);
@@ -96,13 +91,9 @@ public class NomenclatureSubmissionController {
         return "nomenclature/gene-name-submit";
     }
 
+    @RequiresCaptcha
     @RequestMapping(value = "/line-name", method = RequestMethod.GET)
-    public String newLineNameForm(Model model, HttpServletRequest request) {
-        //TODO: This would read better if it was an annotation on the method (eg. `@RequiresCaptcha`)
-        Optional<String> captchaRedirectUrl = CaptchaService.getRedirectUrlIfNeeded(request);
-        if (captchaRedirectUrl.isPresent()) {
-            return "redirect:" + captchaRedirectUrl.get();
-        }
+    public String newLineNameForm(Model model) {
         LineNameSubmission submission = new LineNameSubmission();
         submission.setLineDetails(Arrays.asList(new LineInfo()));
         model.addAttribute("submission", submission);

--- a/source/org/zfin/ontology/presentation/OntologySearchController.java
+++ b/source/org/zfin/ontology/presentation/OntologySearchController.java
@@ -17,8 +17,7 @@ import org.zfin.ontology.Ontology;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
-import java.util.Optional;
-import org.zfin.infrastructure.captcha.CaptchaService;
+import org.zfin.infrastructure.captcha.RequiresCaptcha;
 
 /**
  * Action class that serves the anatomy search page.
@@ -35,29 +34,20 @@ public class OntologySearchController {
     @Autowired
     private AnatomyRepository anatomyRepository;
 
+    @RequiresCaptcha
     @RequestMapping("/search")
     protected String showSearchForm(Model model,
                                     AnatomySearchBean form,
                                     HttpServletRequest request) throws Exception {
-        Optional<String> captchaRedirectUrl = CaptchaService.getRedirectUrlIfNeeded(request);
-        if (captchaRedirectUrl.isPresent()) {
-            return "redirect:" + captchaRedirectUrl.get();
-        }
-
         model.addAttribute(LookupStrings.DYNAMIC_TITLE, "AO / GO Search");
         form.setOntologyName(Ontology.AOGODOCHEBI.getOntologyName());
         model.addAttribute("formBean", form);
         return "ontology/search-form";
     }
 
+    @RequiresCaptcha
     @RequestMapping(value = "/show-anatomy-terms-by-stage", method = RequestMethod.GET)
-    public String showAnatomyTermsByStage(@ModelAttribute("formBean") AnatomySearchBean anatomyForm,
-                                          HttpServletRequest request) throws Exception {
-        Optional<String> captchaRedirectUrl = CaptchaService.getRedirectUrlIfNeeded(request);
-        if (captchaRedirectUrl.isPresent()) {
-            return "redirect:" + captchaRedirectUrl.get();
-        }
-
+    public String showAnatomyTermsByStage(@ModelAttribute("formBean") AnatomySearchBean anatomyForm) throws Exception {
         LOG.debug("Start Action Class");
         doTermSearchByStage(anatomyForm);
         return "ontology/show-anatomy-terms-by-stage";

--- a/source/org/zfin/profile/presentation/OrganizationSubmissionController.java
+++ b/source/org/zfin/profile/presentation/OrganizationSubmissionController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.zfin.framework.mail.AbstractZfinMailSender;
 import org.zfin.infrastructure.captcha.CaptchaService;
+import org.zfin.infrastructure.captcha.RequiresCaptcha;
 import org.zfin.profile.OrganizationSubmission;
 import org.zfin.profile.PersonSubmission;
 import org.zfin.profile.repository.ProfileRepository;
@@ -28,14 +29,9 @@ public class OrganizationSubmissionController {
     @Autowired
     ProfileRepository profileRepository;
 
+    @RequiresCaptcha
     @RequestMapping(value = "/submit", method = RequestMethod.GET)
-    public String newPersonForm(Model model, HttpServletRequest request) {
-        //TODO: This would read better if it was an annotation on the method (eg. `@RequiresCaptcha`)
-        Optional<String> captchaRedirectUrl = CaptchaService.getRedirectUrlIfNeeded(request);
-        if (captchaRedirectUrl.isPresent()) {
-            return "redirect:" + captchaRedirectUrl.get();
-        }
-
+    public String newPersonForm(Model model) {
         OrganizationSubmission submission = new OrganizationSubmission();
         model.addAttribute("submission", submission);
 

--- a/source/org/zfin/profile/presentation/PersonSubmissionController.java
+++ b/source/org/zfin/profile/presentation/PersonSubmissionController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.zfin.framework.mail.AbstractZfinMailSender;
 
 import org.zfin.infrastructure.captcha.CaptchaService;
+import org.zfin.infrastructure.captcha.RequiresCaptcha;
 import org.zfin.profile.OrganizationPosition;
 import org.zfin.profile.PersonSubmission;
 import org.zfin.profile.repository.ProfileRepository;
@@ -35,14 +36,9 @@ public class PersonSubmissionController {
     @Autowired
     ProfileService profileService;
 
+    @RequiresCaptcha
     @RequestMapping(value = "/submit", method = RequestMethod.GET)
-    public String newPersonForm(Model model, HttpServletRequest request) {
-        //TODO: This would read better if it was an annotation on the method (eg. `@RequiresCaptcha`)
-        Optional<String> captchaRedirectUrl = CaptchaService.getRedirectUrlIfNeeded(request);
-        if (captchaRedirectUrl.isPresent()) {
-            return "redirect:" + captchaRedirectUrl.get();
-        }
-
+    public String newPersonForm(Model model) {
         List<OrganizationPosition> roleOptions = profileRepository.getLabPositions();
         model.addAttribute("roleOptions", roleOptions);
 

--- a/source/org/zfin/publication/presentation/PublicationSearchController.java
+++ b/source/org/zfin/publication/presentation/PublicationSearchController.java
@@ -22,7 +22,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import org.zfin.infrastructure.captcha.CaptchaService;
+import org.zfin.infrastructure.captcha.RequiresCaptcha;
 
 @Controller
 @RequestMapping("/publication")
@@ -43,15 +43,11 @@ public class PublicationSearchController {
     @Autowired
     private ProfileRepository profileRepository;
 
+    @RequiresCaptcha
     @RequestMapping(value = "/search", method = RequestMethod.GET)
     public String showSearchForm(Model model,
                                  @ModelAttribute PublicationSearchBean formBean,
                                  HttpServletRequest request) {
-        Optional<String> captchaRedirectUrl = CaptchaService.getRedirectUrlIfNeeded(request);
-        if (captchaRedirectUrl.isPresent()) {
-            return "redirect:" + captchaRedirectUrl.get();
-        }
-
         GregorianCalendar oldestPubEntryDate = publicationRepository.getOldestPubEntryDate();
         GregorianCalendar newestPubEntryDate = publicationRepository.getNewestPubEntryDate();
         setDefaultValue(formBean, "petFromMonth", oldestPubEntryDate.get(Calendar.MONTH) + 1);

--- a/source/org/zfin/publication/presentation/PublicationViewController.java
+++ b/source/org/zfin/publication/presentation/PublicationViewController.java
@@ -19,7 +19,7 @@ import org.zfin.figure.service.FigureViewService;
 import org.zfin.framework.ComparatorCreator;
 import org.zfin.framework.api.Pagination;
 import org.zfin.framework.presentation.*;
-import org.zfin.infrastructure.captcha.CaptchaService;
+import org.zfin.infrastructure.captcha.RequiresCaptcha;
 import org.zfin.infrastructure.repository.InfrastructureRepository;
 import org.zfin.infrastructure.seo.CanonicalLinkConfig;
 import org.zfin.marker.Clone;
@@ -551,6 +551,7 @@ PublicationViewController {
         return "publication/publication-directly-attributed";
     }
 
+    @RequiresCaptcha
     @RequestMapping("/{pubID}/all-figures")
     public String showAllFigures(@PathVariable String pubID,
                                  @RequestParam(value = "probeZdbID", required = false) String probeZdbID,
@@ -558,12 +559,6 @@ PublicationViewController {
                                  @ModelAttribute("pagination") PaginationBean pagination,
                                  HttpServletRequest request,
                                  Model model) {
-        //TODO: This would read better if it was an annotation on the method (eg. `@RequiresCaptcha`)
-        Optional<String> captchaRedirectUrl = CaptchaService.getRedirectUrlIfNeeded(request);
-        if (captchaRedirectUrl.isPresent()) {
-            return "redirect:" + captchaRedirectUrl.get();
-        }
-
         Publication publication = publicationRepository.getPublication(pubID);
 
         if (publication == null) {

--- a/source/org/zfin/search/presentation/MarkerSearchController.java
+++ b/source/org/zfin/search/presentation/MarkerSearchController.java
@@ -15,8 +15,7 @@ import org.zfin.search.service.MarkerSearchService;
 import org.zfin.util.URLCreator;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Optional;
-import org.zfin.infrastructure.captcha.CaptchaService;
+import org.zfin.infrastructure.captcha.RequiresCaptcha;
 
 
 /**
@@ -51,13 +50,9 @@ public class MarkerSearchController {
         return "search/marker-search-results";
     }
 
+    @RequiresCaptcha
     @RequestMapping(value = "/search-results")
     public String results(Model model, @ModelAttribute("criteria") MarkerSearchCriteria criteria, HttpServletRequest request) {
-        Optional<String> captchaRedirectUrl = CaptchaService.getRedirectUrlIfNeeded(request);
-        if (captchaRedirectUrl.isPresent()) {
-            return "redirect:" + captchaRedirectUrl.get();
-        }
-
         criteria.setBaseUrl(getBaseUrl(criteria, request));
         markerSearchService.injectFacets(criteria);
         model.addAttribute("criteria", markerSearchService.injectResults(criteria));

--- a/source/org/zfin/search/presentation/SearchPrototypeController.java
+++ b/source/org/zfin/search/presentation/SearchPrototypeController.java
@@ -23,7 +23,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 import org.zfin.framework.presentation.PaginationBean;
-import org.zfin.infrastructure.captcha.CaptchaService;
+import org.zfin.infrastructure.captcha.RequiresCaptcha;
 import org.zfin.infrastructure.service.ZdbIDService;
 import org.zfin.marker.Marker;
 import org.zfin.ontology.GenericTerm;
@@ -46,8 +46,6 @@ import static org.zfin.search.service.FacetBuilderService.categorySupportsSort;
 @Controller
 @RequestMapping("/quicksearch")
 public class SearchPrototypeController {
-
-    private static final boolean ENABLE_CAPTCHA = true;
 
     @Autowired
     private SolrService solrService;
@@ -92,6 +90,7 @@ public class SearchPrototypeController {
 
     private static final PolicyFactory POLICY = Sanitizers.FORMATTING.and(Sanitizers.LINKS);
 
+    @RequiresCaptcha
     @RequestMapping(value = "/prototype")
     public String viewResults(@RequestParam(value = "q", required = false) String q,
                               @RequestParam(value = "fq", required = false) String[] filterQuery,
@@ -105,12 +104,6 @@ public class SearchPrototypeController {
                               @RequestParam(required = false, defaultValue = "true") Boolean appendCategoryToBaseUrl,
                               Model model,
                               HttpServletRequest request) {
-        //TODO: This would read better if it was an annotation on the method (eg. `@RequiresCaptcha`)
-        Optional<String> captchaRedirectUrl = CaptchaService.getRedirectUrlIfNeeded(request);
-        if (captchaRedirectUrl.isPresent()) {
-            return "redirect:" + captchaRedirectUrl.get();
-        }
-
         if (page == null) {
             page = 1;
         }


### PR DESCRIPTION
Add CaptchaInterceptor that detects @RequiresCaptcha on handler methods and performs the captcha redirect check before the controller runs. This eliminates identical 4-line boilerplate from 13 methods across 11 controllers. The two POST handlers in PersonSubmission/OrganizationSubmission retain their non-standard captcha behavior unchanged.