### PR TITLE
ZFIN-10191: Replace mailhog with mailpit to capture outgoing emails on trunk and test

### DIFF
--- a/commons/env/all-properties.yml
+++ b/commons/env/all-properties.yml
@@ -190,6 +190,7 @@ common_properties:
   SHARED_DOMAIN_NAME: "false"
   SHOW_SQL: "false"
   SHUTDOWNPORT: "2007"
+  SMTP_PORT: "25"
   SOLR_CONTEXT: "solr"
   SOLR_CORE: "site_index"
   SOLR_HOME: "/var/solr/data/site_index"
@@ -272,8 +273,7 @@ unique_properties:
   LOG4J_FILE: "default.log4j.xml"
   PRIMARY_COLOR: "#512da8"
   SCHEDULE_TRIGGER_FILES: "production" # <<< other potential values: trunk, test, blank
-  SMTP_HOST: "mailhog"           # Override: smtp.uoregon.edu for test, trunk, production
-  SMTP_PORT: "25"           # Override: 25 for test, trunk, production
+  SMTP_HOST: "mailpit"           # Override: smtp.uoregon.edu for test, trunk, production
   SOLR_CREATE_BACKUPS: "false"  # Override: true for prod, test, trunk
 
 # -----------------------------------------------------------------------------
@@ -368,8 +368,6 @@ staging_defaults:
   LOG4J_FILE: "test-sites.log4j.xml"
   NODE_ENV: "production"
   ONTOLOGY_LOADER_EMAIL: "informix@zfin.org cmpich@zfin.org"
-  SMTP_HOST: "smtp.uoregon.edu"
-  SMTP_PORT: "25"
   SOLR_CREATE_BACKUPS: "true"
   SOLR_MEMORY: "8g"
 
@@ -389,7 +387,6 @@ prod_defaults:
   PRIMARY_COLOR: "#008080"
   SEND_AUTHOR_NOTIF_EMAIL: "true"
   SMTP_HOST: "smtp.uoregon.edu"
-  SMTP_PORT: "25"
   SOLR_CREATE_BACKUPS: "true"
   SOLR_MEMORY: "10g"
 
@@ -468,7 +465,7 @@ email_overrides:
 #
 # Add new instances here as needed. Common overrides include:
 #   - PRIMARY_COLOR: UI theming to visually distinguish instances
-#   - SMTP_HOST: Mail server (mailhog for dev, smtp.uoregon.edu for others)
+#   - SMTP_HOST: Mail server (mailpit for dev, smtp.uoregon.edu for others)
 #   - SOLR_CREATE_BACKUPS: Enable for persistent instances
 #
 # NOTE: ENVIRONMENT is set via instance_environment above, not here.

--- a/commons/env/all-properties.yml
+++ b/commons/env/all-properties.yml
@@ -273,7 +273,7 @@ unique_properties:
   LOG4J_FILE: "default.log4j.xml"
   PRIMARY_COLOR: "#512da8"
   SCHEDULE_TRIGGER_FILES: "production" # <<< other potential values: trunk, test, blank
-  SMTP_HOST: "mailpit"           # Override: smtp.uoregon.edu for test, trunk, production
+  SMTP_HOST: "mailpit"           # Override: smtp.uoregon.edu for production
   SOLR_CREATE_BACKUPS: "false"  # Override: true for prod, test, trunk
 
 # -----------------------------------------------------------------------------

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -113,6 +113,7 @@ services:
       OPENIDC_CRYPTOPASSPHRASE: ${OPENIDC_CRYPTOPASSPHRASE}
       OPENIDC_CLIENTID: ${OPENIDC_CLIENTID}
       OPENIDC_CLIENTSECRET: ${OPENIDC_CLIENTSECRET}
+      DISABLE_OIDC: ${DISABLE_OIDC:-false}
       TZ: ${TZ}
     ports:
       - "${DOCKER_HTTPD_HTTP_PORT:-8080-8089}:80"
@@ -195,6 +196,7 @@ services:
       MP_DATABASE: /data/mailpit.db
       MP_SMTP_AUTH_ACCEPT_ANY: 1
       MP_SMTP_AUTH_ALLOW_INSECURE: 1
