### PR TITLE
ZFIN-10116: Universal CSV download for search results using injected …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -915,6 +915,7 @@ dependencies {
     implementation "org.jdom:jdom:1.1"
     implementation "org.jooq:jool:0.9.15"
     implementation "org.json:json:20240303"
+    implementation "org.jsoup:jsoup:1.18.3"
     implementation "org.jvnet.staxex:stax-ex:1.8"
     implementation "org.liquibase:liquibase-core:4.30.0"
     implementation "org.nocrala.tools.texttablefmt:text-table-formatter:1.2.4"

--- a/source/org/zfin/search/presentation/SearchPrototypeController.java
+++ b/source/org/zfin/search/presentation/SearchPrototypeController.java
@@ -4,7 +4,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.Predicate;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
@@ -610,8 +609,8 @@ public class SearchPrototypeController {
             }
         }
 
-        response.setContentType("data:text/csv;charset=utf-8");
-        response.setHeader("Content-Disposition", "attachment; filename=\"zfin_search_results.csv\"");
+        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        response.setHeader("Content-Disposition", "attachment; filename=\"zfin_search_results.xlsx\"");
 
         SolrQuery query = new SolrQuery();
 
@@ -643,18 +642,7 @@ public class SearchPrototypeController {
             QueryResponse queryResponse = client.query(query);
             List<SearchResult> results = queryResponse.getBeans(SearchResult.class);
 
-            InputStream csvStream = solrService.buildUniversalCsv(results, resultService);
-            BufferedReader in = new BufferedReader(new InputStreamReader(csvStream));
-
-            OutputStreamWriter out = new OutputStreamWriter(
-                    new BufferedOutputStream(
-                            response.getOutputStream()));
-
-            IOUtils.copy(in, out);
-
-            in.close();
-            out.flush();
-            out.close();
+            solrService.buildUniversalXlsx(results, resultService, response.getOutputStream());
 
         } catch (Exception e) {
             logger.error(e);

--- a/source/org/zfin/search/presentation/SearchPrototypeController.java
+++ b/source/org/zfin/search/presentation/SearchPrototypeController.java
@@ -634,22 +634,14 @@ public class SearchPrototypeController {
             }
         }
 
