### PR TITLE
ZFIN-10079: Feature detail page updates

### DIFF
--- a/source/org/zfin/gwt/curation/server/FeatureRPCServiceImpl.java
+++ b/source/org/zfin/gwt/curation/server/FeatureRPCServiceImpl.java
@@ -23,6 +23,7 @@ import org.zfin.gwt.root.ui.ValidationException;
 import org.zfin.gwt.root.util.NullpointerException;
 import org.zfin.infrastructure.*;
 import org.zfin.infrastructure.repository.InfrastructureRepository;
+import org.zfin.mapping.FeatureGenomeLocation;
 import org.zfin.mapping.FeatureLocation;
 import org.zfin.mapping.GenomicLocationService;
 import org.zfin.marker.Marker;
@@ -133,7 +134,7 @@ public class FeatureRPCServiceImpl extends RemoteServiceServlet implements Featu
         return null;
     }
 
-    private void updateFeatureLocation(FeatureLocation fl, FeatureDTO dto) {
+    private void updateFeatureLocation(FeatureLocation fl, FeatureDTO dto) throws ValidationException {
         // check if no value was submitted. If so then delete it
         if (StringUtils.isEmpty(dto.getFeatureChromosome()) &&
             StringUtils.isEmpty(dto.getFeatureAssembly()) &&
@@ -143,6 +144,14 @@ public class FeatureRPCServiceImpl extends RemoteServiceServlet implements Featu
             infrastructureRepository.deleteRecordAttribution(fl.getZdbID(), dto.getPublicationZdbID());
             HibernateUtil.currentSession().delete(fl);
             return;
+        }
+        // If the assembly is changing, only allow changing to GRCz12tu
+        String previousAssembly = fl.getAssembly();
+        String newAssembly = dto.getFeatureAssembly();
+        if (previousAssembly != null && newAssembly != null
+                && !previousAssembly.equals(newAssembly)
+                && !AssemblyEnum.GRCZ12TU.getName().equals(newAssembly)) {
+            throw new ValidationException("Assembly can only be changed to " + AssemblyEnum.GRCZ12TU.getName());
         }
         fl.setChromosome(dto.getFeatureChromosome());
         fl.setAssembly(dto.getFeatureAssembly());
@@ -272,6 +281,8 @@ public class FeatureRPCServiceImpl extends RemoteServiceServlet implements Featu
             }
 
             DTOConversionService.updateFeatureGenomicMutationDetailWithDTO(fgmd, featureDTO.getFgmdChangeDTO());
+            validateReferenceSequence(fgmd, fgl);
+
             if (fgmd.getZdbID() == null) {
                 HibernateUtil.currentSession().save(fgmd);
             }
@@ -970,6 +981,25 @@ public class FeatureRPCServiceImpl extends RemoteServiceServlet implements Featu
                 }
             }
         }
+
+        if (featureMarkerRelationship.getType().equals(FeatureMarkerRelationshipTypeEnum.IS_ALLELE_OF)) {
+            var linkageRepository = RepositoryFactory.getLinkageRepository();
+            TreeSet<String> featureChromosomes = new TreeSet<>();
+            List<FeatureGenomeLocation> featureLocations = linkageRepository.getGenomeLocation(featureMarkerRelationship.getFeature());
+            for (var loc : featureLocations) {
+                if (loc.getChromosome() != null) {
+                    featureChromosomes.add(loc.getChromosome());
+                }
+            }
+            TreeSet<String> markerChromosomes = linkageRepository.getChromosomeLocations(featureMarkerRelationship.getMarker());
+
+            if (!featureChromosomes.isEmpty() && !markerChromosomes.isEmpty()) {
+                featureChromosomes.retainAll(markerChromosomes);
+                if (featureChromosomes.isEmpty()) {
+                    throw new ValidationException("The feature and gene must be on the same chromosome for an 'is allele of' relationship.");
+                }
+            }
+        }
     }
 
     @Override
@@ -1180,6 +1210,42 @@ public class FeatureRPCServiceImpl extends RemoteServiceServlet implements Featu
             pubs.size(), pubs.size() == 1 ? "" : "s");
     }
 
