### PR TITLE
ZFIN-10225: Fix closed ResultSet error in profile search methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1201,6 +1201,7 @@ test {
             includeTestsMatching "org.zfin.httpunittest.MarkerViewSmokeTest"
             includeTestsMatching "org.zfin.sebservice.MarkerRestSmokeTest"
             includeTestsMatching "org.zfin.framework.presentation.HealthEndpointSmokeTest"
+            includeTestsMatching "org.zfin.profile.smoketest.ProfileSearchSmokeTest"
             //include specific method in any of the tests
             //        includeTestsMatching "*ActiveDataTest"
             }

--- a/source/org/zfin/profile/repository/HibernateProfileRepository.java
+++ b/source/org/zfin/profile/repository/HibernateProfileRepository.java
@@ -19,7 +19,7 @@ import org.zfin.profile.presentation.*;
 import org.zfin.profile.service.ProfileService;
 import org.zfin.publication.Publication;
 import org.zfin.publication.repository.PublicationRepository;
-import org.zfin.repository.PaginationResultFactory;
+
 import org.zfin.repository.RepositoryFactory;
 
 import jakarta.persistence.Tuple;
@@ -821,8 +821,12 @@ public class HibernateProfileRepository implements ProfileRepository {
             parameterMap.forEach((name, value) -> query.setParameter(name, ((String) value).toLowerCase()));
         }
 
-        PaginationResult<Company> paginationResult = PaginationResultFactory.createResultFromScrollableResultAndClose(
-            searchBean.getFirstRecordOnPage() - 1, searchBean.getLastRecordOnPage(), query.scroll());
+        List<Company> allResults = query.getResultList();
+        int start = searchBean.getFirstRecordOnPage() - 1;
+        int end = Math.min(searchBean.getLastRecordOnPage(), allResults.size());
+        PaginationResult<Company> paginationResult = new PaginationResult<>();
+        paginationResult.setPopulatedResults(new ArrayList<>(allResults.subList(start, end)));
+        paginationResult.setTotalCount(allResults.size());
         paginationResult.setStart(searchBean.getFirstRecord());
 
         return paginationResult;
@@ -865,8 +869,12 @@ public class HibernateProfileRepository implements ProfileRepository {
             parameterMap.forEach((name, value) -> query.setParameter(name, ((String) value).toLowerCase()));
         }
 
-        PaginationResult<Lab> paginationResult = PaginationResultFactory.createResultFromScrollableResultAndClose(
-            searchBean.getFirstRecordOnPage() - 1, searchBean.getLastRecordOnPage(), query.scroll());
+        List<Lab> allResults = query.getResultList();
+        int start = searchBean.getFirstRecordOnPage() - 1;
+        int end = Math.min(searchBean.getLastRecordOnPage(), allResults.size());
+        PaginationResult<Lab> paginationResult = new PaginationResult<>();
+        paginationResult.setPopulatedResults(new ArrayList<>(allResults.subList(start, end)));
+        paginationResult.setTotalCount(allResults.size());
         paginationResult.setStart(searchBean.getFirstRecord());
 
         return paginationResult;
@@ -976,8 +984,12 @@ public class HibernateProfileRepository implements ProfileRepository {
             parameterMap.forEach((name, value) -> query.setParameter(name, ((String) value).toLowerCase()));
         }
 
-        PaginationResult<Person> paginationResult = PaginationResultFactory.createResultFromScrollableResultAndClose(
-            searchBean.getFirstRecordOnPage() - 1, searchBean.getLastRecordOnPage(), query.scroll());
+        List<Person> allResults = query.getResultList();
+        int start = searchBean.getFirstRecordOnPage() - 1;
+        int end = Math.min(searchBean.getLastRecordOnPage(), allResults.size());
+        PaginationResult<Person> paginationResult = new PaginationResult<>();
+        paginationResult.setPopulatedResults(new ArrayList<>(allResults.subList(start, end)));
+        paginationResult.setTotalCount(allResults.size());
         paginationResult.setStart(searchBean.getFirstRecord());
 
         return paginationResult;

