### PR TITLE
ZFIN-9723: Fix feature sort order not updating when abbreviation changes

### DIFF
--- a/lib/DB_triggers/feature.sql
+++ b/lib/DB_triggers/feature.sql
@@ -42,7 +42,7 @@ END;
 $BODY$ LANGUAGE plpgsql;
 
 CREATE TRIGGER feature_before_trigger
-BEFORE INSERT ON feature
+BEFORE INSERT OR UPDATE ON feature
 FOR EACH ROW EXECUTE PROCEDURE feature_before();
 
 CREATE TRIGGER feature_after_trigger

--- a/lib/DB_triggers/feature_abbrev.sql
+++ b/lib/DB_triggers/feature_abbrev.sql
@@ -3,14 +3,7 @@ drop trigger if exists feature_abbrev_trigger on feature;
 create or replace function feature_abbrev()
 returns trigger as
 $BODY$
-
-declare feature_abbrev feature.feature_abbrev%TYPE := scrub_char(NEW.feature_abbrev);
-declare feature_abbrev_order feature.feature_abbrev_order%TYPE :=zero_pad(NEW.feature_abbrev_order);
-
 begin
-
-     NEW.feature_abbrev = feature_abbrev;
-     NEW.feature_abbrev_order = zero_pad(NEW.feature_abbrev);
 
      perform checkFeatureAbbrev(NEW.feature_zdb_id,
        		 		     NEW.feature_type, 

--- a/lib/DB_triggers/feature_name.sql
+++ b/lib/DB_triggers/feature_name.sql
@@ -4,13 +4,9 @@ drop trigger if exists feature_name_trigger on feature;
 create or replace function feature_name()
 returns trigger as
 $BODY$
-declare feature_name feature.feature_name%TYPE := scrub_char(NEW.feature_name);
-declare feature_name_order feature.feature_name_order%TYPE := zero_pad(NEW.feature_name_order);
 begin
-     
-     NEW.feature_name = feature_name;
-     
-     NEW.feature_name_order = feature_name_order;
+     -- Row modifications (scrub_char, zero_pad) are handled by the BEFORE trigger in feature.sql.
+     -- This AFTER trigger handles only side effects that need to see the committed row.
 
      perform fhist_event(NEW.feature_zdb_id,
        		'reassigned', NEW.feature_name, OLD.feature_name);

--- a/source/org/zfin/db/postGmakePostloaddb/1181/ZFIN-9723.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1181/ZFIN-9723.sql
@@ -1,0 +1,23 @@
+--liquibase formatted sql
+--changeset rtaylor:ZFIN-9723
+
+-- ZFIN-9723: Fix feature sort order not updating when abbreviation changes
+--
+-- The feature_abbrev and feature_name AFTER UPDATE triggers tried to set
+-- NEW.feature_abbrev_order and NEW.feature_name_order, but PostgreSQL
+-- ignores row modifications in AFTER triggers. This left stale sort-order
+-- values whenever a feature abbreviation or name was changed post-creation.
+--
+-- Fix: make the existing BEFORE INSERT trigger also fire on UPDATE so that
+-- scrub_char and zero_pad are always applied. Clean up the AFTER triggers
+-- to contain only side-effects (history logging, genotype name cascades).
+
+-- Fix any existing stale sort-order values.
+-- Trigger definitions are updated in lib/DB_triggers/ and applied via gradle make.
+UPDATE feature
+SET feature_abbrev_order = zero_pad(feature_abbrev)
+WHERE feature_abbrev_order IS DISTINCT FROM zero_pad(feature_abbrev);
+
+UPDATE feature
+SET feature_name_order = zero_pad(feature_name)
+WHERE feature_name_order IS DISTINCT FROM zero_pad(feature_name);

--- a/source/org/zfin/db/postGmakePostloaddb/1181/db.changelog.master.xml
+++ b/source/org/zfin/db/postGmakePostloaddb/1181/db.changelog.master.xml
@@ -6,5 +6,6 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <include file="source/org/zfin/db/postGmakePostloaddb/1181/ZFIN-10204.sql" />
+    <include file="source/org/zfin/db/postGmakePostloaddb/1181/ZFIN-9723.sql" />
 
 </databaseChangeLog>


### PR DESCRIPTION
Fix feature sort order update triggers for abbreviation and name changes.

The feature_abbrev and feature_name AFTER UPDATE triggers tried to set NEW.feature_abbrev_order and NEW.feature_name_order, but PostgreSQL ignores row modifications in AFTER triggers. This left stale sort-order values whenever a feature abbreviation or name was changed post-creation.

Fix: make the existing BEFORE INSERT trigger also fire on UPDATE so that scrub_char and zero_pad are always applied. Clean up the AFTER triggers to contain only side-effects (history logging, genotype name cascades).

Fix any existing stale sort-order values.
Trigger definitions are updated in lib/DB_triggers/ and applied via gradle make.