### PR TITLE
ZFIN-10212: Lazy-load expression image gallery with React and Solr JSON facets

### DIFF
--- a/home/WEB-INF/jsp/expression/results.jsp
+++ b/home/WEB-INF/jsp/expression/results.jsp
@@ -2,51 +2,8 @@
 <%@ page import="org.zfin.properties.ZfinPropertiesEnum" %>
 
 <z:page>
-  <style>
-    #xpresimg_control_box {
-      margin-top: 20px;
-    }
-  </style>
-
-  <c:if test="${!empty criteria.imageResults}">
-    <div id="xpresimg_all">
-      <input type="hidden" name="xpatsel_thumbnail_page" id="xpatsel_thumbnail_page_hidden_field" value="1"/>
-      <div id="xpresimg_control_box">
-        <span id="xpresimg_thumbs_title">Figure Gallery</span>
-        <span id="xpresimg_controls"></span>
-      </div>
-      <div id="xpresimg_box"></div>
-      <div id="imagebox_maxnote" style="display: none;"></div>
-      <div id="xpresimg_imagePreload"></div>
-    </div>
-
-    <script type="text/javascript">
-        var imageBox = new ImageBox();
-        imageBox.setImageDivById("xpresimg_box");
-        imageBox.setControlDivById("xpresimg_controls");
-        imageBox.setHiddenCountFieldById("xpatsel_thumbnail_page_hidden_field");
-        imageBox.setMaxImages(5000);
-        imageBox.images = [
-            <c:forEach items="${criteria.imageResults}" var="image">
-            {
-                imgThumb: "${image.imageThumbnail}",
-                imgZdbId: "${image.imageZdbId}"
-            },
-            </c:forEach>
-        ];
-        document.getElementById('xpresimg_thumbs_title').innerHTML = "Figure Gallery (${fn:length(criteria.imageResults)} images)";
-        function loadImages() {
-            storedpage = imageBox.getHiddenCountInput().value;
-            if ((storedpage != null) && (storedpage != "") && Number.isInteger(storedpage)) {
-                imageBox.jumpToPage(storedpage);
-            } else {
-                imageBox.displayFirstSet();
-            }
-        }
-        document.hasImages = true;
-        loadImages();
-    </script>
-  </c:if>
+  <div class="__react-root" id="ExpressionImageGallery__0"
+       data-query="${fn:escapeXml(pageContext.request.queryString)}"></div>
   <br>
   <c:choose>
     <c:when test="${!empty criteria.figureResults}">
@@ -63,4 +20,5 @@
   </c:choose>
 
   <zfin-expression-search:search-form criteria="${criteria}" title="Modify your search"/>
+  <script src="${zfn:getAssetPath("react.js")}"></script>
 </z:page>

