### PR TITLE
ZFIN-9946: Use npm ci instead of npm install in build steps

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install ESLint
-        run: npm install
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run ESLint
         run: npm run lint

--- a/build.gradle
+++ b/build.gradle
@@ -1496,7 +1496,7 @@ task npmInstall(type: Exec) {
     description = 'Install npm dependencies'
     group = 'build'
 
-    commandLine 'npm', 'install'
+    commandLine 'npm', 'ci'
 
     inputs.file 'package.json'
     inputs.file 'package-lock.json'

--- a/build.xml
+++ b/build.xml
@@ -507,7 +507,7 @@
 
     <target name="npmInstall">
         <exec executable="npm" failonerror="true">
-            <arg value="install"/>
+            <arg value="ci"/>
         </exec>
     </target>
 


### PR DESCRIPTION
npm ci is faster and more deterministic for CI/build environments — it installs exactly what's in package-lock.json and fails if the lock file is out of sync with package.json.