+      MP_WEBROOT: /mailpit
     volumes:
       - ./data:/data
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -185,10 +185,18 @@ services:
     volumes:
       - ${DOCKER_ABBLAST_PATH}:/opt/ab-blast
       - ${DOCKER_BLASTSERVER_BLAST_DATABASE_PATH}:/opt/zfin/blastdb
-  mailhog:
-    build: ./mailhog/
+  mailpit:
+    image: axllent/mailpit
+    container_name: mailpit
+    restart: unless-stopped
     environment:
-      MH_SMTP_BIND_ADDR: "0.0.0.0:25"
+      MP_SMTP_BIND_ADDR: "0.0.0.0:25"
+      MP_MAX_MESSAGES: 5000
+      MP_DATABASE: /data/mailpit.db
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1
+    volumes:
+      - ./data:/data
     ports:
       - "1025:25"
       - "8025:8025"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -199,9 +199,6 @@ services:
       MP_WEBROOT: /mailpit
     volumes:
       - ./data:/data
-    ports:
-      - "1025:25"
-      - "8025:8025"
   jenkins:
     build: 
       context: ./jenkins/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -198,7 +198,7 @@ services:
       MP_SMTP_AUTH_ALLOW_INSECURE: 1
       MP_WEBROOT: /mailpit
     volumes:
-      - ./data:/data
+      - mailpit_data:/data
   jenkins:
     build: 
       context: ./jenkins/
@@ -363,6 +363,7 @@ volumes:
   kibana_data:
   certbot_data:
   jbrowse_data:
+  mailpit_data:
   nfs-zunloads:
     driver_opts:
       type: nfs

--- a/docker/environment_linux
+++ b/docker/environment_linux
@@ -32,3 +32,6 @@ ZFIN_RELEASE=latest
 DOCKER_HTTPD_HTTP_PORT=127.0.0.2:8084
 DOCKER_HTTPD_HTTPS_PORT=127.0.0.2:443
 DOCKER_JENKINS_HTTP_PORT=127.0.0.2:9499
+
+# To override OIDC settings for local development Set the following to "true"
+# DISABLE_OIDC=false

--- a/docker/httpd/conf-local
+++ b/docker/httpd/conf-local
@@ -95,15 +95,6 @@ OIDCXForwardedHeaders X-Forwarded-Host X-Forwarded-Port X-Forwarded-Proto
    Require all granted
    Require not env RejectRequest
   </RequireAll>
-  # Note: To bypass OIDC for PDF files locally, replace the auth directives below with:
-  #   <If "reqenv('DISABLE_OIDC') == 'true'">
-  #     Require all granted
-  #   </If>
-  #   <Else>
-  #     Require env ZfinHosts
-  #     AuthType openid-connect
-  #     Require valid-user
-  #   </Else>
   <FilesMatch ".+\.(?i)(pdf|doc|docx|xls|xlsx|nxml)$">
     SSLRequireSSL
     Require env ZfinHosts

--- a/docker/httpd/conf-local
+++ b/docker/httpd/conf-local
@@ -80,7 +80,7 @@ SetEnvIf Remote_Addr "(87.245.153.182)|(204.251.10.202)|(155.230.158.26)|(38.99.
 Alias /imageLoadUp "/opt/zfin/loadUp/pubs"
 Alias /PDFLoadUp "/opt/zfin/loadUp/pubs"
 #this is required by mod_auth_openidc
-PassEnv OPENIDC_CRYPTOPASSPHRASE OPENIDC_CLIENTID OPENIDC_CLIENTSECRET
+PassEnv OPENIDC_CRYPTOPASSPHRASE OPENIDC_CLIENTID OPENIDC_CLIENTSECRET DISABLE_OIDC
 OIDCCryptoPassphrase ${OPENIDC_CRYPTOPASSPHRASE}
 OIDCProviderMetadataURL https://bouncer.zfin.org/realms/ZFIN/.well-known/openid-configuration
 OIDCClientID ${OPENIDC_CLIENTID}
@@ -95,6 +95,15 @@ OIDCXForwardedHeaders X-Forwarded-Host X-Forwarded-Port X-Forwarded-Proto
    Require all granted
    Require not env RejectRequest
   </RequireAll>