+
+    @Override
+    public String getReferenceSequence(String assembly, String chromosome, int start, int end) {
+        AssemblyEnum assemblyEnum = null;
+        for (AssemblyEnum ae : AssemblyEnum.values()) {
+            if (ae.getName().equals(assembly)) {
+                assemblyEnum = ae;
+                break;
+            }
+        }
+        if (assemblyEnum == null) {
+            return null;
+        }
+        GenomicLocationService genomicLocationService = new GenomicLocationService();
+        return new String(genomicLocationService.getReferenceSequence(assemblyEnum, chromosome, start, end).getBases()).toUpperCase();
+    }
+
+    private void validateReferenceSequence(FeatureGenomicMutationDetail fgmd, FeatureLocation fgl) throws ValidationException {
+        if (StringUtils.isEmpty(fgmd.getFgmdSeqRef()) || fgl == null
+                || StringUtils.isEmpty(fgl.getAssembly())
+                || StringUtils.isEmpty(fgl.getChromosome())
+                || fgl.getStartLocation() == null || fgl.getEndLocation() == null) {
+            return;
+        }
+        GenomicLocationService glService = new GenomicLocationService();
+        for (AssemblyEnum ae : AssemblyEnum.values()) {
+            if (ae.getName().equals(fgl.getAssembly())) {
+                String expected = new String(glService.getReferenceSequence(ae, fgl.getChromosome(),
+                        fgl.getStartLocation(), fgl.getEndLocation()).getBases()).toUpperCase();
+                if (!expected.equals(fgmd.getFgmdSeqRef().toUpperCase())) {
+                    throw new ValidationException("Sequence of Reference does not match the auto-generated sequence from the genome assembly");
+                }
+                break;
+            }
+        }
+    }
 
     private class SupplierCacheThread extends Thread {
 

--- a/source/org/zfin/gwt/curation/ui/FeatureRPCService.java
+++ b/source/org/zfin/gwt/curation/ui/FeatureRPCService.java
@@ -93,4 +93,6 @@ public interface FeatureRPCService extends RemoteService {
     String isValidAccession(String accessionNumber, String type);
     String getWarningForDeleteRelationship(FeatureMarkerRelationshipDTO featureMarkerRelationshipDTO);
 
+    String getReferenceSequence(String assembly, String chromosome, int start, int end);
+
 }

--- a/source/org/zfin/gwt/curation/ui/FeatureRPCServiceAsync.java
+++ b/source/org/zfin/gwt/curation/ui/FeatureRPCServiceAsync.java
@@ -73,5 +73,7 @@ public interface FeatureRPCServiceAsync {
 
     void isValidAccession(String accessionNumber, String type, AsyncCallback<String> valid);
 
+    void getReferenceSequence(String assembly, String chromosome, int start, int end, AsyncCallback<String> async);
+
 }
 

--- a/source/org/zfin/gwt/curation/ui/FeatureValidationService.java
+++ b/source/org/zfin/gwt/curation/ui/FeatureValidationService.java
@@ -41,6 +41,20 @@ public class FeatureValidationService {
             return "You must specify a chromosome if you specify a location";
         }
 
+        if (featureDTO.getFgmdChangeDTO() != null && StringUtils.isNotEmpty(featureDTO.getFgmdChangeDTO().getFgmdSeqVar())) {
+            if (StringUtils.isEmptyTrim(featureDTO.getFeatureChromosome())
+                    || StringUtils.isEmptyTrim(featureDTO.getFeatureAssembly())
+                    || featureDTO.getFeatureStartLoc() == null
+                    || featureDTO.getFeatureEndLoc() == null
+                    || StringUtils.isEmptyTrim(featureDTO.getEvidence())) {
+                return "Chromosome, Assembly, Start Location, End Location, and Evidence Code are required when Sequence of Variant is specified";
+            }
+            if (StringUtils.isNotEmpty(featureDTO.getFgmdChangeDTO().getFgmdSeqRef())
+                    && featureDTO.getFgmdChangeDTO().getFgmdSeqVar().trim().equals(featureDTO.getFgmdChangeDTO().getFgmdSeqRef().trim())) {
+                return "Sequence of Variant cannot be the same as Sequence of Reference";
+            }
+        }
+
         if (StringUtils.isNotEmpty(featureDTO.getAssemblyInfoDate())) {
             if (featureDTO.getAssemblyInfoDate().length() != 8 || !(featureDTO.getAssemblyInfoDate().contains("/"))) {
                 return "Please enter date in mm/dd/yy format";

--- a/source/org/zfin/gwt/curation/ui/feature/AbstractFeaturePresenter.java
+++ b/source/org/zfin/gwt/curation/ui/feature/AbstractFeaturePresenter.java
@@ -188,6 +188,49 @@ public abstract class AbstractFeaturePresenter implements HandlesError {
 
     }
 
+    public void fetchReferenceSequenceIfReady() {
+        String featureType = view.featureTypeBox.getSelected();
+        if (featureType == null) return;
+
+        boolean needsRefSeq = featureType.equals(FeatureTypeEnum.DELETION.getName())
+                || featureType.equals(FeatureTypeEnum.POINT_MUTATION.getName())
+                || featureType.equals(FeatureTypeEnum.INDEL.getName())
+                || featureType.equals(FeatureTypeEnum.MNV.getName());
+        if (!needsRefSeq) return;
+
+        String chromosome = view.featureChromosome.getText();
+        String assembly = view.featureAssembly.getSelectedItemText();
+        Integer startLoc = view.featureStartLoc.getBoxValue();
+        Integer endLoc;
+        if (featureType.equals(FeatureTypeEnum.POINT_MUTATION.getName())) {
+            endLoc = startLoc;
+        } else {
+            endLoc = view.featureEndLoc.getBoxValue();
+        }
+
+        if (chromosome == null || chromosome.trim().isEmpty()) return;
+        if (assembly == null || assembly.trim().isEmpty()) return;
+        if (startLoc == null || endLoc == null) return;
+        if (!assembly.equals("GRCz11") && !assembly.equals("GRCz12tu")) return;
+
+        view.genomicMutationDetailView.setReferenceSequenceLoading();
+
+        FeatureRPCService.App.getInstance().getReferenceSequence(assembly, chromosome, startLoc, endLoc,
+                new FeatureEditCallBack<String>("Failed to fetch reference sequence", this) {
+                    @Override
+                    public void onSuccess(String result) {
+                        view.genomicMutationDetailView.setReferenceSequence(result);
+                    }
+
+                    @Override
+                    public void onFailure(Throwable throwable) {
+                        view.genomicMutationDetailView.setReferenceSequence("");
+                        super.onFailure(throwable);
+                    }
+                }
+        );
+    }
+
     public FeatureDTO createDTOFromGUI(AbstractFeatureView view) {
 
         FeatureDTO featureDTO = new FeatureDTO();
@@ -220,7 +263,11 @@ public abstract class AbstractFeaturePresenter implements HandlesError {
         featureDTO.setFeatureChromosome(view.featureChromosome.getText());
         featureDTO.setFeatureAssembly(view.featureAssembly.getSelectedItemText());
         featureDTO.setFeatureStartLoc(view.featureStartLoc.getBoxValue());
-        featureDTO.setFeatureEndLoc(view.featureEndLoc.getBoxValue());
+        if (featureTypeEnum == FeatureTypeEnum.POINT_MUTATION) {
+            featureDTO.setFeatureEndLoc(view.featureStartLoc.getBoxValue());
+        } else {
+            featureDTO.setFeatureEndLoc(view.featureEndLoc.getBoxValue());
+        }
 
         if (view.hasMutationDetails()) {
             featureDTO.setDnaChangeDTO(view.mutationDetailDnaView.getDto());

--- a/source/org/zfin/gwt/curation/ui/feature/AbstractFeatureView.java
+++ b/source/org/zfin/gwt/curation/ui/feature/AbstractFeatureView.java
@@ -353,7 +353,6 @@ public abstract class AbstractFeatureView extends Composite implements Revertibl
                 break;
             case POINT_MUTATION:
             case DELETION:
-            case SEQUENCE_VARIANT:
             case INSERTION:
                 // just uses the defaults
                 featureNameBox.setText("");
@@ -538,8 +537,7 @@ public abstract class AbstractFeatureView extends Composite implements Revertibl
         INSERTION,
         INDEL,
         MNV,
-        TRANSGENIC_INSERTION,
-        SEQUENCE_VARIANT;
+        TRANSGENIC_INSERTION;
 
         public static boolean hasFeatureType(String featureType, boolean knownInsertionSite) {
             for (MutationDetailType type : values()) {

--- a/source/org/zfin/gwt/curation/ui/feature/AbstractFeatureView.java
+++ b/source/org/zfin/gwt/curation/ui/feature/AbstractFeatureView.java
@@ -78,6 +78,18 @@ public abstract class AbstractFeatureView extends Composite implements Revertibl
     Label dnaChangeFirstColumn;
     @UiField
     Label variantInfoFirstColumn;
+    @UiField
+    HorizontalPanel endLocationPanel;
+    @UiField
+    Label chromosomeLabel;
+    @UiField
+    HorizontalPanel chromosomePanel;
+    @UiField
+    Label startLocationLabel;
+    @UiField
+    HTML startLocHint;
+    @UiField
+    HTML endLocHint;
 
     public AbstractFeatureView() {
     }
@@ -117,6 +129,9 @@ public abstract class AbstractFeatureView extends Composite implements Revertibl
             featureSuffixPanel.setVisible(true);
             featureSuffixPanel.setVisible(true);
         }
+        boolean showChromosome = knownInsertionCheckBox.getValue();
+        chromosomeLabel.setVisible(showChromosome);
+        chromosomePanel.setVisible(showChromosome);
         handleChanges();
     }
 
@@ -172,11 +187,13 @@ public abstract class AbstractFeatureView extends Composite implements Revertibl
     @UiHandler("featureChromosome")
     void onKeyUpChr(@SuppressWarnings("unused") KeyUpEvent event) {
         handleChanges();
+        presenter.fetchReferenceSequenceIfReady();
     }
 
     @UiHandler("featureChromosome")
     void onChangeChromosome(@SuppressWarnings("unused") ChangeEvent event) {
         handleChanges();
+        presenter.fetchReferenceSequenceIfReady();
     }
 
     @UiHandler("featureEvidenceCode")
@@ -188,16 +205,23 @@ public abstract class AbstractFeatureView extends Composite implements Revertibl
     @UiHandler("featureAssembly")
     void onChangeAssembly(@SuppressWarnings("unused") ChangeEvent event) {
         handleChanges();
+        presenter.fetchReferenceSequenceIfReady();
     }
 
     @UiHandler("featureStartLoc")
     void onChangeStartLocation(@SuppressWarnings("unused") ChangeEvent event) {
+        String featureType = featureTypeBox.getSelected();
+        if (featureType != null && featureType.equals(FeatureTypeEnum.POINT_MUTATION.getName())) {
+            featureEndLoc.setNumber(featureStartLoc.getBoxValue());
+        }
         handleChanges();
+        presenter.fetchReferenceSequenceIfReady();
     }
 
     @UiHandler("featureEndLoc")
     void onChangeEndLocation(@SuppressWarnings("unused") ChangeEvent event) {
         handleChanges();
+        presenter.fetchReferenceSequenceIfReady();
     }
 
 
@@ -212,6 +236,7 @@ public abstract class AbstractFeatureView extends Composite implements Revertibl
     @UiHandler("featureAssembly")
     void onKeyUpAssembly(@SuppressWarnings("unused") KeyUpEvent event) {
         handleChanges();
+        presenter.fetchReferenceSequenceIfReady();
     }
 
     /*@UiHandler("featureStartLoc")
@@ -358,6 +383,35 @@ public abstract class AbstractFeatureView extends Composite implements Revertibl
 
         }
 
+        boolean showChromosomeRow = featureTypeSelected == FeatureTypeEnum.POINT_MUTATION
+                || featureTypeSelected == FeatureTypeEnum.INSERTION
+                || featureTypeSelected == FeatureTypeEnum.INDEL
+                || featureTypeSelected == FeatureTypeEnum.DELETION
+                || (featureTypeSelected == FeatureTypeEnum.TRANSGENIC_INSERTION && knownInsertionCheckBox.getValue());
+        chromosomeLabel.setVisible(showChromosomeRow);
+        chromosomePanel.setVisible(showChromosomeRow);
+
+        boolean isPointMutation = featureTypeSelected == FeatureTypeEnum.POINT_MUTATION;
+        endLocationPanel.setVisible(!isPointMutation);
+        startLocationLabel.setText(isPointMutation ? "Location" : "Start Location");
+        if (isPointMutation) {
+            featureEndLoc.setNumber(featureStartLoc.getBoxValue());
+        }
+
+        boolean isDeletionOrIndel = featureTypeSelected == FeatureTypeEnum.DELETION
+                || featureTypeSelected == FeatureTypeEnum.INDEL;
+        boolean isInsertion = featureTypeSelected == FeatureTypeEnum.INSERTION;
+        boolean showLocHints = isDeletionOrIndel || isInsertion;
+        startLocHint.setVisible(showLocHints);
+        endLocHint.setVisible(showLocHints);
+        if (isDeletionOrIndel) {
+            startLocHint.setHTML("Position of<br/>1st nucleotide deleted");
+            endLocHint.setHTML("Position of<br/>last nucleotide deleted");
+        } else if (isInsertion) {
+            startLocHint.setHTML("Position of<br/>5' flanking nucleotide");
+            endLocHint.setHTML("Position of<br/>3' flanking nucleotide");
+        }
+
         presenter.updateMutagenOnFeatureTypeChange(featureTypeSelected);
     }
 
@@ -395,6 +449,12 @@ public abstract class AbstractFeatureView extends Composite implements Revertibl
         genomicMutationDetailView.resetGUI();
         knownInsertionCheckBox.setValue(false);
         featureSuffixPanel.setVisible(false);
+        chromosomeLabel.setVisible(true);
+        chromosomePanel.setVisible(true);
+        endLocationPanel.setVisible(true);
+        startLocationLabel.setText("Start Location");
+        startLocHint.setVisible(false);
+        endLocHint.setVisible(false);
         saveButton.setEnabled(false);
     }
 
@@ -510,9 +570,6 @@ public abstract class AbstractFeatureView extends Composite implements Revertibl
     void setFeatureAssemblyList() {
         featureAssembly.addItem("");
         featureAssembly.addItem("GRCz12tu");
-        featureAssembly.addItem("GRCz11");
-        featureAssembly.addItem("GRCz10");
-        featureAssembly.addItem("Zv9");
     }
 
 

--- a/source/org/zfin/gwt/curation/ui/feature/EditMutationDetailPresenter.java
+++ b/source/org/zfin/gwt/curation/ui/feature/EditMutationDetailPresenter.java
@@ -45,7 +45,6 @@ public class EditMutationDetailPresenter extends MutationDetailPresenter {
         } else {
 
             col.addBoolean(genMutView.seqVariant.isDirty(fgmdChangeDTO.getFgmdSeqVar()));
-            col.addBoolean(genMutView.seqReference.isDirty(fgmdChangeDTO.getFgmdSeqRef()));
         }
 
         MutationDetailDNAView mutationDetailDnaView = view.mutationDetailDnaView;

--- a/source/org/zfin/gwt/curation/ui/feature/FeatureAddView.ui.xml
+++ b/source/org/zfin/gwt/curation/ui/feature/FeatureAddView.ui.xml
@@ -46,7 +46,7 @@
             <g:Label text=":&nbsp;" addStyleNames="bold"/>
             <zfin:ShowHideToggle widget="{featureConstructionPanel}" ui:field="showHideToggle" show="false"/>
         </g:HorizontalPanel>
-        <g:Grid ui:field="featureConstructionPanel" styleName="{style.grey-background}" visible="false">
+        <g:Grid ui:field="featureConstructionPanel" styleName="{style.grey-background}" visible="false" width="100%">
             <g:row>
                 <g:cell styleName="{style.grey-background}">Feature Type</g:cell>
                 <g:customCell>
@@ -120,9 +120,11 @@
             </g:row>
             <g:row>
 
-                    <g:cell styleName="{style.grey-background}">Chromosome</g:cell>
+                    <g:customCell styleName="{style.grey-background}">
+                        <g:Label ui:field="chromosomeLabel" text="Chromosome"/>
+                    </g:customCell>
                 <g:customCell>
-                    <g:HorizontalPanel>
+                    <g:HorizontalPanel ui:field="chromosomePanel">
 
                     <zfin:StringTextBox ui:field="featureChromosome" visibleLength="5"/>
 
@@ -130,13 +132,20 @@
 
 
                         <zfin:StringListBox ui:field="featureAssembly"/>
-                    <g:Label text="Start Location" />
+                    <g:Label text="Start Location" ui:field="startLocationLabel"/>
 
-                    <zfin:NumberTextBox ui:field="featureStartLoc" visibleLength="13"/>
+                    <g:FlowPanel>
+                        <zfin:NumberTextBox ui:field="featureStartLoc" visibleLength="13"/>
+                        <g:HTML ui:field="startLocHint" visible="false" styleName="{style.grey-text}"/>
+                    </g:FlowPanel>
 
-                    <g:Label text="End Location"/>
-
-                    <zfin:NumberTextBox ui:field="featureEndLoc" visibleLength="13"/>
+                    <g:HorizontalPanel ui:field="endLocationPanel">
+                        <g:Label text="End Location"/>
+                        <g:FlowPanel>
+                            <zfin:NumberTextBox ui:field="featureEndLoc" visibleLength="13"/>
+                            <g:HTML ui:field="endLocHint" visible="false" styleName="{style.grey-text}"/>
+                        </g:FlowPanel>
+                    </g:HorizontalPanel>
                         <g:Label text="EvidenceCode"/>
                         <zfin:StringListBox ui:field="featureEvidenceCode"/>
 
@@ -149,8 +158,7 @@
                 </g:customCell>
                 <g:customCell>
 
-                    <g:HTML ui:field="noMutationDetailMessage" styleName="{style.grey-text}">Only for feature type:
-                        Point Mutation, Insertion, Indel ,Unknown, Deletion and Transgenic Insertion with known insertion site</g:HTML>
+                    <g:HTML ui:field="noMutationDetailMessage" styleName="{style.grey-text}"/>
                 </g:customCell>
             </g:row>
             <g:row>

--- a/source/org/zfin/gwt/curation/ui/feature/FeatureEditPresenter.java
+++ b/source/org/zfin/gwt/curation/ui/feature/FeatureEditPresenter.java
@@ -106,7 +106,6 @@ public class FeatureEditPresenter extends AbstractFeaturePresenter {
                 featureDTO.setPublicationZdbID(publicationID);
                 dto = featureDTO;
                 mutationDetailPresenter.setDto(featureDTO);
-                view.onChangeFeatureType();
                 revertGUI();
                 view.removeFeatureLink.setUrl("/action/infrastructure/deleteRecord/" + dto.getZdbID());
                 view.removeFeatureLink.setTitle("Delete Feature " + dto.getZdbID());
@@ -208,7 +207,11 @@ public class FeatureEditPresenter extends AbstractFeaturePresenter {
         view.assemblyInfoDate.setText(dto.getAssemblyInfoDate());
         featureNotesPresenter.setFeatureDTO(dto);
         featureNotesPresenter.rebuildGUI();
-        view.featureNameBox.setText(FeatureValidationService.getNameFromFullName(dto));
+        String nameForBox = FeatureValidationService.getNameFromFullName(dto);
+        if ((nameForBox == null || nameForBox.isEmpty()) && dto.getFeatureType() == FeatureTypeEnum.TRANSGENIC_INSERTION) {
+            nameForBox = dto.getName();
+        }
+        view.featureNameBox.setText(nameForBox);
         view.labOfOriginBox.setIndexForValue(dto.getLabOfOrigin());
         String selectedLab =  view.labOfOriginBox.getSelectedText();
         if (selectedLab != null)
@@ -225,6 +228,8 @@ public class FeatureEditPresenter extends AbstractFeaturePresenter {
         mutationDetailPresenter.setDtoSet(dto.getTranscriptChangeDTOSet());
         view.genomicMutationDetailView.populateFields(dto.getFgmdChangeDTO(),dto.getFeatureType(),dto.getKnownInsertionSite());
 
+        // Recalculate dirty state after all fields are populated
+        handleDirty();
     }
 
 

--- a/source/org/zfin/gwt/curation/ui/feature/FeatureEditView.java
+++ b/source/org/zfin/gwt/curation/ui/feature/FeatureEditView.java
@@ -141,5 +141,12 @@ public class FeatureEditView extends AbstractFeatureView implements Revertible {
         removeFeatureLink.setVisible(true);
     }
 
+    @Override
+    void setFeatureAssemblyList() {
+        super.setFeatureAssemblyList();
+        featureAssembly.addItem("GRCz11");
+        featureAssembly.addItem("GRCz10");
+        featureAssembly.addItem("Zv9");
+    }
 
 }

--- a/source/org/zfin/gwt/curation/ui/feature/FeatureEditView.ui.xml
+++ b/source/org/zfin/gwt/curation/ui/feature/FeatureEditView.ui.xml
@@ -43,7 +43,7 @@
             <g:Label text=":&nbsp;" addStyleNames="bold"/>
             <zfin:ShowHideToggle widget="{featureConstructionPanel}" ui:field="showHideToggle" show="false"/>
         </g:HorizontalPanel>
-        <g:Grid ui:field="featureConstructionPanel" styleName="{style.grey-background}">
+        <g:Grid ui:field="featureConstructionPanel" styleName="{style.grey-background}" width="100%">
             <g:row>
                 <g:cell>Feature Name/Abbrev</g:cell>
                 <g:customCell>
@@ -126,22 +126,31 @@
             </g:row>
             <g:row>
 
-                <g:cell styleName="{style.grey-background}">Chromosome</g:cell>
+                <g:customCell styleName="{style.grey-background}">
+                    <g:Label ui:field="chromosomeLabel" text="Chromosome"/>
+                </g:customCell>
                 <g:customCell>
-                    <g:HorizontalPanel>
+                    <g:HorizontalPanel ui:field="chromosomePanel">
 
                         <zfin:StringTextBox ui:field="featureChromosome" visibleLength="5"/>
 
                         <g:Label text="Assembly"/>
 
                         <zfin:StringListBox ui:field="featureAssembly"/>
-                        <g:Label text="Start Location" />
+                        <g:Label text="Start Location" ui:field="startLocationLabel"/>
 
-                        <zfin:NumberTextBox ui:field="featureStartLoc" visibleLength="13"/>
+                        <g:FlowPanel>
+                            <zfin:NumberTextBox ui:field="featureStartLoc" visibleLength="13"/>
+                            <g:HTML ui:field="startLocHint" visible="false" styleName="{style.grey-text}"/>
+                        </g:FlowPanel>
 
-                        <g:Label text="End Location"/>
-
-                        <zfin:NumberTextBox ui:field="featureEndLoc" visibleLength="13"/>
+                        <g:HorizontalPanel ui:field="endLocationPanel">
+                            <g:Label text="End Location"/>
+                            <g:FlowPanel>
+                                <zfin:NumberTextBox ui:field="featureEndLoc" visibleLength="13"/>
+                                <g:HTML ui:field="endLocHint" visible="false" styleName="{style.grey-text}"/>
+                            </g:FlowPanel>
+                        </g:HorizontalPanel>
                         <g:Label text="EvidenceCode"/>
                         <zfin:StringListBox ui:field="featureEvidenceCode"/>
 
@@ -153,8 +162,7 @@
                     <g:Label text="Mutation Detail"/>
                 </g:customCell>
                 <g:customCell>
-                    <g:HTML ui:field="noMutationDetailMessage" styleName="{style.grey-text}">Only for feature type:
-                        Point Mutation, Insertion, Indel , Deletion, Unknown and Transgenic Insertion with known insertion site</g:HTML>
+                    <g:HTML ui:field="noMutationDetailMessage" styleName="{style.grey-text}"/>
                 </g:customCell>
             </g:row>
             <g:row>

--- a/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.java
+++ b/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.java
@@ -8,10 +8,7 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.uibinder.client.UiTemplate;
-import com.google.gwt.user.client.ui.Button;
-import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.Grid;
-import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.*;
 
 import org.zfin.gwt.curation.ui.AbstractViewComposite;
 import org.zfin.gwt.root.dto.FeatureGenomeMutationDetailChangeDTO;
@@ -39,15 +36,17 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
     @UiField
     FlowPanel changePanel;
     @UiField
-    StringTextBox seqReference;
+    TextArea seqReference;
     @UiField
     StringTextBox seqVariant;
-    @UiField
-    Button reverseComplRefButton;
     @UiField
     Button reverseComplVarButton;
     @UiField
     TableRowElement sequenceOfReferenceRow;
+    @UiField
+    TableRowElement sequenceOfReferenceSmallRow;
+    @UiField
+    TextBox seqReferenceSmall;
     @UiField
     TableRowElement sequenceOfVariantRow;
 
@@ -55,20 +54,6 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
         initWidget(uiBinder.createAndBindUi(this));
     }
 
-
-    @UiHandler("seqReference")
-    void onKeyDownseqRef(@SuppressWarnings("unused") KeyDownEvent event) {
-        if (event.getNativeKeyCode() == KeyCodes.KEY_ENTER)
-
-            seqReference.setText(seqReference.getText().toUpperCase());
-
-        handleChanges();
-
-    }
-    @UiHandler("seqReference")
-    void onKeyChangeSeqReference(@SuppressWarnings("unused") KeyUpEvent event) {
-        handleChanges();
-    }
 
     @UiHandler("seqVariant")
     void onKeyDownseqVar(@SuppressWarnings("unused") KeyDownEvent event) {
@@ -82,14 +67,6 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
     @UiHandler("seqVariant")
     void onKeyChangeSeqVar(@SuppressWarnings("unused") KeyUpEvent event) {
         handleChanges();
-    }
-
-    @UiHandler("reverseComplRefButton")
-    void onClickComplRefButton(@SuppressWarnings("unused") ClickEvent event) {
-
-        seqReference.setText(reverseComplement(seqReference.getText().toUpperCase()));
-
-
     }
 
     @UiHandler("reverseComplVarButton")
@@ -131,13 +108,25 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
         row.getStyle().setDisplay(show ? Style.Display.TABLE_ROW : Style.Display.NONE);
     }
 
+    private String getRefSeqText() {
+        boolean smallVisible = sequenceOfReferenceSmallRow.getStyle().getDisplay().equals(Style.Display.TABLE_ROW.getCssName());
+        if (smallVisible) {
+            return seqReferenceSmall.getText();
+        }
+        return seqReference.getText();
+    }
+
     public FeatureGenomeMutationDetailChangeDTO getDto() {
-        if (!hasEnteredValues())
+        String currentRefText = getRefSeqText();
+        boolean hasRefSeq = currentRefText != null && !currentRefText.trim().isEmpty();
+        if (!hasEnteredValues() && !hasRefSeq)
             return null;
         FeatureGenomeMutationDetailChangeDTO dto = new FeatureGenomeMutationDetailChangeDTO();
 
-        dto.setFgmdSeqRef(seqReference.getBoxValue());
-        dto.setFgmdSeqVar(seqVariant.getBoxValue());
+        String refText = currentRefText;
+        dto.setFgmdSeqRef(refText != null ? refText.toUpperCase() : null);
+        String varText = seqVariant.getBoxValue();
+        dto.setFgmdSeqVar(varText != null ? varText.toUpperCase() : null);
 
         return dto;
     }
@@ -146,7 +135,7 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
         switch (type) {
             case POINT_MUTATION:
 
-                    showBoth();
+                    showBothPointMutation();
 
                 break;
             case INSERTION:
@@ -179,7 +168,8 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
 
     public void resetGUI() {
 
-        seqReference.clear();
+        seqReference.setText("");
+        seqReferenceSmall.setText("");
         seqVariant.clear();
 
         clearError();
@@ -188,7 +178,6 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
     public Set<IsDirtyWidget> getValueFields() {
         Set<IsDirtyWidget> fields = new HashSet<>();
 
-        fields.add(seqReference);
         fields.add(seqVariant);
 
         return fields;
@@ -197,6 +186,7 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
     public void showVariantSeq() {
 
         showRow(sequenceOfReferenceRow, false);
+        showRow(sequenceOfReferenceSmallRow, false);
         showRow(sequenceOfVariantRow, true);
 
     }
@@ -204,6 +194,7 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
     public void showReferenceSeq() {
 
         showRow(sequenceOfVariantRow, false);
+        showRow(sequenceOfReferenceSmallRow, false);
         showRow(sequenceOfReferenceRow, true);
 
     }
@@ -211,7 +202,16 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
     public void showBoth() {
 
         showRow(sequenceOfVariantRow, true);
+        showRow(sequenceOfReferenceSmallRow, false);
         showRow(sequenceOfReferenceRow, true);
+
+    }
+
+    public void showBothPointMutation() {
+
+        showRow(sequenceOfVariantRow, true);
+        showRow(sequenceOfReferenceRow, false);
+        showRow(sequenceOfReferenceSmallRow, true);
 
     }
 
@@ -219,22 +219,36 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
 
         showRow(sequenceOfVariantRow, false);
         showRow(sequenceOfReferenceRow, false);
+        showRow(sequenceOfReferenceSmallRow, false);
 
     }
 
 
+    public void setReferenceSequence(String seq) {
+        String value = seq != null ? seq : "";
+        seqReference.setText(value);
+        seqReferenceSmall.setText(value);
+    }
+
+    public void setReferenceSequenceLoading() {
+        seqReference.setText("Loading...");
+        seqReferenceSmall.setText("Loading...");
+    }
+
     public void populateFields(FeatureGenomeMutationDetailChangeDTO dto, FeatureTypeEnum type, Boolean knownInsSite) {
         if (dto == null) {
-            seqReference.clear();
+            seqReference.setText("");
+            seqReferenceSmall.setText("");
             seqVariant.clear();
             return;
         }
         seqReference.setText(dto.getFgmdSeqRef());
+        seqReferenceSmall.setText(dto.getFgmdSeqRef() != null ? dto.getFgmdSeqRef() : "");
         seqVariant.setText(dto.getFgmdSeqVar());
         switch (type) {
             case POINT_MUTATION:
 
-                showBoth();
+                showBothPointMutation();
 
                 break;
             case INSERTION:

--- a/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.java
+++ b/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.java
@@ -154,9 +154,6 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
                     showTgFields();
                 }
                 break;
-            case SEQUENCE_VARIANT:
-                showTgFields();
-                break;
             case INDEL:
                 showBoth();
                 break;
@@ -266,9 +263,6 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
                 else{
                     showTgFields();
                 }
-                break;
-            case SEQUENCE_VARIANT:
-                showTgFields();
                 break;
             case INDEL:
                 showBoth();

--- a/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.ui.xml
+++ b/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.ui.xml
@@ -33,10 +33,30 @@
         .green {
             color: green;
         }
+
+        .uppercase {
+            text-transform: uppercase;
+        }
+
+        @external .seq-detail-table;
+        .seq-detail-table {
+            width: 100%;
+        }
+
+        @external .seq-label-column;
+        .seq-label-column {
+            width: 40%;
+        }
+
+        @external .seq-textarea;
+        .seq-textarea {
+            width: 100%;
+        }
+
     </ui:style>
 
     <g:FlowPanel ui:field="changePanel" visible="false">
-        <g:Grid ui:field='genomicDetailsTable' cellSpacing='2' styleName="searchresults groupstripes-hover">
+        <g:Grid ui:field='genomicDetailsTable' cellSpacing='2' styleName="searchresults groupstripes-hover" width="100%">
             <!--<g:row>
                 <g:cell>Change</g:cell>
                 <g:cell>Position</g:cell>
@@ -52,20 +72,20 @@
             <g:row visible="false">
                 <g:customCell>
                     <g:HTMLPanel visible="true">
-                        <table>
-                            <tr ui:field="sequenceMessage">
-                                <td><i>Please enter data from the + strand</i>
-                                </td>
-                            </tr>
+                        <table class="{style.seq-detail-table}">
                             <tr ui:field="sequenceOfReferenceRow">
-                                <td>Sequence of  Reference</td>
-                                <td><zfin:StringTextBox ui:field="seqReference" /></td>
-                                <td><g:Button ui:field="reverseComplRefButton" text="Reverse Complement" /></td>
+                                <td class="{style.seq-label-column}">Sequence of Reference (auto-generated)</td>
+                                <td colspan="2"><g:TextArea ui:field="seqReference" readOnly="true" addStyleNames="{style.uppercase} {style.seq-textarea}"/></td>
+                            </tr>
+
+                            <tr ui:field="sequenceOfReferenceSmallRow">
+                                <td class="{style.seq-label-column}">Sequence of Reference (auto-generated)</td>
+                                <td colspan="2"><g:TextBox ui:field="seqReferenceSmall" readOnly="true" addStyleNames="{style.uppercase}"/></td>
                             </tr>
 
                             <tr ui:field="sequenceOfVariantRow">
-                                <td>Sequence of Variant</td>
-                                <td><zfin:StringTextBox ui:field="seqVariant" /></td>
+                                <td class="{style.seq-label-column}">Sequence of Variant<br/><i>Please enter data from the + strand</i></td>
+                                <td><zfin:StringTextBox ui:field="seqVariant" addStyleNames="{style.uppercase}"/></td>
                                 <td><g:Button ui:field="reverseComplVarButton" text="Reverse Complement" /></td>
                             </tr>
                         </table>

--- a/source/org/zfin/gwt/curation/ui/feature/MutationDetailDNAView.java
+++ b/source/org/zfin/gwt/curation/ui/feature/MutationDetailDNAView.java
@@ -291,9 +291,6 @@ public class MutationDetailDNAView extends AbstractViewComposite {
             case TRANSGENIC_INSERTION:
                 showTgFields();
                 break;
-            case SEQUENCE_VARIANT:
-                showTgFields();
-                break;
         }
     }
 

--- a/source/org/zfin/gwt/curation/ui/feature/MutationDetailDNAView.java
+++ b/source/org/zfin/gwt/curation/ui/feature/MutationDetailDNAView.java
@@ -48,6 +48,12 @@ public class MutationDetailDNAView extends AbstractViewComposite {
     @UiField
     NumberTextBox positionEnd;
     @UiField
+    Label changeLabel;
+    @UiField
+    Label positionLabel;
+    @UiField
+    Label accessionLabel;
+    @UiField
     Label exonLabel;
     @UiField
     Label intronLabel;
@@ -153,15 +159,23 @@ public class MutationDetailDNAView extends AbstractViewComposite {
                 localizationTerm.getSelected().equals(THREE_PRIME_SPLICE)) {
             WidgetUtil.showHideBoxField(intronNumber, true);
             WidgetUtil.showHideBoxField(exonNumber, true);
+            intronLabel.setVisible(true);
+            exonLabel.setVisible(true);
         } else if (localizationTerm.getSelected().equals(EXON)) {
             WidgetUtil.showHideBoxField(intronNumber, false);
             WidgetUtil.showHideBoxField(exonNumber, true);
+            intronLabel.setVisible(false);
+            exonLabel.setVisible(true);
         } else if (localizationTerm.getSelected().equals(INTRON)) {
             WidgetUtil.showHideBoxField(intronNumber, true);
             WidgetUtil.showHideBoxField(exonNumber, false);
+            intronLabel.setVisible(true);
+            exonLabel.setVisible(false);
         } else {
             WidgetUtil.showHideBoxField(intronNumber, false);
             WidgetUtil.showHideBoxField(exonNumber, false);
+            intronLabel.setVisible(false);
+            exonLabel.setVisible(false);
         }
         handleChanges();
     }
@@ -172,6 +186,9 @@ public class MutationDetailDNAView extends AbstractViewComposite {
         //0showRow(insertionSequenceRow, false);
         showRow(deletionLengthRow, false);
         //showRow(deletionSequenceRow, false);
+        changeLabel.setVisible(true);
+        positionLabel.setVisible(true);
+        accessionLabel.setVisible(true);
         positionStart.setVisible(true);
         positionDash.setVisible(false);
         positionEnd.setVisible(false);
@@ -183,6 +200,7 @@ public class MutationDetailDNAView extends AbstractViewComposite {
         //showRow(insertionSequenceRow, true);
         showRow(deletionLengthRow, false);
         //showRow(deletionSequenceRow, false);
+        changeLabel.setVisible(true);
         showHideBaseFields(true);
     }
 
@@ -192,6 +210,7 @@ public class MutationDetailDNAView extends AbstractViewComposite {
         //showRow(insertionSequenceRow, false);
         showRow(deletionLengthRow, true);
         //showRow(deletionSequenceRow, true);
+        changeLabel.setVisible(true);
         showHideBaseFields(true);
     }
 
@@ -201,6 +220,7 @@ public class MutationDetailDNAView extends AbstractViewComposite {
         //showRow(insertionSequenceRow, true);
         showRow(deletionLengthRow, true);
         //showRow(deletionSequenceRow, true);
+        changeLabel.setVisible(true);
         showHideBaseFields(true);
     }
 
@@ -210,6 +230,9 @@ public class MutationDetailDNAView extends AbstractViewComposite {
         //showRow(insertionSequenceRow, false);
         showRow(deletionLengthRow, false);
         //showRow(deletionSequenceRow, false);
+        changeLabel.setVisible(false);
+        exonLabel.setVisible(false);
+        intronLabel.setVisible(false);
         showHideBaseFields(false);
     }
 
@@ -217,7 +240,9 @@ public class MutationDetailDNAView extends AbstractViewComposite {
         positionStart.setVisible(show);
         positionEnd.setVisible(show);
         positionDash.setVisible(show);
+        positionLabel.setVisible(show);
         zfinAccessionBox.setVisible(show);
+        accessionLabel.setVisible(show);
     }
 
     private void showRow(TableRowElement row, boolean show) {

--- a/source/org/zfin/gwt/curation/ui/feature/MutationDetailDNAView.ui.xml
+++ b/source/org/zfin/gwt/curation/ui/feature/MutationDetailDNAView.ui.xml
@@ -38,9 +38,15 @@
     <g:FlowPanel ui:field="changePanel" visible="false">
         <g:Grid ui:field='dnaDataTable' cellSpacing='2' styleName="searchresults groupstripes-hover">
             <g:row>
-                <g:cell>Change</g:cell>
-                <g:cell>Position</g:cell>
-                <g:cell>Accession #</g:cell>
+                <g:customCell>
+                    <g:Label text="Change" ui:field="changeLabel"/>
+                </g:customCell>
+                <g:customCell>
+                    <g:Label text="Position" ui:field="positionLabel"/>
+                </g:customCell>
+                <g:customCell>
+                    <g:Label text="Accession #" ui:field="accessionLabel"/>
+                </g:customCell>
                 <g:cell>Localization</g:cell>
                 <g:customCell>
                     <g:Label text="Exon" ui:field="exonLabel"/>


### PR DESCRIPTION
**Feature validation and backend logic:**

* Added a backend validation to ensure that for an 'is allele of' relationship, the feature and gene must be on the same chromosome. If not, a validation exception is thrown.
* Introduced a new RPC method `getReferenceSequence` in `FeatureRPCServiceImpl` to fetch the reference sequence for a given assembly, chromosome, and location range. 
* Enhanced feature validation to require Chromosome, Assembly, Start/End Location, and Evidence Code when a Sequence of Variant is specified, and to prevent the Sequence of Variant from being identical to the Sequence of Reference.

**UI/UX improvements for feature curation:**

* The UI now automatically fetches and displays the reference sequence when all required fields are populated for relevant feature types (deletion, point mutation, indel, MNV), providing immediate feedback to the curator.
* The chromosome, assembly, and location fields dynamically update their visibility and labels based on the selected feature type, and location hints are shown contextually for deletions, indels, and insertions.
* For point mutations, the end location is automatically set to match the start location, both in the DTO and in the UI. 

**UI code and layout updates:**

* Refactored UI XML files to use `chromosomeLabel`, `chromosomePanel`, `startLocationLabel`, `endLocationPanel`, and contextual HTML hints.
* Updated `GenomicMutationDetailView` to use a `TextArea` for the sequence of reference, replacing the previous `StringTextBox`, to better support longer sequences.

**Minor code and logic improvements:**

* Removed an unnecessary dirty-check on the reference sequence in `EditMutationDetailPresenter`.
* Improved import statements and minor code cleanup.

These changes collectively enhance the accuracy, usability, and robustness of the feature curation workflow.