### PR TITLE
ZFIN-10205: Sync mrkr_name and mrkr_abbrev with construct_name

### DIFF
--- a/source/org/zfin/db/postGmakePostloaddb/1181/ZFIN-10205.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1181/ZFIN-10205.sql
@@ -1,0 +1,13 @@
+--liquibase formatted sql
+--changeset rtaylor:ZFIN-10205
+
+-- Sync mrkr_name and mrkr_abbrev with construct_name for constructs
+-- where they have drifted out of sync.
+-- construct_name is the canonical source of truth.
+
+UPDATE marker
+SET mrkr_name = construct_name,
+    mrkr_abbrev = construct_name
+FROM construct
+WHERE construct_zdb_id = mrkr_zdb_id
+  AND construct_name <> mrkr_abbrev;

--- a/source/org/zfin/db/postGmakePostloaddb/1181/ZFIN-10205.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1181/ZFIN-10205.sql
@@ -2,8 +2,6 @@
 --changeset rtaylor:ZFIN-10205
 
 -- Sync mrkr_name and mrkr_abbrev with construct_name for constructs
--- where they have drifted out of sync.
--- construct_name is the canonical source of truth.
 
 UPDATE marker
 SET mrkr_name = construct_name,

--- a/source/org/zfin/db/postGmakePostloaddb/1181/db.changelog.master.xml
+++ b/source/org/zfin/db/postGmakePostloaddb/1181/db.changelog.master.xml
@@ -5,6 +5,6 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-<!--    <include file="source/org/zfin/db/postGmakePostloaddb/1181/ZFIN-.....sql" />-->
+    <include file="source/org/zfin/db/postGmakePostloaddb/1181/ZFIN-10205.sql" />
 
 </databaseChangeLog>


### PR DESCRIPTION
8 constructs had mrkr_abbrev (and/or mrkr_name) out of sync with construct_name, the canonical source of truth. This changeset updates both marker fields to match construct_name for any mismatched rows.