+  # Note: To bypass OIDC for PDF files locally, replace the auth directives below with:
+  #   <If "reqenv('DISABLE_OIDC') == 'true'">
+  #     Require all granted
+  #   </If>
+  #   <Else>
+  #     Require env ZfinHosts
+  #     AuthType openid-connect
+  #     Require valid-user
+  #   </Else>
   <FilesMatch ".+\.(?i)(pdf|doc|docx|xls|xlsx|nxml)$">
     SSLRequireSSL
     Require env ZfinHosts

--- a/docker/httpd/conf-zfin.org
+++ b/docker/httpd/conf-zfin.org
@@ -46,6 +46,9 @@
     RewriteCond %{HTTPS} =off
     RewriteCond %{REQUEST_URI} ^/logs
     RewriteRule ^(.*)$ https://%{SERVER_NAME}/$1 [R=301,L]
+    RewriteCond %{HTTPS} =off
+    RewriteCond %{REQUEST_URI} ^/mailpit
+    RewriteRule ^(.*)$ https://%{SERVER_NAME}/$1 [R=301,L]
 
     Include /srv/www/zfin.org/server_apps/apache/inc-redirect
 
@@ -90,6 +93,16 @@
         Require env ZfinRestrictedHosts
         ProxyPass         http://kibana:5601/logs
         ProxyPassReverse  http://kibana:5601/logs
+    </Location>
+    <Location /mailpit>
+        SSLRequireSSL
+        Require env ZfinRestrictedHosts
+        RewriteEngine On
+        RewriteCond %{HTTP:Upgrade} websocket [NC]
+        RewriteCond %{HTTP:Connection} upgrade [NC]
+        RewriteRule ^/mailpit/(.*) ws://mailpit:8025/mailpit/$1 [P,L]
+        ProxyPass         http://mailpit:8025/mailpit
+        ProxyPassReverse  http://mailpit:8025/mailpit
     </Location>
     <Location /jbrowse>
         ProxyPreserveHost Off
@@ -147,7 +160,7 @@
     ProxyPassReverse /zfinlabs/ http://zygotix.zfin.org:9109/action/quicksearch/
 
     #this is required by mod_auth_openidc
-    PassEnv OPENIDC_CRYPTOPASSPHRASE OPENIDC_CLIENTID OPENIDC_CLIENTSECRET
+    PassEnv OPENIDC_CRYPTOPASSPHRASE OPENIDC_CLIENTID OPENIDC_CLIENTSECRET DISABLE_OIDC
     OIDCCryptoPassphrase ${OPENIDC_CRYPTOPASSPHRASE}
     OIDCProviderMetadataURL https://bouncer.zfin.org/realms/ZFIN/.well-known/openid-configuration
     OIDCClientID ${OPENIDC_CLIENTID}
@@ -162,15 +175,25 @@
         Require valid-user
     </Location>
     <Location /cgi-bin/>
-        AuthType openid-connect
-        Require valid-user
+        <If "osenv('DISABLE_OIDC') == 'true'">
+            Require all granted
+        </If>
+        <Else>
+            AuthType openid-connect
+            Require valid-user
+        </Else>
     </Location>
     <Location /jobs>
-        AuthType openid-connect
-        <RequireAll>
-          #Require env ZfinHosts
-          Require valid-user
-        </RequireAll>
+        <If "osenv('DISABLE_OIDC') == 'true'">
+            Require all granted
+        </If>
+        <Else>
+            AuthType openid-connect
+            <RequireAll>
+              #Require env ZfinHosts
+              Require valid-user
+            </RequireAll>
+        </Else>
         ProxyPass         http://jenkins:9499/jobs
         ProxyPassReverse  http://jenkins:9499/jobs
         ProxyPassReverse  http://zfin.org/jobs
@@ -183,23 +206,52 @@
     <Location /solr>
       # Make sure you're using HTTPS, or anyone can read your LDAP password.
       SSLRequireSSL
-      AuthType openid-connect
-      <RequireAll>
-        Require env ZfinRestrictedHosts
-        Require valid-user
-      </RequireAll>
+      <If "osenv('DISABLE_OIDC') == 'true'">
+          Require all granted
+      </If>
+      <Else>
+          AuthType openid-connect
+          <RequireAll>
+            Require env ZfinRestrictedHosts
+            Require valid-user
+          </RequireAll>
+      </Else>
       ProxyPass         http://solr:8983/solr
       ProxyPassReverse  http://solr:8983/solr
     </Location>
     <Location /logs>
         SSLRequireSSL
