### PR TITLE
ZFIN-10231 & ZFIN-10236: GAF load - accept multiple IEA inferences

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -225,6 +225,7 @@ services:
       - ${DOCKER_RESEARCH_PATH}:/mnt/research
       - ${DOCKER_ABBLAST_PATH}:/opt/ab-blast
       - ${DOCKER_BLASTSERVER_BLAST_DATABASE_PATH}:/opt/zfin/blastdb
+      - ${DOCKER_DB_UNLOADS_PATH}:/opt/zfin/unloads/db
       - ${DOCKER_DOWNLOADS_PATH}:/opt/zfin/download-files
       - ${DOCKER_LOADUP_PATH}:/opt/zfin/loadUp
       - ${DOCKER_GFF3_PATH}:/opt/zfin/gff3

--- a/reference/load-gaf-goa.md
+++ b/reference/load-gaf-goa.md
@@ -1,0 +1,201 @@
+# Load-GAF-GOA Job
+
+## Overview
+
+The Load-GAF-GOA job (`Load-GAF-GOA_m`) runs monthly to sync ZFIN's Gene Ontology annotations with the latest release from the GOA (Gene Ontology Annotation) project at EBI. It downloads zebrafish GO annotation files in GAF (Gene Association Format), maps entries to ZFIN genes, validates them, and loads new annotations while removing stale ones.
+
+**Jenkins job**: `Load-GAF-GOA_m`
+**Schedule**: Monthly
+**Timeout**: 300 minutes
+
+## Input Files
+
+Three files are downloaded from EBI and concatenated into a single GAF file for processing:
+
+| File | Contents |
+|------|----------|
+| `goa_zebrafish.gaf.gz` | Main file. GO annotations for zebrafish proteins (UniProt accessions). Sources include UniProt (IEA), GO_Central (IBA), IntAct (IPI), and manual curation. This is the bulk of the data. |
+| `goa_zebrafish_isoform.gaf.gz` | Annotations for specific protein isoforms (splice variants). Same format but includes isoform-specific accessions like `UniProtKB:E9QI36-1` in the `geneProductFormID` field. |
+| `goa_zebrafish_rna.gaf.gz` | Annotations for non-coding RNA sequences using RNAcentral IDs (`URS*`). Sources are primarily RNAcentral with Rfam evidence. |
+
+Default URLs (overridable via Jenkins environment variables `GOA_GAF_URL1`, `GOA_GAF_URL2`, `GOA_GAF_URL3`):
+- `ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/ZEBRAFISH/goa_zebrafish.gaf.gz`
+- `ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/ZEBRAFISH/goa_zebrafish_isoform.gaf.gz`
+- `ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/ZEBRAFISH/goa_zebrafish_rna.gaf.gz`
+
+## Processing Pipeline
+
+### 1. Download
+Downloads all three GAF files. Files 2 and 3 are appended to file 1 to create a combined input. If the file hasn't changed since the last successful run and `skipDownloadIfUnchanged` is true, the job exits early.
+
+### 2. Parse (`FpInferenceGafParser`)
+Each line is parsed into a `GafEntry`. Entries are filtered during parsing and rejected if:
+- **Evidence code is excluded**: ND, NAS, TAS, or EXP
+- **`createdBy` is empty**
+- **`createdBy` is "ZFIN"**: We don't reimport our own annotations
+- **Taxon is not zebrafish**: Must be `taxon:7955`
+- **GO_REF is excluded**: `GO_REF:0000002`, `0000003`, `0000004`, `0000015`, `0000037`, `0000038`
+
+Rejection counts by reason are tracked and included in the error summary report.
+
+### 3. Map to ZFIN Genes (`GafService.getGenes()`)
+Each entry's `entryId` (typically a UniProt accession) is looked up in `db_link` to find the associated ZFIN gene:
+
+- **ZDB-GENE / RNAG IDs**: Looked up directly via `markerRepository.getGeneByID()`
+- **URS* (RNAcentral) IDs**: Taxon suffix (`_7955`) is stripped, then looked up in `db_link` across all foreign databases. If the link points to a transcript (`ZDB-TSCRIPT-*`), the parent gene is resolved via the "gene produces transcript" marker relationship.
+- **All other IDs** (UniProt): Looked up via `db_link` filtered to UniProtKB and GenPept reference databases.
+
+### 4. Validate
+Each annotation is validated for:
+- GO term not obsolete, not in "Do Not Annotate" subset
+- Inference field cardinality and type validity
+- Evidence code vs publication consistency
+- Protein binding (`GO:0005515`) requires IPI evidence
+- No duplicate of an existing or more-specific annotation
+
+### 5. Load
+New `MarkerGoTermEvidence` records are batch-inserted. Stale annotations (in the DB but not in the new GAF file) are removed.
+
+### 6. Report
+Output files written to `$TARGETROOT/server_apps/DB_maintenance/gafLoad/Load-GAF-GOA_m/`:
+
+| File | Contents |
+|------|----------|
+| `Load-GAF-GOA_m_summary.txt` | High-level counts (added, removed, errors, existing) |
+| `Load-GAF-GOA_m_details.txt` | Full details of every removed, added, updated, errored, and existing entry |
+| `Load-GAF-GOA_m_error_summary.txt` | Categorized error analysis with counts, gene-not-found breakdown, and parser rejection stats |
+| `Load-GAF-GOA_m_errors.txt` | Stack trace if the job fails with an exception |
+
+The error summary and the regular summary are both included in the success email.
+
+## Key Code Locations
+
+| File | Purpose |
+|------|---------|
+| `source/org/zfin/datatransfer/go/service/GafLoadJob.java` | Main job orchestration |
+| `source/org/zfin/datatransfer/go/service/GafService.java` | Gene mapping, annotation generation, validation |
+| `source/org/zfin/datatransfer/go/FpInferenceGafParser.java` | GAF file parsing and entry filtering |
+| `source/org/zfin/datatransfer/go/GoaGafParser.java` | GOA-specific parser extensions |
+| `source/org/zfin/datatransfer/go/GafErrorSummary.java` | Error summary report generation |
+| `source/org/zfin/gwt/root/dto/GoEvidenceCodeEnum.java` | Evidence code definitions and cardinality rules |
+| `source/org/zfin/gwt/root/dto/InferenceCategory.java` | Inference type definitions and regex matching |
+| `source/org/zfin/gwt/root/dto/GoDefaultPublication.java` | GO_REF to ZFIN publication mappings |
+| `source/org/zfin/gwt/root/ui/GoEvidenceValidator.java` | Evidence and inference validation logic |
+| `server_apps/jenkins/jobs/Load-GAF-GOA_m/config.xml` | Jenkins job configuration |
+
+## Error Analysis
+
+### Typical Error Distribution
+
+Based on analysis of 12 builds (Feb 2025 — Apr 2026):
+
+| Category | Typical Count | Notes |
+|----------|--------------|-------|
+| Gene not found for ID | ~17,000 | Dominant category. See breakdown below. |
+| Obsolete GO term referenced | 0–968 | Spikes when GO ontology obsoletes terms, drops to 0 after cleanup |
+| IEA inference field validation | ~300 | UniRule, RHEA, Ensembl, SubCell — entries with multiple inference refs |
+| Term in "Do Not Annotate" subset | ~38 | |
+| Duplicate annotation entry | ~14 | |
+| Publication not found for PMID | ~8 | |
+
+### Gene Not Found — Breakdown
+
+The ~17,000 "Gene not found" errors come from ~9,000 unique IDs:
+
+| ID Type | % of unique IDs | Description |
+|---------|----------------|-------------|
+| RNAcentral (`URS*`) | ~63% | Non-coding RNA IDs. Most are not in ZFIN's `db_link`. 30 unique IDs (55 annotation matches) now load after the TranscriptDBLink fix. |
+| TrEMBL (`A0A*`) | ~36% | Unreviewed UniProt entries. Computationally predicted proteins not yet loaded into ZFIN. |
+| Swiss-Prot / other | ~1% | Older accessions not present in ZFIN. |
+
+By annotation source: RNAcentral (~51%), UniProt (~36%), GO_Central (~13%).
+
+## Recent Changes and Motivations
+
+### IEA Inference Cardinality: 1 → 1+ (GoEvidenceCodeEnum)
+
+**Problem**: GOA began providing multiple inference references per IEA annotation (e.g., `UniRule:UR000376739|UniRule:UR000414636`). The old cardinality=1 rule rejected these, losing ~322 valid annotations per load.
+
+**Fix**: Changed IEA cardinality from exactly-1 to `CARDINALITY_ONE_OR_MORE`. The individual inference validation (`isInferenceValid`) still filters bad types, and the database schema (`inference_group_member` table) supports multiple members per annotation.
+
+**Monitoring**: IEA annotations with >1 inference are logged with `"IEA annotation with N inferences"`.
+
+### RNAcentral ID Mapping (GafService.getGenes)
+
+**Problem**: The RNA GAF file uses IDs with taxon suffixes (`URS0000005DE0_7955`) but ZFIN stores them without (`URS0000005DE0`). Additionally, RNAcentral `db_link` records point to transcripts (`ZDB-TSCRIPT-*`), which use the Hibernate discriminator `'TSCR'`. The original code queried `MarkerDBLink` (discriminator `'MARK'`), which silently excluded all transcript-linked records.
+
+**Fix**: Added a `URS*` branch in `getGenes()` that strips the `_7955` suffix and queries `TranscriptDBLink` directly. The transcript's parent gene is resolved via the "gene produces transcript" relationship. Confirmed: 55 RNACentral matches from 30 unique URS IDs now load, mapping to miRNA genes (mir196c, mir214a, etc.), lincRNA genes, and lncRNA genes (gas5).
+
+**Monitoring**: All matches are logged with `"RNACentral Match"` prefix.
+
+### Ensembl Inference Case Sensitivity (InferenceCategory)
+
+**Problem**: GOA files use lowercase `ensembl:` but the `ENSEMBL` inference category matched `Ensembl:` (case-sensitive regex). This caused valid Ensembl inferences to fail validation.
+
+**Fix**: Changed the ENSEMBL match pattern to `(?i)ensembl:.*` for case-insensitive matching.
+
+### Evidence vs Pub Validation (GoEvidenceValidator)
+
+**Problem**: `validateEvidenceVsPub` was called with a random inference from a `HashSet` iterator. With multiple inferences now allowed, this was nondeterministic — the validation result could differ between runs depending on which inference the iterator returned first.
+
+**Fix**: Now iterates over all accepted inferences (those that passed `isInferenceValid`) and validates each individually.
+
+### Unrecognized Inference Categories (GoEvidenceValidator)
+
+**Problem**: `InferenceCategory.getInferenceCategoryByValue()` threw a `RuntimeException` for unrecognized values, crashing the entire load.
+
+**Fix**: Caught in `validateEvidenceVsPub` and converted to a `ValidationException` so the entry is rejected gracefully and reported in the error summary.
+
+### Unknown Evidence Codes (FpInferenceGafParser)
+
+**Problem**: Evidence codes not in `GoEvidenceCodeEnum` (like `EXP`, newly introduced by GO) caused a `RuntimeException` that aborted the entire load during parsing.
+
+**Fix**: Added `EXP` to the explicit exclusion set alongside `ND`, `NAS`, and `TAS`. Unknown codes that aren't in the exclusion set still throw (so new codes are surfaced as errors rather than silently ignored).
+
+### Parser Rejection Tracking (FpInferenceGafParser)
+
+**Problem**: Entries filtered during parsing were logged individually at WARN level (noisy, ~100k+ messages) with no summary of why they were rejected.
+
+**Fix**: Changed to DEBUG level. Added `rejectionCounts` map that tracks counts by reason (e.g., "Excluded GO_REF: GO_REF:0000002", "Excluded evidence code: EXP"). These counts are included in the error summary report.
+
+### Error Summary Report (GafErrorSummary)
+
+**Problem**: The details file contained ~19,000 error lines with no categorization or analysis. Understanding the error landscape required manual parsing.
+
+**Fix**: Added `GafErrorSummary.java` that processes the error list directly from `GafJobData` after the load completes. Generates a categorized report with:
+- Error counts by category
+- Parser rejection counts by reason
+- Gene-not-found deep dive (by ID type and annotation source)
+- Top 20 unmapped IDs
+- Examples for each error category
+
+Output: `Load-GAF-GOA_m_error_summary.txt`, also included in the success email.
+
+## Grepping the Console Output
+
+```bash
+# RNAcentral matches (new gene mappings)
+grep "RNACentral Match"
+
+# IEA annotations with multiple inferences
+grep "IEA annotation with"
+
+# Error summary file location
+grep "Error summary written to"
+
+# Unrecognized inference categories (caught, not crashing)
+grep "Unrecognized inference category"
+
+# Invalid NCBI API key warning (from NCBIRequest, used by UniProt load)
+grep "NCBI API token appears invalid"
+```
+
+## Historical Trend Analysis
+
+A one-off analysis of 12 months of historical details files was performed to produce trend graphs. The results are in https://zfin.atlassian.net/browse/ZFIN-10231 (gaf-error-report.html). Going forward, the Java `GafErrorSummary` generates the error summary automatically as part of each load run.
+
+Key findings:
+- RNAcentral errors are constant (~5,730 unique IDs / ~8,969 occurrences) — structural, won't change unless ZFIN maps more RNA IDs
+- TrEMBL errors fluctuate with UniProt releases
+- Obsolete GO term errors spike when the ontology updates, then resolve
+- IEA inference validation errors have been growing as GOA provides richer multi-reference evidence