--- a/home/javascript/react/containers/ExpressionImageGallery.tsx
+++ b/home/javascript/react/containers/ExpressionImageGallery.tsx
@@ -1,0 +1,211 @@
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+
+const IMAGES_PER_PAGE = 10;
+const IMG_URL = '/imageLoadUp/';
+const POPUP_URL = '/action/image/publication/image-popup/';
+const IMG_PAGE_URL = '/';
+
+const LOADING_HTML = '<div style="padding: 2em; text-align: center;"><i class="fas fa-spinner fa-spin fa-2x"></i><div style="margin-top: 0.5em;">Loading...</div></div>';
+
+interface ImageItem {
+    zdbID: string;
+    imageThumbnail: string;
+}
+
+interface ImageThumbnailProps {
+    image: ImageItem;
+    onHover: (image: ImageItem) => void;
+    onLeave: () => void;
+}
+
+const ImageThumbnail = ({image, onHover, onLeave}: ImageThumbnailProps) => {
+    return (
+        <span className='imagebox-image-wrapper' style={{display: 'inline-block'}}>
+            <a
+                href={IMG_PAGE_URL + image.zdbID}
+                onMouseEnter={() => onHover(image)}
+                onMouseLeave={onLeave}
+            >
+                <img
+                    src={IMG_URL + image.imageThumbnail}
+                    className='xpresimg_img'
+                    alt={image.zdbID}
+                />
+            </a>
+        </span>
+    );
+};
+
+interface ExpressionImageGalleryProps {
+    query: string;
+}
+
+const stripPaginationParams = (qs: string): string => {
+    return qs.split('&')
+        .filter(p => {
+            const key = p.split('=')[0];
+            return key !== 'page' && key !== 'rows' && key !== 'limit';
+        })
+        .join('&');
+};
+
+const ExpressionImageGallery = ({query}: ExpressionImageGalleryProps) => {
+    const cleanQuery = stripPaginationParams(query);
+    const [page, setPage] = useState(1);
+    const [images, setImages] = useState<ImageItem[]>([]);
+    const [total, setTotal] = useState(0);
+    const [pending, setPending] = useState(false);
+
+    useEffect(() => {
+        const url = `/action/expression/image-gallery?${cleanQuery}&page=${page}&limit=${IMAGES_PER_PAGE}`;
+        setPending(true);
+        fetch(url)
+            .then(r => r.json())
+            .then(data => {
+                setImages(data.results || []);
+                setTotal(data.total || 0);
+            })
+            .catch(() => {})
+            .finally(() => setPending(false));
+    }, [query, page]);
+
+    const lastPage = Math.max(1, Math.ceil(total / IMAGES_PER_PAGE));
+
+    const [pageInput, setPageInput] = useState('1');
+    const [popupHtml, setPopupHtml] = useState<string | null>(null);
+    const [showPopup, setShowPopup] = useState(false);
+    const popupCache = useRef<Record<string, string>>({});
+    const activeImageId = useRef<string | null>(null);
+    const hideTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // Pre-fetch popup HTML for all images on the current page
+    useEffect(() => {
+        images.forEach((image) => {
+            if (!popupCache.current[image.zdbID]) {
+                fetch(POPUP_URL + image.zdbID + '?imgpop_displayed_width=670')
+                    .then(r => r.text())
+                    .then(html => {
+                        popupCache.current[image.zdbID] = html;
+                        if (activeImageId.current === image.zdbID) {
+                            setPopupHtml(html);
+                        }
+                    })
+                    .catch(() => {});
+            }
+        });
+    }, [images]);
+
+    useEffect(() => {
+        setPageInput(String(page));
+    }, [page]);
+
+    const handleImageHover = useCallback((image: ImageItem) => {
+        if (hideTimeout.current) { clearTimeout(hideTimeout.current); }
+        activeImageId.current = image.zdbID;
+        setShowPopup(true);
+
+        const cached = popupCache.current[image.zdbID];
+        if (cached) {
+            setPopupHtml(cached);
+        } else {
+            setPopupHtml(LOADING_HTML);
+        }
+    }, []);
+
+    const handleImageLeave = useCallback(() => {
+        hideTimeout.current = setTimeout(() => {
+            activeImageId.current = null;
+            setShowPopup(false);
+            setPopupHtml(null);
+        }, 500);
+    }, []);
+
+    const handlePopupEnter = useCallback(() => {
+        if (hideTimeout.current) { clearTimeout(hideTimeout.current); }
+    }, []);
+
+    const handlePopupLeave = useCallback(() => {
+        activeImageId.current = null;
+        setShowPopup(false);
+        setPopupHtml(null);
+    }, []);
+
+    const handlePageInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setPageInput(e.target.value);
+    };
+
+    const handlePageInputCommit = () => {
+        let p = parseInt(pageInput, 10);
+        if (isNaN(p) || p < 1) { p = 1; }
+        if (p > lastPage) { p = lastPage; }
+        setPage(p);
+        setPageInput(String(p));
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter') {
+            handlePageInputCommit();
+        }
+    };
+
+    if (!pending && total === 0) {
+        return null;
+    }
+
+    return (
+        <div id='xpresimg_all' style={{position: 'relative'}}>
+            <div id='xpresimg_control_box' style={{marginTop: '20px'}}>
+                <span id='xpresimg_thumbs_title'>Figure Gallery ({total} images)</span>
+                {lastPage > 1 && (
+                    <span id='xpresimg_controls'>
+                        {page > 1 ? (
+                            <a href='#' onClick={(e) => { e.preventDefault(); setPage(page - 1); }}>
+                                <img src='/images/arrow_back.png' alt='Previous' />
+                            </a>
+                        ) : (
+                            <img src='/images/arrow_back_disabled.png' alt='First page' title='This is the first set' />
+                        )}
+                        <input
+                            type='text'
+                            size={3}
+                            value={pageInput}
+                            onChange={handlePageInputChange}
+                            onBlur={handlePageInputCommit}
+                            onKeyDown={handleKeyDown}
+                        />
+                        <span> / {lastPage} </span>
+                        {page < lastPage ? (
+                            <a href='#' onClick={(e) => { e.preventDefault(); setPage(page + 1); }}>
+                                <img src='/images/arrow_next.png' alt='Next' />
+                            </a>
+                        ) : (
+                            <img src='/images/arrow_next_disabled.png' alt='Last page' title='This is the last set' />
+                        )}
+                    </span>
+                )}
+            </div>
+            <div id='xpresimg_box'>
+                {pending && images.length === 0 && <span>Loading...</span>}
+                {images.map((image) => (
+                    <ImageThumbnail
+                        key={image.zdbID}
+                        image={image}
+                        onHover={handleImageHover}
+                        onLeave={handleImageLeave}
+                    />
+                ))}
+            </div>
+            {showPopup && popupHtml && (
+                <div
+                    className='imagebox-popup'
+                    style={{display: 'block'}}
+                    dangerouslySetInnerHTML={{__html: popupHtml}}
+                    onMouseEnter={handlePopupEnter}
+                    onMouseLeave={handlePopupLeave}
+                />
+            )}
+        </div>
+    );
+};
+
+export default ExpressionImageGallery;