-        AuthType openid-connect
-        <RequireAll>
-          Require env ZfinRestrictedHosts
-          Require valid-user
-        </RequireAll>
+        <If "osenv('DISABLE_OIDC') == 'true'">
+            Require all granted
+        </If>
+        <Else>
+            AuthType openid-connect
+            <RequireAll>
+              Require env ZfinRestrictedHosts
+              Require valid-user
+            </RequireAll>
+        </Else>
         ProxyPass          http://kibana:5601/logs
         ProxyPassReverse   http://kibana:5601/logs
+    </Location>
+    <Location /mailpit>
+        SSLRequireSSL
+        <If "osenv('DISABLE_OIDC') == 'true'">
+            Require all granted
+        </If>
+        <Else>
+            AuthType openid-connect
+            <RequireAll>
+              Require env ZfinRestrictedHosts
+              Require valid-user
+            </RequireAll>
+        </Else>
+        RewriteEngine On
+        RewriteCond %{HTTP:Upgrade} websocket [NC]
+        RewriteCond %{HTTP:Connection} upgrade [NC]
+        RewriteRule ^/mailpit/(.*) ws://mailpit:8025/mailpit/$1 [P,L]
+        ProxyPass          http://mailpit:8025/mailpit
+        ProxyPassReverse   http://mailpit:8025/mailpit
     </Location>
     <Location /jbrowse>
         ProxyPreserveHost Off

--- a/docker/httpd/conf-zfin.org
+++ b/docker/httpd/conf-zfin.org
@@ -78,31 +78,12 @@
     </Location>
     <Location /jobs>
         SSLRequireSSL
-        Require env ZfinRestrictedHosts
-        ProxyPass         http://jenkins:9499/jobs
-        ProxyPassReverse  http://jenkins:9499/jobs
-        ProxyPassReverse  http://zfin.org/jobs
-        ProxyPassReverse  http://clone.zfin.org/jobs
-        ProxyPassReverse  http://watson.zfin.org/jobs
-        ProxyPassReverse  http://franklin.zfin.org/jobs
-        ProxyPassReverse  http://crick.zfin.org/jobs
-        ProxyPassReverse  http://stage.zfin.org/jobs
     </Location>
     <Location /logs>
         SSLRequireSSL
-        Require env ZfinRestrictedHosts
-        ProxyPass         http://kibana:5601/logs
-        ProxyPassReverse  http://kibana:5601/logs
     </Location>
     <Location /mailpit>
         SSLRequireSSL
-        Require env ZfinHosts
-        RewriteEngine On
-        RewriteCond %{HTTP:Upgrade} websocket [NC]
-        RewriteCond %{HTTP:Connection} upgrade [NC]
-        RewriteRule ^/mailpit/(.*) ws://mailpit:8025/mailpit/$1 [P,L]
-        ProxyPass         http://mailpit:8025/mailpit
-        ProxyPassReverse  http://mailpit:8025/mailpit
     </Location>
     <Location /jbrowse>
         ProxyPreserveHost Off
@@ -242,8 +223,11 @@
         <Else>
             AuthType openid-connect
             <RequireAll>
-              Require env ZfinHosts
-              Require valid-user
+                Require valid-user
+                <RequireAny>
+                    Require env ZfinHosts
+                    Require env ZfinRestrictedHosts
+                </RequireAny>
             </RequireAll>
         </Else>
         RewriteEngine On

--- a/docker/httpd/conf-zfin.org
+++ b/docker/httpd/conf-zfin.org
@@ -96,7 +96,7 @@
     </Location>
     <Location /mailpit>
         SSLRequireSSL
-        Require env ZfinRestrictedHosts
+        Require env ZfinHosts
         RewriteEngine On
         RewriteCond %{HTTP:Upgrade} websocket [NC]
         RewriteCond %{HTTP:Connection} upgrade [NC]
@@ -242,7 +242,7 @@
         <Else>
             AuthType openid-connect
             <RequireAll>
-              Require env ZfinRestrictedHosts
+              Require env ZfinHosts
               Require valid-user
             </RequireAll>
         </Else>

--- a/docker/mailhog/Dockerfile
+++ b/docker/mailhog/Dockerfile
@@ -1,1 +1,0 @@
-FROM mailhog/mailhog:v1.0.1