-        query.setRows(Integer.MAX_VALUE);
-
         handleRootOnlyResults(query);
 
         try {
-            SolrClient client = SolrService.getSolrClient();
-            QueryResponse queryResponse = client.query(query);
-            List<SearchResult> results = queryResponse.getBeans(SearchResult.class);
+            Writer out = new OutputStreamWriter(
+                    new BufferedOutputStream(response.getOutputStream()),
+                    java.nio.charset.StandardCharsets.UTF_8);
 
-            InputStream csvStream = solrService.buildUniversalCsv(results, resultService);
-
-            OutputStreamWriter out = new OutputStreamWriter(
-                    new BufferedOutputStream(
-                            response.getOutputStream()));
-
-            IOUtils.copy(new InputStreamReader(csvStream), out);
+            solrService.streamCsvResults(query, out, resultService);
             out.flush();
             out.close();
 

--- a/source/org/zfin/search/presentation/SearchPrototypeController.java
+++ b/source/org/zfin/search/presentation/SearchPrototypeController.java
@@ -35,8 +35,6 @@ import org.zfin.search.service.*;
 import org.zfin.util.URLCreator;
 
 import java.io.*;
-import java.net.URL;
-import java.net.URLConnection;
 import java.util.*;
 
 import static org.zfin.repository.RepositoryFactory.getMarkerRepository;
@@ -616,7 +614,6 @@ public class SearchPrototypeController {
         response.setHeader("Content-Disposition", "attachment; filename=\"zfin_search_results.csv\"");
 
         SolrQuery query = new SolrQuery();
-        query.setParam("wt", "csv");
 
         category = getCategory(filterQuery, category);
 
@@ -624,14 +621,9 @@ public class SearchPrototypeController {
             query.addFilterQuery("category:\"" + category + "\"");
         }
 
-        //this should do everything exactly the same as regular controller method to build the result set,
-        //but...
-        //  leave facets off
         query.setFacet(false);
-        //  no highlighting
         query.setHighlight(false);
-        //  set the fl to just name, id
-        query.set("fl", "id, name");
+        query.set("fl", "id, name, category, type, url");
 
         if (StringUtils.isNotEmpty(q)) {
             query.setQuery(q);
@@ -642,19 +634,17 @@ public class SearchPrototypeController {
             }
         }
 
-        //set rows to...lots
         query.setRows(Integer.MAX_VALUE);
 
         handleRootOnlyResults(query);
 
         try {
+            SolrClient client = SolrService.getSolrClient();
+            QueryResponse queryResponse = client.query(query);
+            List<SearchResult> results = queryResponse.getBeans(SearchResult.class);
 
-            URL urlForQuery = SolrService.getUrlForQuery(query);
-            URLConnection connection = urlForQuery.openConnection();
-
-            BufferedReader in = new BufferedReader(
-                    new InputStreamReader(
-                            solrService.transformSolrCsvToZfinCsv(query.getFilterQueries(), connection.getInputStream())));
+            InputStream csvStream = solrService.buildUniversalCsv(results, resultService);
+            BufferedReader in = new BufferedReader(new InputStreamReader(csvStream));
 
             OutputStreamWriter out = new OutputStreamWriter(
                     new BufferedOutputStream(
@@ -666,10 +656,9 @@ public class SearchPrototypeController {
             out.flush();
             out.close();
 
-        } catch (IOException e) {
+        } catch (Exception e) {
             logger.error(e);
         }
-
 
     }
 

--- a/source/org/zfin/search/presentation/SearchPrototypeController.java
+++ b/source/org/zfin/search/presentation/SearchPrototypeController.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.Predicate;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
@@ -609,8 +610,8 @@ public class SearchPrototypeController {
             }
         }
 
-        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        response.setHeader("Content-Disposition", "attachment; filename=\"zfin_search_results.xlsx\"");
+        response.setContentType("text/csv;charset=utf-8");
+        response.setHeader("Content-Disposition", "attachment; filename=\"zfin_search_results.csv\"");
 
         SolrQuery query = new SolrQuery();
 
@@ -642,7 +643,15 @@ public class SearchPrototypeController {
             QueryResponse queryResponse = client.query(query);
             List<SearchResult> results = queryResponse.getBeans(SearchResult.class);
 
-            solrService.buildUniversalXlsx(results, resultService, response.getOutputStream());
+            InputStream csvStream = solrService.buildUniversalCsv(results, resultService);
+
+            OutputStreamWriter out = new OutputStreamWriter(
+                    new BufferedOutputStream(
+                            response.getOutputStream()));
+
+            IOUtils.copy(new InputStreamReader(csvStream), out);
+            out.flush();
+            out.close();
 
         } catch (Exception e) {
             logger.error(e);

--- a/source/org/zfin/search/service/SolrService.java
+++ b/source/org/zfin/search/service/SolrService.java
@@ -1,8 +1,6 @@
 package org.zfin.search.service;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.WordUtils;
@@ -10,6 +8,9 @@ import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrRequest;
@@ -27,7 +28,6 @@ import org.zfin.search.*;
 import org.zfin.search.presentation.FacetValue;
 import org.zfin.search.presentation.SearchResult;
 import org.zfin.util.URLCreator;
-import org.zfin.util.ZfinStringUtils;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.*;
@@ -982,60 +982,104 @@ public class SolrService {
     }
 
     /**
-     * Builds a CSV from search results using injected attributes (the same data shown on the results page).
+     * Builds an XLSX workbook from search results using injected attributes (the same data shown on the results page).
      * This works universally for all search categories.
      *
-     * @param results the search results with attributes already injected
-     * @return InputStream of the CSV data
+     * @param results the search results to include
+     * @param resultService used to inject display attributes into each result
+     * @param outputStream the stream to write the XLSX workbook to
      */
     @SuppressWarnings("unchecked")
-    public InputStream buildUniversalCsv(List<SearchResult> results, ResultService resultService) {
-        try {
-            StringBuilder out = new StringBuilder();
-            CSVPrinter csvPrinter = new CSVPrinter(out, CSVFormat.DEFAULT);
+    public void buildUniversalXlsx(List<SearchResult> results, ResultService resultService, OutputStream outputStream) throws IOException {
+        resultService.injectAttributes(results);
 
-            // inject attributes for each result
-            resultService.injectAttributes(results);
-
-            // collect attribute keys from first result that has attributes
-            List<String> attributeKeys = new ArrayList<>();
-            for (SearchResult result : results) {
-                if (result.getAttributes() != null && !result.getAttributes().isEmpty()) {
-                    attributeKeys = new ArrayList<>(result.getAttributes().keySet());
-                    break;
-                }
+        // collect attribute keys from first result that has attributes
+        List<String> attributeKeys = new ArrayList<>();
+        for (SearchResult result : results) {
+            if (result.getAttributes() != null && !result.getAttributes().isEmpty()) {
+                attributeKeys = new ArrayList<>(result.getAttributes().keySet());
+                break;
             }
+        }
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook()) {
+            XSSFSheet sheet = workbook.createSheet("Search Results");
+
+            // bold header style
+            CellStyle headerStyle = workbook.createCellStyle();
+            Font headerFont = workbook.createFont();
+            headerFont.setBold(true);
+            headerStyle.setFont(headerFont);
+
+            // wrap text style for data cells
+            CellStyle wrapStyle = workbook.createCellStyle();
+            wrapStyle.setWrapText(true);
+            wrapStyle.setVerticalAlignment(VerticalAlignment.TOP);
 
             // header row
-            List<String> header = new ArrayList<>();
-            header.add("ID");
-            header.add("Name");
-            header.addAll(attributeKeys);
-            csvPrinter.printRecord(header);
+            Row headerRow = sheet.createRow(0);
+            int col = 0;
+            setCellValue(headerRow, col++, "ID", headerStyle);
+            setCellValue(headerRow, col++, "Name", headerStyle);
+            for (String key : attributeKeys) {
+                setCellValue(headerRow, col++, key, headerStyle);
+            }
 
             // data rows
+            int rowNum = 1;
             for (SearchResult result : results) {
-                List<String> row = new ArrayList<>();
-                row.add(result.getId() != null ? result.getId() : "");
-                row.add(result.getName() != null ? result.getName() : "");
+                Row row = sheet.createRow(rowNum++);
+                col = 0;
+                setCellValue(row, col++, result.getId() != null ? result.getId() : "", null);
+                setCellValue(row, col++, result.getName() != null ? result.getName() : "", null);
 
                 Map<String, String> attrs = result.getAttributes();
                 for (String key : attributeKeys) {
-                    String value = attrs != null ? attrs.get(key) : null;
+                    String value = attrs != null ? (String) attrs.get(key) : null;
                     if (value != null) {
-                        row.add(ZfinStringUtils.removeHtmlTags(value));
+                        setCellValue(row, col++, stripHtmlToPlainText(value), wrapStyle);
                     } else {
-                        row.add("");
+                        setCellValue(row, col++, "", null);
                     }
                 }
-                csvPrinter.printRecord(row);
             }
 
-            return new ByteArrayInputStream(out.toString().getBytes(StandardCharsets.UTF_8));
-        } catch (IOException e) {
-            logger.error(e);
-            return new ByteArrayInputStream(new byte[0]);
+            workbook.write(outputStream);
         }
+    }
+
+    private void setCellValue(Row row, int col, String value, CellStyle style) {
+        Cell cell = row.createCell(col);
+        cell.setCellValue(value);
+        if (style != null) {
+            cell.setCellStyle(style);
+        }
+    }
+
+    /**
+     * Converts HTML to plain text, preserving list/block structure as newline-separated values.
+     */
+    static String stripHtmlToPlainText(String html) {
+        if (html == null) return "";
+        // convert block-level separators to newlines
+        String text = html;
+        text = text.replaceAll("(?i)<br\\s*/?>", "\n");
+        text = text.replaceAll("(?i)</li>", "\n");
+        text = text.replaceAll("(?i)</div>", "\n");
+        text = text.replaceAll("(?i)</p>", "\n");
+        // strip remaining tags
+        text = text.replaceAll("<[^>]+>", "");
+        // decode common HTML entities
+        text = text.replace("&amp;", "&");
+        text = text.replace("&lt;", "<");
+        text = text.replace("&gt;", ">");
+        text = text.replace("&quot;", "\"");
+        text = text.replace("&#39;", "'");
+        text = text.replace("&nbsp;", " ");
+        // clean up extra whitespace/newlines
+        text = text.replaceAll("[ \t]+\n", "\n");
+        text = text.replaceAll("\n{2,}", "\n");
+        return text.strip();
     }
 }
 

--- a/source/org/zfin/search/service/SolrService.java
+++ b/source/org/zfin/search/service/SolrService.java
@@ -1018,7 +1018,9 @@ public class SolrService {
                     List<String> header = new ArrayList<>();
                     header.add("ID");
                     header.add("Name");
-                    header.addAll(attributeKeys[0]);
+                    for (String key : attributeKeys[0]) {
+                        header.add(key.endsWith(":") ? key.substring(0, key.length() - 1) : key);
+                    }
                     csvPrinter.printRecord(header);
                 }
 
@@ -1039,7 +1041,11 @@ public class SolrService {
             Map<String, String> attrs = result.getAttributes();
             for (String key : attributeKeys) {
                 String value = attrs != null ? (String) attrs.get(key) : null;
-                row.add(value != null ? htmlToPlainText(value) : "");
+                String text = value != null ? htmlToPlainText(value) : "";
+                if ("Location:".equals(key)) {
+                    text = text.replaceAll("\\s*Mapping Details/Browsers\\s*", "").trim();
+                }
+                row.add(text);
             }
             csvPrinter.printRecord(row);
         }

--- a/source/org/zfin/search/service/SolrService.java
+++ b/source/org/zfin/search/service/SolrService.java
@@ -1,6 +1,8 @@
 package org.zfin.search.service;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.WordUtils;
@@ -8,9 +10,6 @@ import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.poi.ss.usermodel.*;
-import org.apache.poi.xssf.usermodel.XSSFSheet;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrRequest;
@@ -28,6 +27,7 @@ import org.zfin.search.*;
 import org.zfin.search.presentation.FacetValue;
 import org.zfin.search.presentation.SearchResult;
 import org.zfin.util.URLCreator;
+import org.jsoup.Jsoup;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.*;
@@ -982,104 +982,70 @@ public class SolrService {
     }
 
     /**
-     * Builds an XLSX workbook from search results using injected attributes (the same data shown on the results page).
+     * Builds a CSV from search results using injected attributes (the same data shown on the results page).
      * This works universally for all search categories.
      *
      * @param results the search results to include
      * @param resultService used to inject display attributes into each result
-     * @param outputStream the stream to write the XLSX workbook to
+     * @return InputStream of the CSV data
      */
     @SuppressWarnings("unchecked")
-    public void buildUniversalXlsx(List<SearchResult> results, ResultService resultService, OutputStream outputStream) throws IOException {
-        resultService.injectAttributes(results);
+    public InputStream buildUniversalCsv(List<SearchResult> results, ResultService resultService) {
+        try {
+            StringBuilder out = new StringBuilder();
+            CSVPrinter csvPrinter = new CSVPrinter(out, CSVFormat.DEFAULT);
 
-        // collect attribute keys from first result that has attributes
-        List<String> attributeKeys = new ArrayList<>();
-        for (SearchResult result : results) {
-            if (result.getAttributes() != null && !result.getAttributes().isEmpty()) {
-                attributeKeys = new ArrayList<>(result.getAttributes().keySet());
-                break;
+            resultService.injectAttributes(results);
+
+            // collect attribute keys from first result that has attributes
+            List<String> attributeKeys = new ArrayList<>();
+            for (SearchResult result : results) {
+                if (result.getAttributes() != null && !result.getAttributes().isEmpty()) {
+                    attributeKeys = new ArrayList<>(result.getAttributes().keySet());
+                    break;
+                }
             }
-        }
-
-        try (XSSFWorkbook workbook = new XSSFWorkbook()) {
-            XSSFSheet sheet = workbook.createSheet("Search Results");
-
-            // bold header style
-            CellStyle headerStyle = workbook.createCellStyle();
-            Font headerFont = workbook.createFont();
-            headerFont.setBold(true);
-            headerStyle.setFont(headerFont);
-
-            // wrap text style for data cells
-            CellStyle wrapStyle = workbook.createCellStyle();
-            wrapStyle.setWrapText(true);
-            wrapStyle.setVerticalAlignment(VerticalAlignment.TOP);
 
             // header row
-            Row headerRow = sheet.createRow(0);
-            int col = 0;
-            setCellValue(headerRow, col++, "ID", headerStyle);
-            setCellValue(headerRow, col++, "Name", headerStyle);
-            for (String key : attributeKeys) {
-                setCellValue(headerRow, col++, key, headerStyle);
-            }
+            List<String> header = new ArrayList<>();
+            header.add("ID");
+            header.add("Name");
+            header.addAll(attributeKeys);
+            csvPrinter.printRecord(header);
 
             // data rows
-            int rowNum = 1;
             for (SearchResult result : results) {
-                Row row = sheet.createRow(rowNum++);
-                col = 0;
-                setCellValue(row, col++, result.getId() != null ? result.getId() : "", null);
-                setCellValue(row, col++, result.getName() != null ? result.getName() : "", null);
+                List<String> row = new ArrayList<>();
+                row.add(result.getId() != null ? result.getId() : "");
+                row.add(result.getName() != null ? result.getName() : "");
 
                 Map<String, String> attrs = result.getAttributes();
                 for (String key : attributeKeys) {
                     String value = attrs != null ? (String) attrs.get(key) : null;
-                    if (value != null) {
-                        setCellValue(row, col++, stripHtmlToPlainText(value), wrapStyle);
-                    } else {
-                        setCellValue(row, col++, "", null);
-                    }
+                    row.add(value != null ? htmlToPlainText(value) : "");
                 }
+                csvPrinter.printRecord(row);
             }
 
-            workbook.write(outputStream);
-        }
-    }
-
-    private void setCellValue(Row row, int col, String value, CellStyle style) {
-        Cell cell = row.createCell(col);
-        cell.setCellValue(value);
-        if (style != null) {
-            cell.setCellStyle(style);
+            return new ByteArrayInputStream(out.toString().getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            logger.error(e);
+            return new ByteArrayInputStream(new byte[0]);
         }
     }
 
     /**
-     * Converts HTML to plain text, preserving list/block structure as newline-separated values.
+     * Converts HTML to plain text using Jsoup. Block-level elements (li, div, br, p)
+     * are converted to semicolon-separated values suitable for CSV cells.
      */
-    static String stripHtmlToPlainText(String html) {
-        if (html == null) return "";
-        // convert block-level separators to newlines
-        String text = html;
-        text = text.replaceAll("(?i)<br\\s*/?>", "\n");
-        text = text.replaceAll("(?i)</li>", "\n");
-        text = text.replaceAll("(?i)</div>", "\n");
-        text = text.replaceAll("(?i)</p>", "\n");
-        // strip remaining tags
-        text = text.replaceAll("<[^>]+>", "");
-        // decode common HTML entities
-        text = text.replace("&amp;", "&");
-        text = text.replace("&lt;", "<");
-        text = text.replace("&gt;", ">");
-        text = text.replace("&quot;", "\"");
-        text = text.replace("&#39;", "'");
-        text = text.replace("&nbsp;", " ");
-        // clean up extra whitespace/newlines
-        text = text.replaceAll("[ \t]+\n", "\n");
-        text = text.replaceAll("\n{2,}", "\n");
-        return text.strip();
+    static String htmlToPlainText(String html) {
+        if (html == null || html.isEmpty()) return "";
+        // insert semicolon separators before stripping, so list items don't collapse together
+        String prepared = html;
+        prepared = prepared.replaceAll("(?i)</li>\\s*<li>", "; ");
+        prepared = prepared.replaceAll("(?i)</div>\\s*<div>", "; ");
+        prepared = prepared.replaceAll("(?i)<br\\s*/?>", "; ");
+        return Jsoup.parse(prepared).text();
     }
 }
 

--- a/source/org/zfin/search/service/SolrService.java
+++ b/source/org/zfin/search/service/SolrService.java
@@ -6,7 +6,6 @@ import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.WordUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.logging.log4j.LogManager;
@@ -23,11 +22,12 @@ import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.CursorMarkParams;
 import org.apache.solr.common.util.NamedList;
 import org.springframework.stereotype.Service;
-import org.zfin.marker.Marker;
 import org.zfin.properties.ZfinPropertiesEnum;
 import org.zfin.search.*;
 import org.zfin.search.presentation.FacetValue;
+import org.zfin.search.presentation.SearchResult;
 import org.zfin.util.URLCreator;
+import org.zfin.util.ZfinStringUtils;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.*;
@@ -38,11 +38,9 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.zfin.repository.RepositoryFactory.getMarkerRepository;
 
 
 /**
@@ -984,73 +982,59 @@ public class SolrService {
     }
 
     /**
-     * Transforms a solr csv to a zfin csv based on the filterQuery. This involves adding more fields that are not available through solr
+     * Builds a CSV from search results using injected attributes (the same data shown on the results page).
+     * This works universally for all search categories.
      *
-     * @param filterQuery the filter query that was used to get the solr csv
-     * @param inputStream the solr csv input stream
-     * @return the transformed csv input stream
+     * @param results the search results with attributes already injected
+     * @return InputStream of the CSV data
      */
-    public InputStream transformSolrCsvToZfinCsv(String[] filterQuery, InputStream inputStream) {
-        Map<String, List<String>> filterQueryMap = getFilterQueryMap(filterQuery);
-
-        //categoryTypePairs is a list of pairs of category and type that we want to transform
-        //if there is a match in the filterQueryMap, we will transform the csv, otherwise we will return the original csv
-        Map<Pair<String, String>, Function<InputStream, InputStream>> categoryTypePairs = Map.of(
-            Pair.of("Gene / Transcript", "Gene"), in -> transformSolrCsvForGenestoZfinCsv(in)
-            //add more rows for other category/type pairs to transform...
-        );
-
-        //category and type_0 are the keys in the filterQueryMap that we want to check for. The value has quotes around it, so we remove them
-        String category = "";
-        String type = "";
-        try {
-            category = filterQueryMap.get("category").stream().map(s -> s.replaceAll("\"", "")).findFirst().orElse("");
-            type = filterQueryMap.get("type_0").stream().map(s -> s.replaceAll("\"", "")).findFirst().orElse("");
-        } catch (Exception e) {
-            //default to "" and "" for category and type if there is an exception
-        }
-        
-        //get the transformer for the category and type pair, or return the original inputStream if there is no transformer
-        Function<InputStream, InputStream> transformer = categoryTypePairs.get(Pair.of(category, type));
-        return transformer == null ? inputStream : transformer.apply(inputStream);
-    }
-
-    /**
-     * Transforms the solr csv to a zfin csv for genes
-     *
-     * Includes the following fields: ZFIN ID, Symbol, Aliases, Name, Location, Type
-     *
-     * @param inputStream the solr csv input stream for the original csv
-     * @return the transformed csv input stream
-     */
-    private InputStream transformSolrCsvForGenestoZfinCsv(InputStream inputStream) {
-        BufferedReader in = new BufferedReader(new InputStreamReader(inputStream));
+    @SuppressWarnings("unchecked")
+    public InputStream buildUniversalCsv(List<SearchResult> results, ResultService resultService) {
         try {
             StringBuilder out = new StringBuilder();
             CSVPrinter csvPrinter = new CSVPrinter(out, CSVFormat.DEFAULT);
 
-            List<String> ids = in.lines()
-                .skip(1) // Skip the header row
-                .map(l -> l.split(",")[0])
-                .toList();
+            // inject attributes for each result
+            resultService.injectAttributes(results);
 
-            List<Marker> markers = getMarkerRepository().getMarkersByZdbIDsJoiningAliases(ids);
-
-            csvPrinter.printRecord("ZFIN ID", "Symbol", "Aliases", "Name", "Location", "Type");
-            for(Marker marker : markers) {
-                String zdbID = marker.getZdbID();
-                String symbol = marker.getAbbreviation();
-                String aliases = marker.getAliases() == null ? "" : marker.getAliases().stream().map(alias -> alias.getAlias()).collect(Collectors.joining("; "));
-                String name = marker.getName();
-                String location = marker.getChromosomeLocations().stream().collect(Collectors.joining("; "));
-                String markerType = marker.getMarkerType().getDisplayName();
-                csvPrinter.printRecord(zdbID, symbol, aliases, name, location, markerType);
+            // collect attribute keys from first result that has attributes
+            List<String> attributeKeys = new ArrayList<>();
+            for (SearchResult result : results) {
+                if (result.getAttributes() != null && !result.getAttributes().isEmpty()) {
+                    attributeKeys = new ArrayList<>(result.getAttributes().keySet());
+                    break;
+                }
             }
 
-            return new ByteArrayInputStream(out.toString().getBytes());
+            // header row
+            List<String> header = new ArrayList<>();
+            header.add("ID");
+            header.add("Name");
+            header.addAll(attributeKeys);
+            csvPrinter.printRecord(header);
+
+            // data rows
+            for (SearchResult result : results) {
+                List<String> row = new ArrayList<>();
+                row.add(result.getId() != null ? result.getId() : "");
+                row.add(result.getName() != null ? result.getName() : "");
+
+                Map<String, String> attrs = result.getAttributes();
+                for (String key : attributeKeys) {
+                    String value = attrs != null ? attrs.get(key) : null;
+                    if (value != null) {
+                        row.add(ZfinStringUtils.removeHtmlTags(value));
+                    } else {
+                        row.add("");
+                    }
+                }
+                csvPrinter.printRecord(row);
+            }
+
+            return new ByteArrayInputStream(out.toString().getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
             logger.error(e);
-            return inputStream;
+            return new ByteArrayInputStream(new byte[0]);
         }
     }
 }

--- a/source/org/zfin/search/service/SolrService.java
+++ b/source/org/zfin/search/service/SolrService.java
@@ -982,55 +982,66 @@ public class SolrService {
     }
 
     /**
-     * Builds a CSV from search results using injected attributes (the same data shown on the results page).
-     * This works universally for all search categories.
+     * Streams search results as CSV using cursor-based Solr pagination.
+     * Each batch is fetched, attribute-injected, and written to the output immediately,
+     * so the first bytes reach the client quickly and memory stays bounded.
      *
-     * @param results the search results to include
-     * @param resultService used to inject display attributes into each result
-     * @return InputStream of the CSV data
+     * @param query         the base Solr query (rows/cursor will be overridden)
+     * @param writer        the response writer to stream CSV into
+     * @param resultService used to inject display attributes into each batch
      */
     @SuppressWarnings("unchecked")
-    public InputStream buildUniversalCsv(List<SearchResult> results, ResultService resultService) {
-        try {
-            StringBuilder out = new StringBuilder();
-            CSVPrinter csvPrinter = new CSVPrinter(out, CSVFormat.DEFAULT);
+    public void streamCsvResults(SolrQuery query, Writer writer, ResultService resultService) throws IOException, SolrServerException {
+        CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT);
+        // mutable holder so the lambda can carry attribute keys across batches
+        final List<String>[] attributeKeys = new List[]{null};
 
-            resultService.injectAttributes(results);
+        getAllResults(query, response -> {
+            try {
+                List<SearchResult> batch = response.getBeans(SearchResult.class);
+                if (batch.isEmpty()) return;
 
-            // collect attribute keys from first result that has attributes
-            List<String> attributeKeys = new ArrayList<>();
-            for (SearchResult result : results) {
-                if (result.getAttributes() != null && !result.getAttributes().isEmpty()) {
-                    attributeKeys = new ArrayList<>(result.getAttributes().keySet());
-                    break;
+                resultService.injectAttributes(batch);
+
+                // derive attribute keys from first batch that has them
+                if (attributeKeys[0] == null) {
+                    for (SearchResult result : batch) {
+                        if (result.getAttributes() != null && !result.getAttributes().isEmpty()) {
+                            attributeKeys[0] = new ArrayList<>(result.getAttributes().keySet());
+                            break;
+                        }
+                    }
+                    if (attributeKeys[0] == null) {
+                        attributeKeys[0] = new ArrayList<>();
+                    }
+
+                    List<String> header = new ArrayList<>();
+                    header.add("ID");
+                    header.add("Name");
+                    header.addAll(attributeKeys[0]);
+                    csvPrinter.printRecord(header);
                 }
+
+                writeBatchRows(csvPrinter, batch, attributeKeys[0]);
+                writer.flush();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
             }
+        });
+    }
 
-            // header row
-            List<String> header = new ArrayList<>();
-            header.add("ID");
-            header.add("Name");
-            header.addAll(attributeKeys);
-            csvPrinter.printRecord(header);
+    private void writeBatchRows(CSVPrinter csvPrinter, List<SearchResult> results, List<String> attributeKeys) throws IOException {
+        for (SearchResult result : results) {
+            List<String> row = new ArrayList<>();
+            row.add(result.getId() != null ? result.getId() : "");
+            row.add(result.getName() != null ? result.getName() : "");
 
-            // data rows
-            for (SearchResult result : results) {
-                List<String> row = new ArrayList<>();
-                row.add(result.getId() != null ? result.getId() : "");
-                row.add(result.getName() != null ? result.getName() : "");
-
-                Map<String, String> attrs = result.getAttributes();
-                for (String key : attributeKeys) {
-                    String value = attrs != null ? (String) attrs.get(key) : null;
-                    row.add(value != null ? htmlToPlainText(value) : "");
-                }
-                csvPrinter.printRecord(row);
+            Map<String, String> attrs = result.getAttributes();
+            for (String key : attributeKeys) {
+                String value = attrs != null ? (String) attrs.get(key) : null;
+                row.add(value != null ? htmlToPlainText(value) : "");
             }
-
-            return new ByteArrayInputStream(out.toString().getBytes(StandardCharsets.UTF_8));
-        } catch (IOException e) {
-            logger.error(e);
-            return new ByteArrayInputStream(new byte[0]);
+            csvPrinter.printRecord(row);
         }
     }
 


### PR DESCRIPTION
…attributes

Replace per-category CSV transformers with a universal approach that reuses ResultService.injectAttributes() to include all columns shown on the search results page. HTML is stripped from attribute values and CSV escaping is handled by Apache Commons CSV.