--- a/test/org/zfin/SmokeTests.java
+++ b/test/org/zfin/SmokeTests.java
@@ -15,6 +15,7 @@ import org.zfin.httpunittest.MarkerViewSmokeTest;
 import org.zfin.mapping.MappingDetailSmokeTest;
 import org.zfin.marker.MarkerStrSmokeTest;
 import org.zfin.mutant.smoketest.ConstructSmokeTest;
+import org.zfin.profile.smoketest.ProfileSearchSmokeTest;
 import org.zfin.sequence.blast.smoketest.BlastSmokeTest;
 import org.zfin.webservice.MarkerRestSmokeTest;
 
@@ -39,6 +40,7 @@ import org.zfin.webservice.MarkerRestSmokeTest;
     MarkerStrSmokeTest.class,
     MarkerViewSmokeTest.class,
     MarkerRestSmokeTest.class,
+    ProfileSearchSmokeTest.class,
 
 //TODO: fix these webspecs and uncomment them
 //        FigureViewWebSpec.class,

--- a/test/org/zfin/profile/smoketest/ProfileSearchSmokeTest.java
+++ b/test/org/zfin/profile/smoketest/ProfileSearchSmokeTest.java
@@ -1,0 +1,46 @@
+package org.zfin.profile.smoketest;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.zfin.AbstractSmokeTest;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@RunWith(Parameterized.class)
+public class ProfileSearchSmokeTest extends AbstractSmokeTest {
+
+    public ProfileSearchSmokeTest(WebClient webClient) {
+        super(webClient);
+    }
+
+    @Test
+    public void testLabSearchReturnsResults() throws IOException {
+        HtmlPage page = webClient.getPage(nonSecureUrlDomain +
+            "/action/profile/lab/search/execute?name=zfin&maxDisplayRecords=25&containsType=bio&action=Search");
+        assertThat(page.getTitleText(), containsString("Lab Search"));
+        assertThat(page.getByXPath("//table[contains(@class,'searchresults')]").size(), greaterThan(0));
+    }
+
+    @Test
+    public void testCompanySearchReturnsResults() throws IOException {
+        HtmlPage page = webClient.getPage(nonSecureUrlDomain +
+            "/action/profile/company/search/execute?name=aquatic&maxDisplayRecords=25&containsType=bio&action=Search");
+        assertThat(page.getTitleText(), containsString("Company Search"));
+        assertThat(page.getByXPath("//table[contains(@class,'searchresults')]").size(), greaterThan(0));
+    }
+
+    @Test
+    public void testPersonSearchReturnsResults() throws IOException {
+        HtmlPage page = webClient.getPage(nonSecureUrlDomain +
+            "/action/profile/person/search/execute?name=westerfield&maxDisplayRecords=25&containsType=bio&action=Search");
+        assertThat(page.getTitleText(), containsString("Person Search"));
+        assertThat(page.getByXPath("//table[contains(@class,'searchresults')]").size(), greaterThan(0));
+    }
+
+}


### PR DESCRIPTION
Replace ScrollableResults with getResultList() in searchLabs, searchCompanies, and searchPeople to avoid JDBC cursor conflicts caused by eager-loaded Person associations triggering secondary queries that close the open cursor on PostgreSQL.

The problem was a circular EAGER fetch chain:
1. searchLabs uses query.scroll() → returns a ScrollableResults backed by an open JDBC cursor
2. As Hibernate materializes each Lab, it eagerly loads Organization.owner (a Person, since @ManyToOne defaults to EAGER)
3. Person.labs is annotated @ManyToMany(fetch = FetchType.EAGER) at Person.java:142 — so loading the Person triggers loading all their Labs
4. This secondary query executes on the same JDBC connection while the ScrollableResults cursor is still open
5. PostgreSQL's JDBC driver can only have one open ResultSet per connection — the secondary query closes the original cursor
6. When scrollableResults.next() is called again → "closed ResultSet"

The fix is to replace query.scroll() with query.getResultList() in these search methods. The scroll-based approach provides no benefit here anyway — the code iterates through ALL rows to get a total count, so there's no memory savings from the cursor.