--- a/docs/build-and-docker.md
+++ b/docs/build-and-docker.md
@@ -59,6 +59,12 @@ Named volumes are managed by Docker. Bind mounts (prefixed with `$DOCKER_*`) are
 | `/var/run/docker.sock` | `/var/run/docker.sock` | compile |
 | `~/.ssh/known_hosts` | `/home/gradle/.ssh/known_hosts` | compile |
 
+### Service Environment Variables (from `.env`)
+
+| Variable | Default | Used By | Purpose |
+|----------|---------|---------|---------|
+| `DISABLE_OIDC` | `false` | httpd | Set to `true` to bypass OpenID Connect authentication on `/cgi-bin`, `/jobs`, `/solr`, `/logs`, and `/mailpit` for local development. Requires rebuilding the httpd container (`docker compose up -d httpd`). |
+
 ### Key Observations
 
 - The **compile** container has the most volume mounts — it needs access to source code, all output directories, build caches, Docker socket, and SSH for the full build pipeline.
@@ -70,20 +76,13 @@ Named volumes are managed by Docker. Bind mounts (prefixed with `$DOCKER_*`) are
 
 GoCD uses the following steps to build and deploy a full instance.
 
-### 1. Build Docker Images
+### 1. Pull Docker Images
 
 ```bash
-docker compose build base
-docker compose kill compile
-docker compose build compile
+docker compose pull
 docker compose run --rm compile bash -lc '# init volumes for certs and zfin.properties'
 docker compose run --rm --detach --name trunk-compile-run-1 compile #kick off the compile container to run in the background and be available for `docker exec...`
 docker compose run --rm compile bash -lc "ant do"
-docker compose build db
-docker compose build solr
-docker compose build tomcat
-docker compose build jenkins
-docker compose build httpd
 ```
 
 ### 2. Load Database

--- a/docs/build-and-docker.md
+++ b/docs/build-and-docker.md
@@ -2,19 +2,19 @@
 
 ## Docker Services
 
-| Service | Image | Purpose | Ports |
-|---------|-------|---------|-------|
-| **base** | `ghcr.io/zfin/zfin-base` | Foundation image — Gradle 8, JDK 21, Node 18, Ant, Perl, Groovy, Bowtie | — |
-| **compile** | `ghcr.io/zfin/zfin-compile` | Build container — inherits base, adds Docker CLI | — |
-| **db** | `ghcr.io/zfin/zfin-db` | PostgreSQL 18 | 5432 |
-| **solr** | — | Solr search engine | 8983 |
-| **tomcat** | — | Tomcat 10 + JDK 21 (app server) | 8080 |
+| Service         | Image | Purpose | Ports |
+|-----------------|-------|---------|-------|
+| **base**        | `ghcr.io/zfin/zfin-base` | Foundation image — Gradle 8, JDK 21, Node 18, Ant, Perl, Groovy, Bowtie | — |
+| **compile**     | `ghcr.io/zfin/zfin-compile` | Build container — inherits base, adds Docker CLI | — |
+| **db**          | `ghcr.io/zfin/zfin-db` | PostgreSQL 18 | 5432 |
+| **solr**        | — | Solr search engine | 8983 |
+| **tomcat**      | — | Tomcat 10 + JDK 21 (app server) | 8080 |
 | **tomcatdebug** | — | Debug variant of Tomcat (JPDA) | 5000 |
-| **httpd** | — | Apache (reverse proxy + static files) | 80/443 |
-| **jenkins** | — | CI/CD server | 9499 |
-| **ncbiload** | — | NCBI data loading | — |
-| **blast** | — | BLAST sequence search | — |
-| **mailhog** | — | Email testing | — |
+| **httpd**       | — | Apache (reverse proxy + static files) | 80/443 |
+| **jenkins**     | — | CI/CD server | 9499 |
+| **ncbiload**    | — | NCBI data loading | — |
+| **blast**       | — | BLAST sequence search | — |
+| **mailpit**     | — | Email testing | — |
 
 ## Container Volumes
 


### PR DESCRIPTION
This replaces mailhog with mailpit. It also changes the SMTP_HOST for trunk and test to point to mailpit so that trunk and test should no longer send emails out to actual email inboxes. mailpit must be running to be able to read those emails (`docker compose up -d mailpit`).
