### PR TITLE
ZFIN-10182: Minimize regen_term() lock duration to prevent deadlocks

### DIFF
--- a/lib/DB_functions/Regen_genox/regen_cleanup_renamed_tables.sql
+++ b/lib/DB_functions/Regen_genox/regen_cleanup_renamed_tables.sql
@@ -6,9 +6,9 @@ DECLARE
     result text;
 BEGIN
 
-    --if table_prefix doesn't contain _fast_search_old_ then it's not a renamed table
-    if (table_prefix not like '%_fast_search_old_%') then
-        return 'this function should only be used to clean up tables named like ..._fast_search_old_...';
+    --if table_prefix doesn't match a known renamed-table pattern, reject it
+    if (table_prefix not like '%_fast_search_old_%' and table_prefix not like 'all_term_contains_old_%') then
+        return 'this function should only be used to clean up tables named like ..._fast_search_old_... or all_term_contains_old_...';
     end if;
 
     result := 'tables dropped: ';

--- a/lib/DB_functions/regen_term.sql
+++ b/lib/DB_functions/regen_term.sql
@@ -6,31 +6,16 @@
 -- ---------------------------------------------------------------------
 
 create or replace function regen_term()
-  returns int as $log$ 
+  returns int as $log$
 
   -- populates term fast search tables:
-  --  term_display: term's position in a dag display of a certain stage
   --  all_term_contains: each and every ancestor and descendant
-    
-    declare nSynonyms int;
-     nGenesForThisItem int;
-     nGenesForChildItems int;
-     nDistinctGenes int;
-     nGenosForThisItem int;
-     nGenosForChildItems int;
-     nDistinctGenos int;
+  --
+  -- This table stores every term with every ancestor that has a contains
+  -- relationship and the shortest distance between each pair.
+  -- Contains relationships: is_a, part_of, positively/negatively regulates, occurs in.
 
-
-      -- ---- ALL_TERM_CONTAINS ----
-  
-      -- this table stores every term term with every ancestor 
-      -- that has a contains relationship and the shortest distance 
-      -- between each pair.  In this case, a contains relationship
-      -- is being defined as dagedit_id's "is_a", "part_of", which
-      -- leaves out "develops_from".  Unfortunately, the only place
-      -- where that is defined is in this file, when we have a generic
-      -- DAG, we will probably need relationship type groups so that
-      -- nothing has to be hardcoded.
+    declare old_table_name text;
 
     begin
       drop table if exists all_term_contains_new;
@@ -42,32 +27,67 @@ create or replace function regen_term()
 	  alltermcon_min_contain_distance	int not null
         );
 
-
-      -- =================   POPULATE TABLES   ===============================
-
-      -- -----------------------------------------------------------------------
-      --     ALL_TERM_CONTAINS_NEW
-      -- -----------------------------------------------------------------------
-
-  
-
+      -- populate the transitive closure
       perform populate_all_term_contains();
 
-      
+      -- add self-records before the swap so the table is complete when it goes live
+      insert into all_term_contains_new
+              select term_zdb_id, term_zdb_id, 0
+              from term;
+
+      -- build indexes and constraints on _new table BEFORE the swap
+      -- so the live table is never unindexed and queries are fast immediately
+      create unique index atc_pk_idx_new
+          on all_term_contains_new (alltermcon_container_zdb_id, alltermcon_contained_zdb_id);
+
+      create index atc_container_idx_new
+          on all_term_contains_new (alltermcon_container_zdb_id);
+
+      create index atc_contained_idx_new
+          on all_term_contains_new (alltermcon_contained_zdb_id);
+
+      alter table all_term_contains_new
+          add constraint atc_pk_new primary key using index atc_pk_idx_new;
+
+      alter table all_term_contains_new add constraint atc_container_fk_new
+          foreign key (alltermcon_container_zdb_id) references term on delete cascade;
+
+      alter table all_term_contains_new add constraint atc_contained_fk_new
+          foreign key (alltermcon_contained_zdb_id) references term on delete cascade;
+
     -- -------------------------------------------------------------------------
-    -- RENAME the new tables to REPLACE the old
+    -- Swap: rename old out, rename new in.
+    -- The exclusive lock window is just these two fast DDL renames.
+    -- Old table is renamed with a timestamp, truncated, and left for later cleanup.
     -- -------------------------------------------------------------------------
 
-      drop table all_term_contains;
+      IF EXISTS (SELECT 1 FROM information_schema.tables
+                 WHERE table_name = 'all_term_contains' AND table_schema = 'public') THEN
+
+          old_table_name := 'all_term_contains_old_' || to_char(now(), 'YYMMDDHH24MI');
+          old_table_name := old_table_name || '_' || substring(md5(random()::text), 1, 4);
+
+          EXECUTE 'ALTER TABLE all_term_contains RENAME TO ' || old_table_name;
+          EXECUTE 'TRUNCATE ' || old_table_name;
+
+          EXECUTE 'ALTER INDEX IF EXISTS all_term_contains_primary_key_index RENAME TO '
+              || old_table_name || '_pk_idx';
+          EXECUTE 'ALTER INDEX IF EXISTS alltermcon_container_zdb_id_index RENAME TO '
+              || old_table_name || '_container_idx';
+          EXECUTE 'ALTER INDEX IF EXISTS alltermcon_contained_zdb_id_index RENAME TO '
+              || old_table_name || '_contained_idx';
+
+      END IF;
+
       alter table all_term_contains_new rename to all_term_contains;
 