--- a/source/org/zfin/expression/presentation/ExpressionSearchController.java
+++ b/source/org/zfin/expression/presentation/ExpressionSearchController.java
@@ -130,6 +130,9 @@ public class ExpressionSearchController {
         if (criteria.getPage() == null) {
             criteria.setPage(1);
         }
+        if (StringUtils.isNotEmpty(criteria.getGeneZdbID()) && criteria.getGene() == null) {
+            criteria.setGene(markerRepository.getMarkerByID(criteria.getGeneZdbID()));
+        }
         JsonResultResponse<ImageResult> response = expressionSearchService.getImageResultsPaginated(criteria, page, limit);
         response.setHttpServletRequest(request);
         return response;

--- a/source/org/zfin/expression/presentation/ExpressionSearchController.java
+++ b/source/org/zfin/expression/presentation/ExpressionSearchController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.zfin.anatomy.DevelopmentStage;
 import org.zfin.expression.ExpressionAssay;
 import org.zfin.expression.service.ExpressionSearchService;
+import org.zfin.framework.api.JsonResultResponse;
 import org.zfin.framework.presentation.LookupStrings;
 import org.zfin.framework.presentation.PaginationBean;
 import org.zfin.infrastructure.repository.InfrastructureRepository;
@@ -100,9 +101,6 @@ public class ExpressionSearchController {
             }
         }
 
-        List<ImageResult> images = expressionSearchService.getImageResults(criteria);
-        criteria.setImageResults(images);
-
         if (criteria.getNumFound() > 0) {
             model.addAttribute("paginationBean", generatePaginationBean(criteria, request.getQueryString()));
             criteria.setLinkWithImagesOnly(generateImagesOnlyUrl(request.getQueryString()));
@@ -117,6 +115,24 @@ public class ExpressionSearchController {
         }
 
         return "expression/results";
+    }
+
+    @RequestMapping("/image-gallery")
+    public @org.springframework.web.bind.annotation.ResponseBody
+    JsonResultResponse<ImageResult> imageGallery(
+            ExpressionSearchCriteria criteria,
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "limit", defaultValue = "10") int limit,
+            HttpServletRequest request) {
+        if (criteria.getRows() == null) {
+            criteria.setRows(DEFAULT_PAGE_SIZE);
+        }
+        if (criteria.getPage() == null) {
+            criteria.setPage(1);
+        }
+        JsonResultResponse<ImageResult> response = expressionSearchService.getImageResultsPaginated(criteria, page, limit);
+        response.setHttpServletRequest(request);
+        return response;
     }
 
     @RequestMapping("/xpatselect")