--- a/reference/load-gaf-goa.md
+++ b/reference/load-gaf-goa.md
@@ -68,6 +68,101 @@ Output files written to `$TARGETROOT/server_apps/DB_maintenance/gafLoad/Load-GAF
 
 The error summary and the regular summary are both included in the success email.
 
+## Example: Loading a Single Annotation
+
+Worked example for a real entry loaded after the IEA cardinality fix:
+
+**GAF line**
+```
+UniProtKB    A0A0G2KKC2    cnnm1    located_in    GO:0016020    GO_REF:0000104    IEA    UniRule:UR000732112|UniRule:UR001725762    C    Metal transporter    cnnm1    protein    taxon:7955    20260407    UniProt
+```
+
+**Console log**
+```
+Loaded IEA annotation with 2 inferences for A0A0G2KKC2: UniRule:UR001725762, UniRule:UR000732112 | GafEntry{entryId='A0A0G2KKC2', qualifier='located_in', goid='GO:0016020', pmid='GO_REF:0000104', evidenceCode='IEA', inferences='UniRule:UR000732112|UniRule:UR001725762', taxonID='taxon:7955', createdDate='20260407', createdBy='UniProt', ...}
+```
+
+### 1. Parse (`FpInferenceGafParser`)
+
+The tab-delimited line is split into a `GafEntry`:
+- `entryId` = `A0A0G2KKC2` (col 2)
+- `qualifier` = `located_in` (col 4)
+- `goid` = `GO:0016020` (col 5)
+- `pmid` = `GO_REF:0000104` (col 6)
+- `evidenceCode` = `IEA` (col 7)
+- `inferences` = `UniRule:UR000732112|UniRule:UR001725762` (col 8, pipe-delimited)
+- `taxonID` = `taxon:7955` (col 13)
+- `createdBy` = `UniProt` (col 15)
+
+`GoaGafParser.isValidGafEntry()` passes: IEA is not excluded, `GO_REF:0000104` is not excluded, taxon is zebrafish, `createdBy=UniProt` is accepted.
+
+### 2. Map to gene (`GafService.getGenes`)
+
+`A0A0G2KKC2` is not a `ZDB-GENE` / `RNAG` and not a `URS*`, so it falls through to:
+
+```java
+sequenceRepository.getMarkerDBLinksForAccession(
+    "A0A0G2KKC2",
+    ReferenceDatabase.UNIPROTKB, ReferenceDatabase.GENPEPT)
+```
+
+This queries `db_link` filtered by the `@DiscriminatorValue("MARK")` (rows where `get_obj_type(dblink_linked_recid) = 'MARK'`) and the two ref-db FKs. Returns one `MarkerDBLink` whose `marker` is the `cnnm1` gene.
+
+### 3. Build the annotation (`generateAnnotation`)
+
+A `MarkerGoTermEvidence` is constructed:
+- `marker` = `cnnm1`
+- `goTerm` = `GO:0016020` (`membrane`)
+- `qualifierRelation` = `LOCATED_IN`
+- `evidenceCode` = `IEA`
+- `source` = `ZDB-PUB-170525-1` (from `GoDefaultPublication.GOREF_UNIRULE`, because `GO_REF:0000104` is the UniRule default pub)
+- `organizationCreatedBy` = `UniProt`
+- `createdWhen` = `20260407`
+
+### 4. Validate inferences (`handleInferences`)
+
+The `inferences` field is split on `|` → `["UniRule:UR000732112", "UniRule:UR001725762"]`. For each:
+- `isValidCardinality(IEA, {...})`: IEA's cardinality is `CARDINALITY_ONE_OR_MORE`, size 2 → pass (this is the fix that unlocks this annotation)
+- `InferenceCategory.getInferenceCategoryByValue(...)` matches `UNIRULE`'s regex `UniRule:.*` → pass
+- `validateEvidenceVsPub(IEA, GOREF_UNIRULE, inference)`: the GOREF_UNIRULE pub requires `InferenceCategory.UNIRULE`, which matches → pass
+
+Both pass, two `InferenceGroupMember` objects are created, and the multi-inference log line fires.
+
+### 5. Duplicate check
+
+`getLikeMarkerGoTermEvidencesButGo` checks whether `cnnm1` already has a more specific annotation to a descendant of `GO:0016020` from the same pub + evidence + org. No such annotation exists, so the load proceeds.
+
+### 6. The resulting INSERTs
+
+The `MarkerGoTermEvidence` is `session.save()`d, cascading to its `inferenceGroupMembers` set.
+
+**marker_go_term_evidence** (1 row):
+```sql
+INSERT INTO marker_go_term_evidence (
+    mrkrgoev_zdb_id,                   -- ZDB-MRKRGOEV-<date>-<n>
+    mrkrgoev_mrkr_zdb_id,              -- ZDB-GENE-... (cnnm1)
+    mrkrgoev_term_zdb_id,              -- ZDB-TERM-... (GO:0016020)
+    mrkrgoev_source_zdb_id,            -- ZDB-PUB-170525-1
+    mrkrgoev_evidence_code,            -- 'IEA'
+    mrkrgoev_qualifier_relation,       -- 'located_in'
+    mrkrgoev_flag,                     -- null
+    mrkrgoev_organization_created_by,  -- 'UniProt'
+    mrkrgoev_date_entered,             -- now()
+    mrkrgoev_created_when              -- 2026-04-07
+) VALUES (...);
+```
+
+**inference_group_member** (2 rows — composite PK = `mrkrgoev_zdb_id` + `inferred_from`):
+```sql
+INSERT INTO inference_group_member (mrkrgoev_zdb_id, inferred_from)
+VALUES ('ZDB-MRKRGOEV-...', 'UniRule:UR000732112');
+
+INSERT INTO inference_group_member (mrkrgoev_zdb_id, inferred_from)
+VALUES ('ZDB-MRKRGOEV-...', 'UniRule:UR001725762');
+```
+
+Before the IEA cardinality fix (1 → 1+), step 4 would have rejected this annotation outright and no rows would have been inserted.
+
 ## Key Code Locations
 
 | File | Purpose |

--- a/server_apps/data_transfer/RNACentral/LoadRNACentralIDs.groovy
+++ b/server_apps/data_transfer/RNACentral/LoadRNACentralIDs.groovy
@@ -3,6 +3,14 @@
 import org.zfin.properties.ZfinProperties
 import org.zfin.util.ReportGenerator
 import static com.xlson.groovycsv.CsvParser.parseCsv
+import groovy.cli.commons.CliBuilder
+
+cli = new CliBuilder(usage: 'LoadRNACentralIDs')
+cli.jobName(args: 1, 'Name of the job to be displayed in report')
+options = cli.parse(args)
+if (!options) {
+    System.exit(1)
+}
 
 
 ZfinProperties.init("${System.getenv()['ZFIN_PROPERTIES_PATH']}")
@@ -41,11 +49,16 @@ File inputFile = new File("zfin.tsv")
 
 dbname = System.getenv("DBNAME")
 println("Loading terms into $dbname")
+PRE_FILE = "preRNAcentral.unl"
+POST_FILE = "postRNAcentral.unl"
+COUNTS_FILE = "rnaCentralCounts.unl"
 
 
 psql dbname, """
 
 DROP TABLE if exists tmp_rnac_zfin;
+
+\\copy (SELECT dblink_linked_recid, dblink_acc_num FROM db_link WHERE dblink_fdbcont_zdb_id = (SELECT fdbcont_zdb_id FROM foreign_db, foreign_db_contains WHERE fdbcont_fdb_db_id = fdb_db_pk_id AND fdb_db_name LIKE 'RNA Central')) TO '$PRE_FILE';
 
 CREATE TEMP TABLE tmp_rnac_zfin (
     rnacid text,
@@ -58,13 +71,16 @@ CREATE TEMP TABLE tmp_rnac_zfin (
 
 \\copy tmp_rnac_zfin FROM 'zfin.tsv' WITH delimiter E'\\t';
 
- 
-
-
-
+DROP TABLE if exists tmp_rnac_counts;
+CREATE TEMP TABLE tmp_rnac_counts (metric text, count bigint);
+INSERT INTO tmp_rnac_counts SELECT 'downloaded', count(*) FROM tmp_rnac_zfin;
 
 delete from tmp_rnac_zfin where tscriptid not in (select tscript_mrkr_zdb_id from transcript);
+INSERT INTO tmp_rnac_counts SELECT 'after_transcript_filter', count(*) FROM tmp_rnac_zfin;
+
 delete from tmp_rnac_zfin where trim(rnacid) in (select trim(dblink_acc_num) from db_link where dblink_acc_num like 'URS%');
+INSERT INTO tmp_rnac_counts SELECT 'inserted', count(*) FROM tmp_rnac_zfin;
+
 alter table tmp_rnac_zfin add column dblinkid text;
 alter table tmp_rnac_zfin add column fdbcontid text;
 
@@ -79,10 +95,51 @@ insert into db_link (dblink_linked_recid,dblink_acc_num, dblink_zdb_id ,dblink_a
 insert into record_attribution (recattrib_data_zdb_id, recattrib_source_zdb_id)
 select dblinkid,'ZDB-PUB-200928-1' from tmp_rnac_zfin;
 
+\\copy (SELECT dblink_linked_recid, dblink_acc_num FROM db_link WHERE dblink_fdbcont_zdb_id = (SELECT fdbcont_zdb_id FROM foreign_db, foreign_db_contains WHERE fdbcont_fdb_db_id = fdb_db_pk_id AND fdb_db_name LIKE 'RNA Central')) TO '$POST_FILE';
+
+\\copy tmp_rnac_counts TO '$COUNTS_FILE';
+
 """
+println("done with script")
 
+if (options.jobName) {
+    // Running from Jenkins; generate a report.
+    def counts = [:]
+    new File(COUNTS_FILE).eachLine { line ->
+        def parts = line.split("\t")
+        if (parts.size() == 2) {
+            counts[parts[0]] = parts[1] as long
+        }
+    }
 
+    def downloaded = counts.get('downloaded', 0L)
+    def afterTranscriptFilter = counts.get('after_transcript_filter', 0L)
+    def inserted = counts.get('inserted', 0L)
+    def droppedNoTranscript = downloaded - afterTranscriptFilter
+    def droppedAlreadyLoaded = afterTranscriptFilter - inserted
 
+    def preLines = new File(PRE_FILE).readLines()
+    def postLines = new File(POST_FILE).readLines()
+    def added = postLines - preLines
+    def removed = preLines - postLines
+
+    new ReportGenerator().with {
+        setReportTitle("Report for ${options.jobName}")
+        includeTimestamp()
+        addSummaryTable("Load summary", [
+                "Rows downloaded from RNAcentral": downloaded,
+                "Dropped (transcript not in ZFIN)": droppedNoTranscript,
+                "Dropped (already loaded)": droppedAlreadyLoaded,
+                "Inserted into db_link": inserted,
+        ])
+        addDataTable("${added.size()} db_links added", ["Transcript ID", "RNA Central ID"],
+                added.collect { it.split("\t") as List })
+        addDataTable("${removed.size()} db_links removed", ["Transcript ID", "RNA Central ID"],
+                removed.collect { it.split("\t") as List })
+        writeFiles(new File("."), "loadRNACentralReport")
+    }
+}
+System.exit(0)
 
 
 

--- a/server_apps/jenkins/jobs/Load-Database/config.xml
+++ b/server_apps/jenkins/jobs/Load-Database/config.xml
@@ -1,0 +1,159 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>Load a database backup using gradle loaddb.
+
+By default, loads the latest backup from $DB_UNLOADS_PATH.
+Set BACKUP_PATH to load a specific file.
+Set LIST_ONLY to true to list available backups without loading.
+
+Note: This will drop and recreate the database. All existing data will be replaced.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+      <hudson.model.ParametersDefinitionProperty>
+          <parameterDefinitions>
+              <hudson.model.StringParameterDefinition>
+                  <name>BACKUP_PATH</name>
+                  <description>Full path to a specific backup file. Leave blank to use the latest backup from $DB_UNLOADS_PATH.</description>
+                  <defaultValue></defaultValue>
+                  <trim>true</trim>
+              </hudson.model.StringParameterDefinition>
+              <hudson.model.BooleanParameterDefinition>
+                  <name>LIST_ONLY</name>
+                  <description>List available backups and exit without loading.</description>
+                  <defaultValue>false</defaultValue>
+              </hudson.model.BooleanParameterDefinition>
+              <hudson.model.TextParameterDefinition>
+                  <name>NOTES</name>
+                  <description>Optional notes for the build history (e.g. reason for loading, ticket number).</description>
+                  <defaultValue></defaultValue>
+              </hudson.model.TextParameterDefinition>
+          </parameterDefinitions>
+      </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <customWorkspace>$TARGETROOT</customWorkspace>
+  <builders>
+    <hudson.tasks.Shell>
+      <command><![CDATA[#!/bin/bash
+set -e
+
+echo "=============================="
+echo "Load-Database"
+echo "=============================="
+
+if [ -n "$NOTES" ]; then
+    echo ""
+    echo "Notes: $NOTES"
+    echo ""
+fi
+
+# List available backups
+if [ "$LIST_ONLY" = "true" ] || [ -z "$BACKUP_PATH" ]; then
+    echo ""
+    echo "Available backups in $DB_UNLOADS_PATH:"
+    echo "---------------------------------------"
+    for dir in $(ls -dt "$DB_UNLOADS_PATH"/20??.??.??.* 2>/dev/null); do
+        bak=$(ls "$dir"/*.bak 2>/dev/null | head -1)
+        if [ -n "$bak" ]; then
+            size=$(du -sh "$bak" | cut -f1)
+            date=$(stat -c '%y' "$bak" 2>/dev/null || stat -f '%Sm' "$bak" 2>/dev/null)
+            echo "  $bak  ($size, $date)"
+        fi
+    done
+    echo ""
+
+    if [ "$LIST_ONLY" = "true" ]; then
+        echo "LIST_ONLY=true, exiting without loading."
+        exit 0
+    fi
+fi
+
+# Build the gradle command
+GRADLE_ARGS=""
+if [ -n "$BACKUP_PATH" ]; then
+    echo "Loading specific backup: $BACKUP_PATH"
+    if [ ! -f "$BACKUP_PATH" ]; then
+        echo "ERROR: Backup file not found: $BACKUP_PATH"
+        exit 1
+    fi
+    GRADLE_ARGS="-Dunload=$BACKUP_PATH"
+else
+    echo "Loading latest backup from $DB_UNLOADS_PATH"
+fi
+
+echo ""
+echo "Starting database load..."
+echo ""
+
+cd $SOURCEROOT
+gradle loaddb $GRADLE_ARGS
+
+echo ""
+echo "Database load complete."
+]]></command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@2.35.1">
+      <recipientList></recipientList>
+      <configuredTriggers>
+        <hudson.plugins.emailext.plugins.trigger.SuccessTrigger>
+          <email>
+            <recipientList>@SUCCESS-RECIPIENT-LIST@</recipientList>
+            <subject>$PROJECT_DEFAULT_SUBJECT</subject>
+            <body>$PROJECT_DEFAULT_CONTENT
+
+${SCRIPT,template="console-output.template"}
+</body>
+            <sendToDevelopers>false</sendToDevelopers>
+            <sendToRequester>false</sendToRequester>
+            <includeCulprits>false</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+            <attachmentsPattern></attachmentsPattern>
+            <attachBuildLog>false</attachBuildLog>
+            <compressBuildLog>false</compressBuildLog>
+            <replyTo></replyTo>
+            <contentType>project</contentType>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.SuccessTrigger>
+        <hudson.plugins.emailext.plugins.trigger.FailureTrigger>
+          <email>
+            <recipientList>@FAILURE-RECIPIENT-LIST@</recipientList>
+            <subject>$PROJECT_DEFAULT_SUBJECT</subject>
+            <body>$PROJECT_DEFAULT_CONTENT
+
+${SCRIPT,template="console-output.template"}
+</body>
+            <sendToDevelopers>false</sendToDevelopers>
+            <sendToRequester>false</sendToRequester>
+            <includeCulprits>false</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+            <attachmentsPattern></attachmentsPattern>
+            <attachBuildLog>false</attachBuildLog>
+            <compressBuildLog>false</compressBuildLog>
+            <replyTo></replyTo>
+            <contentType>project</contentType>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
+      </configuredTriggers>
+      <contentType>text/html</contentType>
+        <defaultSubject>[Jenkins][${INSTANCE}]: ${PROJECT_NAME}: ${BUILD_STATUS}</defaultSubject>
+      <defaultContent>$DEFAULT_CONTENT</defaultContent>
+      <attachmentsPattern></attachmentsPattern>
+      <presendScript></presendScript>
+      <attachBuildLog>false</attachBuildLog>
+      <compressBuildLog>false</compressBuildLog>
+      <replyTo>${DB_OWNER}@zfin.org</replyTo>
+      <saveOutput>false</saveOutput>
+    </hudson.plugins.emailext.ExtendedEmailPublisher>
+  </publishers>
+  <buildWrappers>
+  </buildWrappers>
+</project>

--- a/server_apps/jenkins/jobs/Load-GAF-GOA_m/config.xml
+++ b/server_apps/jenkins/jobs/Load-GAF-GOA_m/config.xml
@@ -15,6 +15,26 @@ Those can be overridden by setting the environment variables:
 - GOA_GAF_URL2
 - GOA_GAF_URL3
 
+Steps:
+      1. Download the GOA (Gene Ontology Annotation) file for zebrafish from EBI — a GAF (Gene Association Format) file containing GO annotations from multiple sources (UniProt, Ensembl, GO_Central, RNAcentral, etc.)
+      2. Parse each line into a GafEntry — filtering out non-zebrafish entries and entries without valid taxon IDs
+      3. Map UniProt IDs to ZFIN genes — looks up the entryId (e.g., Q5XJQ7) in db_link to find the associated ZFIN gene. This is where the "Gene not found" errors come from.
+      4. Validate each annotation — checks evidence codes, inference fields, GO term validity (not obsolete, not in "Do Not Annotate" subset), publication mappings, protein binding rules, etc.
+      5. Generate MarkerGoTermEvidence records — for each valid entry, creates an annotation linking a ZFIN gene to a GO term with evidence code, publication, and inferences
+      6. Deduplicate — checks against existing annotations in the database. If a more specific annotation already exists, the new one is marked as "existing" and skipped.
+      7. Batch add new annotations to the database
+      8. Remove stale annotations — any previously-loaded annotations that aren't in the new GAF file are removed (these show up as "REMOVED" in the details file)
+      9. Write reports — details file (removed/added/updated/errors/existing), summary file, and now the error summary
+
+Input File Details:
+      goa_zebrafish.gaf.gz — The main file. Contains GO annotations for zebrafish proteins (UniProt accessions). Each row maps a protein to a GO term with evidence. Sources include UniProt (IEA — electronic annotations), GO_Central (IBA — phylogenetic), IntAct
+      (IPI — protein interactions), and manual curation from various groups. This is the bulk of the data — the annotations that map to genes via UniProt ID → db_link → ZFIN gene.
+
+      goa_zebrafish_isoform.gaf.gz — Annotations for specific protein isoforms (splice variants). Same format as the main file, but the geneProductFormID field (column 17) contains isoform-specific accessions like UniProtKB:E9QI36-1, UniProtKB:E9QI36-2. These
+      provide more granular annotations — e.g., isoform 1 of a protein localizes to the cytoplasm while isoform 2 localizes to the mitochondrion.
+
+      goa_zebrafish_rna.gaf.gz — Annotations for non-coding RNA sequences. These use RNAcentral IDs (URS*) rather than UniProt accessions.
+
   </description>
   <keepDependencies>false</keepDependencies>
   <properties/>
@@ -50,6 +70,8 @@ Those can be overridden by setting the environment variables:
             <recipientList>@SUCCESS-RECIPIENT-LIST@</recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
             <body>${FILE,path=&quot;server_apps/DB_maintenance/gafLoad/Load-GAF-GOA_m/Load-GAF-GOA_m_summary.txt&quot;}
+
+${FILE,path=&quot;server_apps/DB_maintenance/gafLoad/Load-GAF-GOA_m/Load-GAF-GOA_m_error_summary.txt&quot;}
 
 See full details at ${BUILD_URL}artifact/server_apps/DB_maintenance/gafLoad/Load-GAF-GOA_m/Load-GAF-GOA_m_details.txt</body>
             <sendToDevelopers>false</sendToDevelopers>

--- a/server_apps/jenkins/jobs/Load-RNACentralLinks_m/config.xml
+++ b/server_apps/jenkins/jobs/Load-RNACentralLinks_m/config.xml
@@ -22,11 +22,11 @@
     </hudson.tasks.Shell>
   </builders>
   <publishers>
-   <!-- <hudson.tasks.ArtifactArchiver>
-      &lt;!&ndash;<artifacts>server_apps/data_transfer/Panther/loadAGRReport*</artifacts>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>server_apps/data_transfer/RNACentral/loadRNACentralReport.*</artifacts>
       <latestOnly>false</latestOnly>
-      <allowEmptyArchive>false</allowEmptyArchive>&ndash;&gt;
-    </hudson.tasks.ArtifactArchiver>-->
+      <allowEmptyArchive>false</allowEmptyArchive>
+    </hudson.tasks.ArtifactArchiver>
     <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@2.35.1">
       <recipientList>$DEFAULT_RECIPIENTS</recipientList>
       <configuredTriggers>
@@ -34,10 +34,10 @@
           <email>
             <recipientList>@FAILURE-RECIPIENT-LIST@</recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <!--<body>${FILE,path=&quot;$TARGETROOT/server_apps/data_transfer/Panther/loadAGRReport.html&quot;}
+            <body>${FILE,path=&quot;$TARGETROOT/server_apps/data_transfer/RNACentral/loadRNACentralReport.html&quot;}
 
               See report on Jenkins dashboard: &lt;a href=&quot;${BUILD_URL}&quot;&gt;${BUILD_URL}&lt;/a&gt;
-            </body>-->
+            </body>
             <sendToDevelopers>false</sendToDevelopers>
             <sendToRequester>false</sendToRequester>
             <includeCulprits>false</includeCulprits>
@@ -53,10 +53,10 @@
           <email>
             <recipientList>@SUCCESS-RECIPIENT-LIST@</recipientList>
            <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <!-- <body>${FILE,path=&quot;$TARGETROOT/server_apps/data_transfer/Panther/alliance-report.html&quot;}
+            <body>${FILE,path=&quot;$TARGETROOT/server_apps/data_transfer/RNACentral/loadRNACentralReport.html&quot;}
 
               See report on Jenkins dashboard: &lt;a href=&quot;${BUILD_URL}&quot;&gt;${BUILD_URL}&lt;/a&gt;
-            </body>-->
+            </body>
             <sendToDevelopers>false</sendToDevelopers>
             <sendToRequester>false</sendToRequester>
             <includeCulprits>false</includeCulprits>

--- a/source/org/zfin/datatransfer/go/FpInferenceGafParser.java
+++ b/source/org/zfin/datatransfer/go/FpInferenceGafParser.java
@@ -110,7 +110,7 @@ public class FpInferenceGafParser {
      */
     private void updateSimilarRecord(GafEntry existingSimilarRecord, GafEntry gafEntry) {
         if (StringUtils.isEmpty(existingSimilarRecord.getGeneProductFormID()) && StringUtils.isNotEmpty(gafEntry.getGeneProductFormID())) {
-            logger.info("Found match to update instead of adding potential duplicate: " + existingSimilarRecord.getEntryId() + " : " + gafEntry.getEntryId());
+            logger.debug("Found match to update instead of adding potential duplicate: " + existingSimilarRecord.getEntryId() + " : " + gafEntry.getEntryId());
             existingSimilarRecord.setGeneProductFormID(gafEntry.getGeneProductFormID());
             existingSimilarRecord.setEntryId(gafEntry.getEntryId());
         }

--- a/source/org/zfin/datatransfer/go/FpInferenceGafParser.java
+++ b/source/org/zfin/datatransfer/go/FpInferenceGafParser.java
@@ -31,6 +31,8 @@ public class FpInferenceGafParser {
     public int countPipes=0;
     public int countCommas=0;
     public int countBoth=0;
+    private int duplicateMergeCount=0;
+    private static final int DUPLICATE_MERGE_LOG_LIMIT = 5;
 
     @Getter
     private final Map<String, Integer> rejectionCounts = new LinkedHashMap<>();
@@ -76,6 +78,10 @@ public class FpInferenceGafParser {
         } finally {
             it.close();
         }
+        if (duplicateMergeCount > DUPLICATE_MERGE_LOG_LIMIT) {
+            logger.info((duplicateMergeCount - DUPLICATE_MERGE_LOG_LIMIT)
+                + " more 'Found match to update instead of adding potential duplicate' messages omitted");
+        }
         logger.info("Finishing parseGafFile at " + (new Date()) );
 
         return gafEntries;
@@ -110,7 +116,10 @@ public class FpInferenceGafParser {
      */
     private void updateSimilarRecord(GafEntry existingSimilarRecord, GafEntry gafEntry) {
         if (StringUtils.isEmpty(existingSimilarRecord.getGeneProductFormID()) && StringUtils.isNotEmpty(gafEntry.getGeneProductFormID())) {
-            logger.debug("Found match to update instead of adding potential duplicate: " + existingSimilarRecord.getEntryId() + " : " + gafEntry.getEntryId());
+            duplicateMergeCount++;
+            if (duplicateMergeCount <= DUPLICATE_MERGE_LOG_LIMIT) {
+                logger.info("Found match to update instead of adding potential duplicate: " + existingSimilarRecord.getEntryId() + " : " + gafEntry.getEntryId());
+            }
             existingSimilarRecord.setGeneProductFormID(gafEntry.getGeneProductFormID());
             existingSimilarRecord.setEntryId(gafEntry.getEntryId());
         }

--- a/source/org/zfin/datatransfer/go/FpInferenceGafParser.java
+++ b/source/org/zfin/datatransfer/go/FpInferenceGafParser.java
@@ -32,6 +32,9 @@ public class FpInferenceGafParser {
     public int countCommas=0;
     public int countBoth=0;
 
+    @Getter
+    private final Map<String, Integer> rejectionCounts = new LinkedHashMap<>();
+
 
     @Getter
     @Setter
@@ -67,7 +70,7 @@ public class FpInferenceGafParser {
                 if (isValidGafEntry(gafEntry)) {
                     addGafEntryOrUpdateExisting(gafEntriesHash, gafEntries, gafEntry);
                 } else {
-                    logger.warn("not a valid gaf entry, ignoring: " + gafEntry);
+                    logger.debug("not a valid gaf entry, ignoring: " + gafEntry);
                 }
             }
         } finally {
@@ -123,27 +126,30 @@ public class FpInferenceGafParser {
 
     protected boolean isValidGafEntry(GafEntry gafEntry) {
         if (!isValidEvidenceCode(gafEntry.getEvidenceCode())) {
-            logger.debug("invalid evidence code[" + gafEntry.getEvidenceCode() + " throwing out: " + gafEntry);
-            return false; // just ignore
+            reject("Excluded evidence code: " + gafEntry.getEvidenceCode());
+            return false;
         }
-        // will get a null-pointer if I don't have this in anyway
         if (StringUtils.isEmpty(gafEntry.getCreatedBy())) {
-            logger.error("createdby field may not be empty throwing out: " + gafEntry);
-            return false; // just ignore
+            reject("Empty createdBy field");
+            return false;
         }
         if (gafEntry.getCreatedBy().equals(ZFIN_CREATED_BY)) {
-            logger.debug("created by is zfin[" + gafEntry.getCreatedBy() + " throwing out: " + gafEntry);
-            return false; // just ignore
+            reject("Created by ZFIN (skip own annotations)");
+            return false;
         }
         if (!gafEntry.getTaxonId().equals(ZEBRAFISH_TAXID)) {
-            logger.debug("taxon id is not zebrafish [" + gafEntry.getTaxonId() + " throwing out: " + gafEntry);
-            return false; // just ignore
+            reject("Non-zebrafish taxon: " + gafEntry.getTaxonId());
+            return false;
         }
         if (goRefExcludePubMap.contains(gafEntry.getPubmedId())) {
-            logger.debug("excluding ref [" + gafEntry.getTaxonId() + " throwing out: " + gafEntry);
-            return false; // just ignore
+            reject("Excluded GO_REF: " + gafEntry.getPubmedId());
+            return false;
         }
         return true;
+    }
+
+    private void reject(String reason) {
+        rejectionCounts.merge(reason, 1, Integer::sum);
     }
 
     private boolean isValidEvidenceCode(String evidenceCode) {

--- a/source/org/zfin/datatransfer/go/FpInferenceGafParser.java
+++ b/source/org/zfin/datatransfer/go/FpInferenceGafParser.java
@@ -152,11 +152,10 @@ public class FpInferenceGafParser {
         rejectionCounts.merge(reason, 1, Integer::sum);
     }
 
+    private static final Set<String> EXCLUDED_EVIDENCE_CODES = Set.of("ND", "NAS", "TAS", "EXP");
+
     private boolean isValidEvidenceCode(String evidenceCode) {
-        GoEvidenceCodeEnum goEvidenceCodeEnum = GoEvidenceCodeEnum.getType(evidenceCode);
-        return !(goEvidenceCodeEnum == GoEvidenceCodeEnum.ND
-                || goEvidenceCodeEnum == GoEvidenceCodeEnum.NAS
-                || goEvidenceCodeEnum == GoEvidenceCodeEnum.TAS);
+        return !EXCLUDED_EVIDENCE_CODES.contains(evidenceCode.trim());
     }
 
 

--- a/source/org/zfin/datatransfer/go/GafErrorSummary.java
+++ b/source/org/zfin/datatransfer/go/GafErrorSummary.java
@@ -1,0 +1,210 @@
+package org.zfin.datatransfer.go;
+
+import java.io.*;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Generates a categorized error summary from GAF load errors.
+ * Takes the error list directly from GafJobData rather than parsing the details file.
+ */
+public class GafErrorSummary {
+
+    private static final Pattern ID_PATTERN = Pattern.compile("ID\\[(.+?)]");
+    private static final Pattern CREATED_BY_PATTERN = Pattern.compile("createdBy='([^']*)'");
+    private static final Pattern TERM_PATTERN = Pattern.compile("termName='([^']+)'.*oboID='([^']+)'");
+
+    private final Map<String, Integer> categoryCounts = new LinkedHashMap<>();
+    private final Map<String, List<String>> categoryExamples = new LinkedHashMap<>();
+    private final Map<String, Integer> geneNotFoundIds = new LinkedHashMap<>();
+    private final Map<String, Integer> geneNotFoundSources = new LinkedHashMap<>();
+
+    private static String categorize(String message) {
+        if (message.startsWith("Annotations with IEA evidence must")) {
+            Matcher m = Pattern.compile("\\[(.+?)]").matcher(message);
+            String type = m.find() ? m.group(1) : "unknown";
+            return "IEA inference field validation (" + type + ")";
+        }
+        if (message.startsWith("Go term in column")) {
+            return "Obsolete GO term referenced";
+        }
+        if (message.startsWith("Unable to find genes associated with ID")) {
+            return "Gene not found for ID";
+        }
+        if (message.startsWith("A duplicate entry is being added:")) {
+            return "Duplicate annotation entry";
+        }
+        if (message.startsWith("Can not use term in a \"Do Not Annotate\"")) {
+            return "Term in \"Do Not Annotate\" subset";
+        }
+        if (message.startsWith("Protein binding")) {
+            return "Protein binding (GO:0005515) requires IPI evidence";
+        }
+        if (message.startsWith("No pub found for pmid:")) {
+            return "Publication not found for PMID";
+        }
+        if (message.startsWith("MarkerGoTermEvidence{")) {
+            return "Annotation insertion failed";
+        }
+        // Strip trailing colon if present
+        if (message.endsWith(":")) {
+            return message.substring(0, message.length() - 1);
+        }
+        return message;
+    }
+
+    private static String classifyId(String entryId) {
+        if (entryId.startsWith("URS")) {
+            return "RNAcentral";
+        }
+        if (entryId.startsWith("A0A")) {
+            return "TrEMBL (unreviewed)";
+        }
+        return "Swiss-Prot / other";
+    }
+
+    private void addExample(String category, String example) {
+        categoryExamples.computeIfAbsent(category, k -> new ArrayList<>());
+        if (categoryExamples.get(category).size() < 3) {
+            categoryExamples.get(category).add(example);
+        }
+    }
+
+    /**
+     * Build the summary directly from the error list produced by the GAF load.
+     */
+    public void processErrors(List<GafValidationError> errors) {
+        for (GafValidationError error : errors) {
+            String fullMessage = error.getMessage();
+            if (fullMessage == null || fullMessage.isBlank()) {
+                continue;
+            }
+
+            // The message format is: "error text:\nGafEntry{...}" or "error text:\nobsolete term detail\nGafEntry{...}"
+            String[] lines = fullMessage.split("\n", 2);
+            String firstLine = lines[0].strip();
+            String detail = lines.length > 1 ? lines[1].strip() : "";
+
+            String category = categorize(firstLine);
+            if (category == null) {
+                continue;
+            }
+            categoryCounts.merge(category, 1, Integer::sum);
+
+            // Add examples
+            if (!detail.isEmpty()) {
+                // For obsolete terms, extract the term name
+                Matcher termMatcher = TERM_PATTERN.matcher(detail);
+                if (termMatcher.find()) {
+                    addExample(category, termMatcher.group(2) + ": " + termMatcher.group(1));
+                } else {
+                    addExample(category, detail.split("\n")[0]);
+                }
+            }
+
+            // Track gene-not-found details
+            if ("Gene not found for ID".equals(category)) {
+                Matcher idMatcher = ID_PATTERN.matcher(firstLine);
+                if (idMatcher.find()) {
+                    geneNotFoundIds.merge(idMatcher.group(1), 1, Integer::sum);
+                }
+                Matcher createdByMatcher = CREATED_BY_PATTERN.matcher(detail);
+                if (createdByMatcher.find()) {
+                    geneNotFoundSources.merge(createdByMatcher.group(1), 1, Integer::sum);
+                }
+            }
+        }
+    }
+
+    public String format() {
+        int totalErrors = categoryCounts.values().stream().mapToInt(Integer::intValue).sum();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("GAF Load Error Summary\n");
+        sb.append("=".repeat(60)).append("\n");
+        sb.append(String.format("Total errors: %,d%n", totalErrors));
+        sb.append(String.format("Unique error categories: %d%n%n", categoryCounts.size()));
+
+        List<Map.Entry<String, Integer>> sorted = categoryCounts.entrySet().stream()
+            .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+            .collect(Collectors.toList());
+
+        sb.append("Error Counts by Category\n");
+        sb.append("-".repeat(60)).append("\n");
+        for (Map.Entry<String, Integer> e : sorted) {
+            sb.append(String.format("  %,6d  %s%n", e.getValue(), e.getKey()));
+        }
+        sb.append(String.format("%n  %,6d  TOTAL%n", totalErrors));
+
+        // Gene not found deep dive
+        if (!geneNotFoundIds.isEmpty()) {
+            int uniqueIds = geneNotFoundIds.size();
+            int totalOccurrences = geneNotFoundIds.values().stream().mapToInt(Integer::intValue).sum();
+
+            Map<String, Integer> idTypeUnique = new LinkedHashMap<>();
+            for (String id : geneNotFoundIds.keySet()) {
+                idTypeUnique.merge(classifyId(id), 1, Integer::sum);
+            }
+
+            sb.append("\n\nGene Not Found — Deep Dive\n");
+            sb.append("=".repeat(60)).append("\n");
+            sb.append(String.format("%,d unique IDs, %,d total occurrences%n", uniqueIds, totalOccurrences));
+            sb.append("(Each ID may appear multiple times — once per GO annotation)\n\n");
+
+            sb.append("By ID Type (unique IDs)\n");
+            sb.append("-".repeat(60)).append("\n");
+            idTypeUnique.entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .forEach(e -> sb.append(String.format("  %,6d  (%4.1f%%)  %s%n",
+                    e.getValue(), e.getValue() * 100.0 / uniqueIds, e.getKey())));
+
+            sb.append("\n  RNAcentral:          URS* IDs — non-coding RNA, not mapped in ZFIN\n");
+            sb.append("  TrEMBL (unreviewed): A0A* IDs — computationally predicted proteins\n");
+            sb.append("  Swiss-Prot / other:  Older accessions not in ZFIN db_link\n");
+
+            sb.append("\nBy Annotation Source (occurrences)\n");
+            sb.append("-".repeat(60)).append("\n");
+            geneNotFoundSources.entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .forEach(e -> sb.append(String.format("  %,6d  (%4.1f%%)  %s%n",
+                    e.getValue(), e.getValue() * 100.0 / totalOccurrences, e.getKey())));
+
+            sb.append("\nTop 20 IDs by Occurrence\n");
+            sb.append("-".repeat(60)).append("\n");
+            geneNotFoundIds.entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .limit(20)
+                .forEach(e -> sb.append(String.format("  %,4dx  %s  (%s)%n",
+                    e.getValue(), e.getKey(), classifyId(e.getKey()))));
+            if (uniqueIds > 20) {
+                sb.append(String.format("  ... and %,d more%n", uniqueIds - 20));
+            }
+        }
+
+        // Examples for other categories
+        sb.append("\n\nExamples by Category\n");
+        sb.append("=".repeat(60)).append("\n");
+        for (Map.Entry<String, Integer> e : sorted) {
+            if ("Gene not found for ID".equals(e.getKey())) {
+                continue;
+            }
+            List<String> examples = categoryExamples.getOrDefault(e.getKey(), Collections.emptyList());
+            if (!examples.isEmpty()) {
+                sb.append(String.format("%n  %s (%,d):%n", e.getKey(), e.getValue()));
+                for (String ex : examples) {
+                    sb.append("    - ").append(ex).append("\n");
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+
+    public void writeToFile(File outputFile) throws IOException {
+        try (FileWriter writer = new FileWriter(outputFile)) {
+            writer.write(format());
+        }
+    }
+}

--- a/source/org/zfin/datatransfer/go/GafErrorSummary.java
+++ b/source/org/zfin/datatransfer/go/GafErrorSummary.java
@@ -20,6 +20,7 @@ public class GafErrorSummary {
     private final Map<String, List<String>> categoryExamples = new LinkedHashMap<>();
     private final Map<String, Integer> geneNotFoundIds = new LinkedHashMap<>();
     private final Map<String, Integer> geneNotFoundSources = new LinkedHashMap<>();
+    private Map<String, Integer> parserRejections = new LinkedHashMap<>();
 
     private static String categorize(String message) {
         if (message.startsWith("Annotations with IEA evidence must")) {
@@ -70,6 +71,13 @@ public class GafErrorSummary {
         if (categoryExamples.get(category).size() < 3) {
             categoryExamples.get(category).add(example);
         }
+    }
+
+    /**
+     * Set the parser rejection counts (entries filtered before validation).
+     */
+    public void setParserRejections(Map<String, Integer> rejections) {
+        this.parserRejections = rejections;
     }
 
     /**
@@ -125,7 +133,27 @@ public class GafErrorSummary {
         sb.append("GAF Load Error Summary\n");
         sb.append("=".repeat(60)).append("\n");
         sb.append(String.format("Total errors: %,d%n", totalErrors));
-        sb.append(String.format("Unique error categories: %d%n%n", categoryCounts.size()));
+        sb.append(String.format("Unique error categories: %d%n", categoryCounts.size()));
+
+        // Parser rejections (entries filtered before validation)
+        if (!parserRejections.isEmpty()) {
+            int totalRejected = parserRejections.values().stream().mapToInt(Integer::intValue).sum();
+            sb.append(String.format("Entries filtered during parsing: %,d%n", totalRejected));
+        }
+        sb.append("\n");
+
+        if (!parserRejections.isEmpty()) {
+            sb.append("Entries Filtered During Parsing\n");
+            sb.append("-".repeat(60)).append("\n");
+            int totalRejected = 0;
+            for (Map.Entry<String, Integer> e : parserRejections.entrySet().stream()
+                    .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                    .collect(Collectors.toList())) {
+                sb.append(String.format("  %,6d  %s%n", e.getValue(), e.getKey()));
+                totalRejected += e.getValue();
+            }
+            sb.append(String.format("%n  %,6d  TOTAL filtered%n%n", totalRejected));
+        }
 
         List<Map.Entry<String, Integer>> sorted = categoryCounts.entrySet().stream()
             .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())

--- a/source/org/zfin/datatransfer/go/service/GafLoadJob.java
+++ b/source/org/zfin/datatransfer/go/service/GafLoadJob.java
@@ -218,6 +218,7 @@ public class GafLoadJob extends AbstractValidateDataReportTask {
             File errorSummaryFile = new File(new File(dataDirectory, jobName), jobName + "_error_summary.txt");
             try {
                 GafErrorSummary errorSummary = new GafErrorSummary();
+                errorSummary.setParserRejections(gafParser.getRejectionCounts());
                 errorSummary.processErrors(gafJobData.getErrors());
                 errorSummary.writeToFile(errorSummaryFile);
                 logger.info("Error summary written to: {}", errorSummaryFile.getAbsolutePath());

--- a/source/org/zfin/datatransfer/go/service/GafLoadJob.java
+++ b/source/org/zfin/datatransfer/go/service/GafLoadJob.java
@@ -214,6 +214,17 @@ public class GafLoadJob extends AbstractValidateDataReportTask {
             details.flush();
             details.close();
 
+            // Generate categorized error summary
+            File errorSummaryFile = new File(new File(dataDirectory, jobName), jobName + "_error_summary.txt");
+            try {
+                GafErrorSummary errorSummary = new GafErrorSummary();
+                errorSummary.processErrors(gafJobData.getErrors());
+                errorSummary.writeToFile(errorSummaryFile);
+                logger.info("Error summary written to: {}", errorSummaryFile.getAbsolutePath());
+            } catch (Exception ex) {
+                logger.warn("Failed to generate error summary", ex);
+            }
+
             //throw an exception if parser encountered an error
             //do this at the end so the load works for records that are valid
             if (gafParser.isErrorEncountered()) {

--- a/source/org/zfin/datatransfer/go/service/GafLoadJob.java
+++ b/source/org/zfin/datatransfer/go/service/GafLoadJob.java
@@ -221,6 +221,7 @@ public class GafLoadJob extends AbstractValidateDataReportTask {
                 errorSummary.processErrors(gafJobData.getErrors());
                 errorSummary.writeToFile(errorSummaryFile);
                 logger.info("Error summary written to: {}", errorSummaryFile.getAbsolutePath());
+                System.out.println("Error summary written to: " + errorSummaryFile.getAbsolutePath());
             } catch (Exception ex) {
                 logger.warn("Failed to generate error summary", ex);
             }

--- a/source/org/zfin/datatransfer/go/service/GafService.java
+++ b/source/org/zfin/datatransfer/go/service/GafService.java
@@ -454,7 +454,10 @@ public class GafService {
 
 
             try {
-                GoEvidenceValidator.validateEvidenceVsPub(goEvidenceCodeEnum, publicationZdbId, inferenceSet.iterator().next());
+                // Validate each accepted inference against its pub
+                for (InferenceGroupMember member : inferredFrom) {
+                    GoEvidenceValidator.validateEvidenceVsPub(goEvidenceCodeEnum, publicationZdbId, member.getInferredFrom());
+                }
                 GoEvidenceValidator.validateProteinBinding(goEvidenceCodeEnum, inferenceSet,
                     markerGoTermEvidence.getGoTerm().getOboID(),
                     markerGoTermEvidence.getGoTerm().getOntology().getOntologyName(),

--- a/source/org/zfin/datatransfer/go/service/GafService.java
+++ b/source/org/zfin/datatransfer/go/service/GafService.java
@@ -452,11 +452,12 @@ public class GafService {
                 }
             }
             if (goEvidenceCodeEnum == GoEvidenceCodeEnum.IEA && inferredFrom.size() > 1) {
-                logger.info("IEA annotation with {} inferences for {}: {}",
+                logger.info("Loaded IEA annotation with {} inferences for {}: {} | {}",
                     inferredFrom.size(), gafEntry.getEntryId(),
                     inferredFrom.stream()
                         .map(InferenceGroupMember::getInferredFrom)
-                        .collect(java.util.stream.Collectors.joining(", ")));
+                        .collect(java.util.stream.Collectors.joining(", ")),
+                    gafEntry);
             }
             markerGoTermEvidence.setInferredFrom(inferredFrom);
 

--- a/source/org/zfin/datatransfer/go/service/GafService.java
+++ b/source/org/zfin/datatransfer/go/service/GafService.java
@@ -419,6 +419,13 @@ public class GafService {
                     inferredFrom.add(inferenceGroupMember);
                 }
             }
+            if (goEvidenceCodeEnum == GoEvidenceCodeEnum.IEA && inferredFrom.size() > 1) {
+                logger.info("IEA annotation with {} inferences for {}: {}",
+                    inferredFrom.size(), gafEntry.getEntryId(),
+                    inferredFrom.stream()
+                        .map(InferenceGroupMember::getInferredFrom)
+                        .collect(java.util.stream.Collectors.joining(", ")));
+            }
             markerGoTermEvidence.setInferredFrom(inferredFrom);
 
 

--- a/source/org/zfin/datatransfer/go/service/GafService.java
+++ b/source/org/zfin/datatransfer/go/service/GafService.java
@@ -16,6 +16,7 @@ import org.zfin.gwt.root.ui.ValidationException;
 import org.zfin.infrastructure.ActiveData;
 import org.zfin.infrastructure.ReplacementZdbID;
 import org.zfin.marker.Marker;
+import org.zfin.marker.MarkerRelationship;
 import org.zfin.marker.repository.MarkerRepository;
 import org.zfin.mutant.*;
 import org.zfin.ontology.GenericTerm;
@@ -218,6 +219,29 @@ public class GafService {
                 throw new GafValidationError("No gene found for ID: " + entryId);
             }
             returnGenes.add(gene);
+        } else if (entryId.startsWith("URS")) {
+            // RNAcentral IDs in the GAF file have a taxon suffix (e.g. URS0000005DE0_7955)
+            // but ZFIN stores them without it (e.g. URS0000005DE0)
+            String lookupId = entryId.contains("_") ? entryId.substring(0, entryId.indexOf("_")) : entryId;
+            List<MarkerDBLink> markerDBLinks = sequenceRepository.getMarkerDBLinksForAccession(lookupId);
+            for (MarkerDBLink markerDBLink : markerDBLinks) {
+                Marker linked = markerDBLink.getMarker();
+                if (linked.getZdbID().startsWith("ZDB-GENE-") || linked.getZdbID().contains("RNAG")) {
+                    logger.info("RNACentral Match: {} -> {} ({})", entryId, linked.getZdbID(), linked.getAbbreviation());
+                    returnGenes.add(linked);
+                } else if (linked.getZdbID().startsWith("ZDB-TSCRIPT-")) {
+                    // Transcript — find the parent gene via "gene produces transcript"
+                    List<Marker> genes = markerRepository.getRelatedMarkersForTypes(
+                        linked, MarkerRelationship.Type.GENE_PRODUCES_TRANSCRIPT);
+                    for (Marker gene : genes) {
+                        if (gene.getZdbID().startsWith("ZDB-GENE-") || gene.getZdbID().contains("RNAG")) {
+                            logger.info("RNACentral Match: {} -> transcript {} -> gene {} ({})",
+                                entryId, linked.getAbbreviation(), gene.getZdbID(), gene.getAbbreviation());
+                            returnGenes.add(gene);
+                        }
+                    }
+                }
+            }
         } else {
             List<MarkerDBLink> markerDBLinks = sequenceRepository.getMarkerDBLinksForAccession(entryId, getUniprotRelatedDatabases());
             for (MarkerDBLink markerDBLink : markerDBLinks) {

--- a/source/org/zfin/datatransfer/go/service/GafService.java
+++ b/source/org/zfin/datatransfer/go/service/GafService.java
@@ -30,7 +30,9 @@ import org.zfin.publication.repository.PublicationRepository;
 import org.zfin.repository.RepositoryFactory;
 import org.zfin.sequence.ForeignDB;
 import org.zfin.sequence.ForeignDBDataType;
+import org.zfin.marker.Transcript;
 import org.zfin.sequence.MarkerDBLink;
+import org.zfin.sequence.TranscriptDBLink;
 import org.zfin.sequence.ReferenceDatabase;
 import org.zfin.sequence.repository.SequenceRepository;
 import org.zfin.sequence.service.SequenceService;
@@ -221,25 +223,31 @@ public class GafService {
             returnGenes.add(gene);
         } else if (entryId.startsWith("URS")) {
             // RNAcentral IDs in the GAF file have a taxon suffix (e.g. URS0000005DE0_7955)
-            // but ZFIN stores them without it (e.g. URS0000005DE0)
+            // but ZFIN stores them without it (e.g. URS0000005DE0).
+            // These db_links point to transcripts (ZDB-TSCRIPT-*), which are mapped as
+            // TranscriptDBLink (discriminator 'TSCR'), not MarkerDBLink ('MARK').
+            // We query TranscriptDBLink and resolve to the parent gene.
             String lookupId = entryId.contains("_") ? entryId.substring(0, entryId.indexOf("_")) : entryId;
+            List<TranscriptDBLink> transcriptDBLinks = sequenceRepository.getTranscriptDBLinksForAccession(lookupId);
+            for (TranscriptDBLink tLink : transcriptDBLinks) {
+                Transcript transcript = tLink.getTranscript();
+                List<Marker> genes = markerRepository.getRelatedMarkersForTypes(
+                    transcript, MarkerRelationship.Type.GENE_PRODUCES_TRANSCRIPT);
+                for (Marker gene : genes) {
+                    if (gene.getZdbID().startsWith("ZDB-GENE-") || gene.getZdbID().contains("RNAG")) {
+                        logger.info("RNACentral Match: {} -> transcript {} -> gene {} ({})",
+                            entryId, transcript.getAbbreviation(), gene.getZdbID(), gene.getAbbreviation());
+                        returnGenes.add(gene);
+                    }
+                }
+            }
+            // Also check MarkerDBLink in case some URS IDs link directly to genes
             List<MarkerDBLink> markerDBLinks = sequenceRepository.getMarkerDBLinksForAccession(lookupId);
             for (MarkerDBLink markerDBLink : markerDBLinks) {
                 Marker linked = markerDBLink.getMarker();
                 if (linked.getZdbID().startsWith("ZDB-GENE-") || linked.getZdbID().contains("RNAG")) {
                     logger.info("RNACentral Match: {} -> {} ({})", entryId, linked.getZdbID(), linked.getAbbreviation());
                     returnGenes.add(linked);
-                } else if (linked.getZdbID().startsWith("ZDB-TSCRIPT-")) {
-                    // Transcript — find the parent gene via "gene produces transcript"
-                    List<Marker> genes = markerRepository.getRelatedMarkersForTypes(
-                        linked, MarkerRelationship.Type.GENE_PRODUCES_TRANSCRIPT);
-                    for (Marker gene : genes) {
-                        if (gene.getZdbID().startsWith("ZDB-GENE-") || gene.getZdbID().contains("RNAG")) {
-                            logger.info("RNACentral Match: {} -> transcript {} -> gene {} ({})",
-                                entryId, linked.getAbbreviation(), gene.getZdbID(), gene.getAbbreviation());
-                            returnGenes.add(gene);
-                        }
-                    }
                 }
             }
         } else {

--- a/source/org/zfin/datatransfer/webservice/NCBIRequest.java
+++ b/source/org/zfin/datatransfer/webservice/NCBIRequest.java
@@ -121,14 +121,20 @@ public class NCBIRequest {
         }
 
         (new TokenStorage()).getValue(TokenStorage.ServiceKey.NCBI_API_TOKEN)
-            .ifPresent(token -> nvps.add(new BasicNameValuePair("api_key", token)));
+            .ifPresent(token -> {
+                if (token.matches("[a-f0-9]{36}")) {
+                    nvps.add(new BasicNameValuePair("api_key", token));
+                } else {
+                    log.warn("NCBI API token appears invalid (expected 36 hex chars, got '{}'). Proceeding without API key.", token);
+                }
+            });
 
         UrlEncodedFormEntity urlEncodedFormEntity = new UrlEncodedFormEntity(nvps, "UTF-8");
 
         String formContentsString = IOUtils.toString(urlEncodedFormEntity.getContent(), "UTF-8");
         //decoded form contents for logging
         String decodedFormContents = java.net.URLDecoder.decode(formContentsString, "UTF-8");
-        log.debug("Form contents: " + decodedFormContents);
+        log.debug("NCBI POST to {} form contents: {}", post.getURI(), decodedFormContents);
 
         post.setEntity(urlEncodedFormEntity);
         log.debug("Posting to URI: " + post.getURI());
@@ -139,6 +145,15 @@ public class NCBIRequest {
             String errorMessage = "Error response from NCBI: " + response.getStatusLine().getStatusCode() +
                                   " - " + response.getStatusLine().getReasonPhrase();
             log.error(errorMessage);
+            if (response.getStatusLine().getStatusCode() == 400) {
+                boolean hasApiKey = nvps.stream().anyMatch(p -> "api_key".equals(p.getName()));
+                if (hasApiKey) {
+                    log.error("A 400 error from NCBI may indicate an invalid API key. " +
+                              "Check the NCBI_API_TOKEN value with: gradle tokenStorage --args='read NCBI_API_TOKEN'");
+                } else {
+                    log.error("No NCBI API key is configured. Request may have been rejected for other reasons.");
+                }
+            }
             throw new IOException(errorMessage);
         }
 

--- a/source/org/zfin/gwt/root/dto/GoEvidenceCodeEnum.java
+++ b/source/org/zfin/gwt/root/dto/GoEvidenceCodeEnum.java
@@ -72,7 +72,7 @@ public enum GoEvidenceCodeEnum implements IsSerializable {
             case IDA:
                 return 0;
             case IEA:
-                return 1;
+                return CARDINALITY_ONE_OR_MORE;
             case IEP:
                 return 0;
             case IGI:

--- a/source/org/zfin/gwt/root/dto/InferenceCategory.java
+++ b/source/org/zfin/gwt/root/dto/InferenceCategory.java
@@ -31,7 +31,7 @@ public enum InferenceCategory {
     UNIPROTKB_SUBCELL("UniProtKB-SubCell"),
     UNIPATHWAY("UniPathway"),
     UNIRULE("UniRule"),
-    ENSEMBL("Ensembl"),
+    ENSEMBL("Ensembl", "(?i)ensembl:.*"),
     PANTHER("PANTHER",false),
     MGI("MGI"),
     RGD("RGD"),

--- a/source/org/zfin/gwt/root/ui/GoEvidenceValidator.java
+++ b/source/org/zfin/gwt/root/ui/GoEvidenceValidator.java
@@ -138,9 +138,14 @@ public class GoEvidenceValidator {
             throw new ValidationException("Annotations with default pub " + GoDefaultPublication.ROOT.title() + " must have evidence code ND.");
         } else if (evidenceCode.equals(GoEvidenceCodeEnum.IEA)) {
             // if a go-ref pub, then
-            String errorString = GoDefaultPublication.validateInference(publicationZdbID, InferenceCategory.getInferenceCategoryByValue(firstInference));
-            if (errorString != null) {
-                throw new ValidationException(errorString);
+            try {
+                InferenceCategory inferenceCategory = InferenceCategory.getInferenceCategoryByValue(firstInference);
+                String errorString = GoDefaultPublication.validateInference(publicationZdbID, inferenceCategory);
+                if (errorString != null) {
+                    throw new ValidationException(errorString);
+                }
+            } catch (RuntimeException e) {
+                throw new ValidationException("Unrecognized inference category for value: " + firstInference);
             }
         }
         // not an IEA EC, but having an IEA pub


### PR DESCRIPTION
GAF load: accept multiple IEA inferences, add error summary report

- Change IEA inference cardinality from exactly-1 to one-or-more. GOA now provides multiple inference references per annotation (e.g. UniRule:UR000376739|UniRule:UR000414636). These were being rejected, losing ~322 valid annotations per load.

- Log IEA annotations that load with multiple inferences so the change can be monitored.

- Add GafErrorSummary.java that parses the details file error section and generates a companion _error_summary.txt with categorized counts, gene-not-found deep dive (by ID type and annotation source), and examples for each error category. Runs automatically after details file is written.

Conveniences:

- Add Database-Load job (so we can run `gradle loaddb` through jenkins
- Add Error logging for issues relating to ncbi api key