-      -- primary key
-
-    
-  -- re-create self-records in all_term_contains
-  insert into all_term_contains
-              select term_zdb_id,term_zdb_id,0
-              from term;
+      -- rename constraints and indexes to canonical names
+      alter index atc_pk_idx_new rename to all_term_contains_primary_key_index;
+      alter index atc_container_idx_new rename to alltermcon_container_zdb_id_index;
+      alter index atc_contained_idx_new rename to alltermcon_contained_zdb_id_index;
+      alter table all_term_contains rename constraint atc_pk_new to all_term_contains_primary_key;
+      alter table all_term_contains rename constraint atc_container_fk_new to alltermcon_container_zdb_id_foreign_key;
+      alter table all_term_contains rename constraint atc_contained_fk_new to alltermcon_contained_zdb_id_foreign_key;
 
   return 0;
 

--- a/server_apps/DB_maintenance/postgres/make_alltermcontains_indexes.sql
+++ b/server_apps/DB_maintenance/postgres/make_alltermcontains_indexes.sql
@@ -1,29 +1,52 @@
-drop index if exists all_term_contains_primary_key_index;
+-- Indexes and constraints for all_term_contains.
+-- As of regen_term() update, these are now built inside the function before
+-- the table swap. This script uses IF NOT EXISTS so it's safe to run as a
+-- no-op after regen_term(), or standalone if needed.
 
-create unique index concurrently all_term_contains_primary_key_index
+create unique index if not exists all_term_contains_primary_key_index
     on all_term_contains (alltermcon_container_zdb_id,
                                  alltermcon_contained_zdb_id);
 
-                                          
-create index concurrently alltermcon_container_zdb_id_index
+create index if not exists alltermcon_container_zdb_id_index
      on all_term_contains (alltermcon_container_zdb_id);
 
-
-create index concurrently alltermcon_contained_zdb_id_index
+create index if not exists alltermcon_contained_zdb_id_index
      on all_term_contains (alltermcon_contained_zdb_id);
 
+-- Add primary key constraint if not already present
+do $$
+begin
+    if not exists (
+        select 1 from pg_constraint
+        where conname = 'all_term_contains_primary_key'
+          and conrelid = 'all_term_contains'::regclass
+    ) then
+        alter table all_term_contains
+            add constraint all_term_contains_primary_key primary key
+            using index all_term_contains_primary_key_index;
+    end if;
+end $$;
 
-alter table all_term_contains
-    add constraint all_term_contains_primary_key primary key using index all_term_contains_primary_key_index;
+-- Add foreign keys if not already present
+do $$
+begin
+    if not exists (
+        select 1 from pg_constraint
+        where conname = 'alltermcon_container_zdb_id_foreign_key'
+          and conrelid = 'all_term_contains'::regclass
+    ) then
+        alter table all_term_contains add constraint alltermcon_container_zdb_id_foreign_key
+            foreign key (alltermcon_container_zdb_id)
+            references term on delete cascade;
+    end if;
 
-      -- foreign keys                                                                                                                                  
-
-alter table all_term_contains add constraint alltermcon_container_zdb_id_foreign_key
-   foreign key (alltermcon_container_zdb_id)
-   references term
-   on delete cascade;
-
-alter table all_term_contains add constraint alltermcon_contained_zdb_id_foreign_key
-   foreign key (alltermcon_contained_zdb_id)
-   references term
-   on delete cascade;
+    if not exists (
+        select 1 from pg_constraint
+        where conname = 'alltermcon_contained_zdb_id_foreign_key'
+          and conrelid = 'all_term_contains'::regclass
+    ) then
+        alter table all_term_contains add constraint alltermcon_contained_zdb_id_foreign_key
+            foreign key (alltermcon_contained_zdb_id)
+            references term on delete cascade;
+    end if;
+end $$;

--- a/server_apps/DB_maintenance/warehouse/regenPhenotypeMartCleanup.sh
+++ b/server_apps/DB_maintenance/warehouse/regenPhenotypeMartCleanup.sh
@@ -12,5 +12,12 @@ do
     fi
 done
 
+echo "Cleaning all_term_contains_old_ tables";
+echo "select regen_cleanup_renamed_tables('all_term_contains_old_')" | ${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DBNAME;
+if [ $? -ne 0 ]; then
+    echo "regen_cleanup_renamed_tables('all_term_contains_old_') failed";
+    exit 1;
+fi
+
 date;
 echo "done with regen finish cleanup";


### PR DESCRIPTION
regen_term() was holding an AccessExclusiveLock on all_term_contains for the entire duration of populating and indexing, blocking all reads (~9200 queued queries, up to 25 min wait). Now indexes, constraints, and self-records are built on the _new table before the swap, reducing the exclusive lock to just two fast DDL renames.

Old table is renamed with a timestamp suffix and truncated rather than dropped, consistent with the pattern used by regen_genox. Cleanup is handled by regen_cleanup_renamed_tables() via regenPhenotypeMartCleanup.

make_alltermcontains_indexes.sql is now idempotent (IF NOT EXISTS) since regen_term() builds indexes internally.