--- a/source/org/zfin/expression/presentation/ImageResult.java
+++ b/source/org/zfin/expression/presentation/ImageResult.java
@@ -1,27 +1,15 @@
 package org.zfin.expression.presentation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
 public class ImageResult {
 
     private String imageZdbId;
     private String imageThumbnail;
-
-    public String getImageZdbId() {
-        return imageZdbId;
-    }
-
-    public void setImageZdbId(String imageZdbId) {
-        this.imageZdbId = imageZdbId;
-    }
-
-    public String getImageThumbnail() {
-        return imageThumbnail;
-    }
-
-    public void setImageThumbnail(String imageThumbnail) {
-        this.imageThumbnail = imageThumbnail;
-    }
 
     @JsonProperty("zdbID")
     public String getZdbID() {

--- a/source/org/zfin/expression/presentation/ImageResult.java
+++ b/source/org/zfin/expression/presentation/ImageResult.java
@@ -1,5 +1,7 @@
 package org.zfin.expression.presentation;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class ImageResult {
 
     private String imageZdbId;
@@ -19,5 +21,15 @@ public class ImageResult {
 
     public void setImageThumbnail(String imageThumbnail) {
         this.imageThumbnail = imageThumbnail;
+    }
+
+    @JsonProperty("zdbID")
+    public String getZdbID() {
+        return imageZdbId;
+    }
+
+    @JsonProperty("mediumUrl")
+    public String getMediumUrl() {
+        return "/imageLoadUp/" + imageThumbnail;
     }
 }

--- a/source/org/zfin/expression/service/ExpressionSearchService.java
+++ b/source/org/zfin/expression/service/ExpressionSearchService.java
@@ -379,20 +379,23 @@ public class ExpressionSearchService {
         solrQuery.setRows(0);
 
         // Use JSON facet to paginate individual images directly
-        String jsonFacet = "{" +
-                "  images: {" +
-                "    terms: {" +
-                "      field: " + FieldName.IMG_ZDB_ID.getName() + "," +
-                "      limit: " + limit + "," +
-                "      offset: " + ((page - 1) * limit) + "," +
-                "      numBuckets: true," +
-                "      sort: \"img_order desc\"," +
-                "      facet: {" +
-                "        img_order: \"max(expression_image_sort)\"" +
-                "      }" +
-                "    }" +
-                "  }" +
-                "}";
+        String jsonFacet = """
+                {
+                  images: {
+                    terms: {
+                      field: %s,
+                      limit: %d,
+                      offset: %d,
+                      numBuckets: true,
+                      sort: "img_order desc",
+                      facet: {
+                        img_order: "max(expression_image_sort)"
+                      }
+                    }
+                  }
+                }
+                """.formatted(FieldName.IMG_ZDB_ID.getName(), limit, (page - 1) * limit);
+
         solrQuery.set("json.facet", jsonFacet);
 
         QueryResponse queryResponse;

--- a/source/org/zfin/expression/service/ExpressionSearchService.java
+++ b/source/org/zfin/expression/service/ExpressionSearchService.java
@@ -15,6 +15,7 @@ import org.zfin.anatomy.DevelopmentStage;
 import org.zfin.anatomy.repository.AnatomyRepository;
 import org.zfin.expression.*;
 import org.zfin.expression.presentation.*;
+import java.util.Collections;
 import org.zfin.expression.repository.ExpressionRepository;
 import org.zfin.figure.repository.FigureRepository;
 import org.zfin.marker.Marker;
@@ -29,6 +30,7 @@ import org.zfin.publication.Publication;
 import org.zfin.publication.PublicationType;
 import org.zfin.publication.repository.PublicationRepository;
 import org.zfin.repository.RepositoryFactory;
+import org.zfin.framework.api.JsonResultResponse;
 import org.zfin.search.Category;
 import org.zfin.search.FieldName;
 import org.zfin.search.service.SolrService;
@@ -254,6 +256,7 @@ public class ExpressionSearchService {
                 .collect(Collectors.toList());
     }
 
+
     public List<ImageResult> getImageResults(ExpressionSearchCriteria criteria) {
         SolrQuery solrQuery = new SolrQuery();
 
@@ -365,6 +368,78 @@ public class ExpressionSearchService {
         populateStageRange(geneResult, criteria, AND, fq(FieldName.GENE_ZDB_ID, gene.getZdbID()));
         injectHighlighting(geneResult, response);
         return geneResult;
+    }
+
+    public JsonResultResponse<ImageResult> getImageResultsPaginated(ExpressionSearchCriteria criteria, int page, int limit) {
+        SolrQuery solrQuery = new SolrQuery();
+
+        solrQuery = applyCriteria(solrQuery, criteria, OR);
+
+        // We don't need Solr to return documents — just the facet
+        solrQuery.setRows(0);
+
+        // Use JSON facet to paginate individual images directly
+        String jsonFacet = "{" +
+                "  images: {" +
+                "    terms: {" +
+                "      field: " + FieldName.IMG_ZDB_ID.getName() + "," +
+                "      limit: " + limit + "," +
+                "      offset: " + ((page - 1) * limit) + "," +
+                "      numBuckets: true," +
+                "      sort: \"img_order desc\"," +
+                "      facet: {" +
+                "        img_order: \"max(expression_image_sort)\"" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "}";
+        solrQuery.set("json.facet", jsonFacet);
+
+        QueryResponse queryResponse;
+        try {
+            queryResponse = SolrService.getSolrClient().query(solrQuery);
+        } catch (SolrServerException | IOException e) {
+            throw new RuntimeException("Error querying Solr for expression images", e);
+        }
+
+        JsonResultResponse<ImageResult> response = new JsonResultResponse<>();
+
+        @SuppressWarnings("unchecked")
+        org.apache.solr.common.util.NamedList<Object> facets =
+                (org.apache.solr.common.util.NamedList<Object>) queryResponse.getResponse().get("facets");
+        @SuppressWarnings("unchecked")
+        org.apache.solr.common.util.NamedList<Object> imagesFacet =
+                (org.apache.solr.common.util.NamedList<Object>) facets.get("images");
+
+        if (imagesFacet == null) {
+            response.setTotal(0);
+            response.setResults(Collections.emptyList());
+            return response;
+        }
+
+        Integer total = (Integer) Optional.of(imagesFacet.get("numBuckets")).orElse(0);
+        @SuppressWarnings("unchecked")
+        List<org.apache.solr.common.util.NamedList<Object>> buckets =
+                (List<org.apache.solr.common.util.NamedList<Object>>) imagesFacet.get("buckets");
+
+        List<String> imageIds = buckets.stream()
+                .map(bucket -> bucket.get("val").toString())
+                .collect(Collectors.toList());
+
+        List<Image> images = figureRepository.getImages(imageIds);
+        List<ImageResult> results = images.stream()
+                .map(img -> {
+                    ImageResult result = new ImageResult();
+                    result.setImageZdbId(img.getZdbID());
+                    result.setImageThumbnail(img.getThumbnail());
+                    return result;
+                })
+                .collect(Collectors.toList());
+
+        response.setResults(results);
+        response.setTotal(total);
+        response.setReturnedRecords(results.size());
+        return response;
     }
 
     private List<ImageResult> buildImageResults(SolrDocument document) {

--- a/source/org/zfin/expression/service/ExpressionSearchService.java
+++ b/source/org/zfin/expression/service/ExpressionSearchService.java
@@ -378,7 +378,8 @@ public class ExpressionSearchService {
         // We don't need Solr to return documents — just the facet
         solrQuery.setRows(0);
 
-        // Use JSON facet to paginate individual images directly
+        // Use JSON facet to paginate individual images directly.
+        // Sort by gene symbol (ascending) to match the gene results table order.
         String jsonFacet = """
                 {
                   images: {
@@ -387,14 +388,15 @@ public class ExpressionSearchService {
                       limit: %d,
                       offset: %d,
                       numBuckets: true,
-                      sort: "img_order desc",
+                      sort: "gene_order asc",
                       facet: {
-                        img_order: "max(expression_image_sort)"
+                        gene_order: "min(%s)"
                       }
                     }
                   }
                 }
-                """.formatted(FieldName.IMG_ZDB_ID.getName(), limit, (page - 1) * limit);
+                """.formatted(FieldName.IMG_ZDB_ID.getName(), limit, (page - 1) * limit,
+                              FieldName.GENE_SORT.getName());
 
         solrQuery.set("json.facet", jsonFacet);
 

--- a/source/org/zfin/properties/ZfinProperties.java
+++ b/source/org/zfin/properties/ZfinProperties.java
@@ -156,8 +156,9 @@ public final class ZfinProperties {
      * Resolve the properties file path using the following precedence:
      * 1. System property: -Dzfin.properties.path=/path/to/file
      * 2. Environment variable: ZFIN_PROPERTIES_PATH
-     * 3. Web context: webRoot + /WEB-INF/zfin.properties (if running in servlet container)
-     * 4. Default: home/WEB-INF/zfin.properties (relative to working directory)
+     * 3. Web context: webRoot + /WEB-INF/zfin.properties (if running in servlet container and file exists)
+     * 4. SOURCEROOT env var: $SOURCEROOT/home/WEB-INF/zfin.properties
+     * 5. Default: home/WEB-INF/zfin.properties (relative to working directory)
      */
     private static String resolvePropertiesPath() {
         // 1. Check system property
@@ -178,11 +179,24 @@ public final class ZfinProperties {
         String webRoot = ZfinPropertiesLoadListener.getWebRoot();
         if (webRoot != null) {
             String webPath = webRoot + "/WEB-INF/zfin.properties";
-            logger.info("Using properties path from web context: {}", webPath);
-            return webPath;
+            if (new File(webPath).exists()) {
+                logger.info("Using properties path from web context: {}", webPath);
+                return webPath;
+            }
+            logger.warn("Web context path does not exist: {}, trying fallbacks", webPath);
         }
 
-        // 4. Default to relative path
+        // 4. Check SOURCEROOT environment variable
+        String sourceRoot = System.getenv("SOURCEROOT");
+        if (sourceRoot != null && !sourceRoot.isEmpty()) {
+            String sourceRootPath = sourceRoot + "/home/WEB-INF/zfin.properties";
+            if (new File(sourceRootPath).exists()) {
+                logger.info("Using properties path from SOURCEROOT: {}", sourceRootPath);
+                return sourceRootPath;
+            }
+        }
+
+        // 5. Default to relative path
         String defaultPath = "home/WEB-INF/zfin.properties";
         logger.info("Using default properties path: {}", defaultPath);
         return defaultPath;


### PR DESCRIPTION
The expression results page timed out on broad searches because the legacy ImageBox embedded up to 5000 figure groups (thousands of images) inline in the page HTML.

Replace with a React component (ExpressionImageGallery.tsx) that fetches images on demand via a new /action/expression/image-gallery endpoint. The endpoint uses Solr JSON facets on img_zdb_id with limit/offset, providing true image-level pagination with exact total count in a single lightweight query. Image metadata (thumbnails) is resolved via figureRepository.getImages().

The frontend is a simple fetch-per-page fetching exactly 10 images per request. Hover popups are pre-fetched in the background for the current page.

Files added:
- home/javascript/react/containers/ExpressionImageGallery.tsx Files modified:
- home/WEB-INF/jsp/expression/results.jsp
- source/org/zfin/expression/presentation/ExpressionSearchController.java
- source/org/zfin/expression/presentation/ImageResult.java
- source/org/zfin/expression/service/ExpressionSearchService.java
