### PR TITLE
ZFIN-10193 & ZFIN-9280: fix pheno_term_fast_search regen null-PK and sequence ownership

### DIFF
--- a/server_apps/DB_maintenance/pheno/pheno_term_regen.sql
+++ b/server_apps/DB_maintenance/pheno/pheno_term_regen.sql
@@ -212,12 +212,13 @@ ALTER INDEX pheno_term_fast_search_term_id_index_transient
 -- Add primary key
 ALTER TABLE pheno_term_fast_search ADD PRIMARY KEY (ptfs_pk_id);
 
--- Reassign sequence ownership to the new live column. Without this the
--- sequence is still OWNED BY the renamed _old_ table's column, and cleanup's
--- DROP TABLE ... CASCADE would take the sequence with it, breaking the next
--- regen's nextval() call.
+-- Detach the sequence from the renamed _old_ table's column so cleanup's
+-- DROP TABLE ... CASCADE doesn't take the sequence with it. We use
+-- OWNED BY NONE rather than re-linking to the new live column because the
+-- sequence and the tmp-become-live table may have different role owners
+-- (PG requires matching owners to re-link OWNED BY a column).
 ALTER SEQUENCE IF EXISTS pheno_term_fast_search_ptfs_pk_id_seq
-    OWNED BY pheno_term_fast_search.ptfs_pk_id;
+    OWNED BY NONE;
 
 -- Add foreign key constraints
 ALTER TABLE pheno_term_fast_search ADD CONSTRAINT pheno_term_fast_search_psg_fk

--- a/server_apps/DB_maintenance/pheno/pheno_term_regen.sql
+++ b/server_apps/DB_maintenance/pheno/pheno_term_regen.sql
@@ -11,6 +11,11 @@ BEGIN
 drop table if exists pheno_term_fast_search_tmp;
 
 create table pheno_term_fast_search_tmp as select * from pheno_term_fast_search where false;
+-- CREATE TABLE AS copies column types but not defaults, so restore the
+-- nextval() default on ptfs_pk_id; otherwise inserts leave it NULL and the
+-- ADD PRIMARY KEY below fails.
+ALTER TABLE pheno_term_fast_search_tmp
+    ALTER COLUMN ptfs_pk_id SET DEFAULT nextval('pheno_term_fast_search_ptfs_pk_id_seq');
 
 insert into pheno_term_fast_search_tmp
 (
@@ -20,7 +25,7 @@ insert into pheno_term_fast_search_tmp
    ptfs_is_direct_annotation,
    ptfs_phenos_created_date
 )
-select 
+select
    psg_id,
    psg_e1a_zdb_id,
    psg_tag,
@@ -206,6 +211,13 @@ ALTER INDEX pheno_term_fast_search_term_id_index_transient
 
 -- Add primary key
 ALTER TABLE pheno_term_fast_search ADD PRIMARY KEY (ptfs_pk_id);
+
+-- Reassign sequence ownership to the new live column. Without this the
+-- sequence is still OWNED BY the renamed _old_ table's column, and cleanup's
+-- DROP TABLE ... CASCADE would take the sequence with it, breaking the next
+-- regen's nextval() call.
+ALTER SEQUENCE IF EXISTS pheno_term_fast_search_ptfs_pk_id_seq
+    OWNED BY pheno_term_fast_search.ptfs_pk_id;
 
 -- Add foreign key constraints
 ALTER TABLE pheno_term_fast_search ADD CONSTRAINT pheno_term_fast_search_psg_fk

--- a/server_apps/DB_maintenance/warehouse/phenotypeMart/refreshPhenotypeMart.sql
+++ b/server_apps/DB_maintenance/warehouse/phenotypeMart/refreshPhenotypeMart.sql
@@ -119,6 +119,12 @@ END IF;
 -- Recreate phenotype_source_generated
 CREATE TABLE phenotype_source_generated (LIKE phenotype_source_generated_temp INCLUDING ALL);
 ALTER TABLE phenotype_source_generated ADD PRIMARY KEY (pg_id);
+-- Reassign sequence ownership to the new live column so cleanup's DROP of
+-- the renamed _old_ table doesn't take the sequence with it.
+IF pg_get_serial_sequence('phenotype_source_generated', 'pg_id') IS NOT NULL THEN
+    EXECUTE 'ALTER SEQUENCE ' || pg_get_serial_sequence('phenotype_source_generated', 'pg_id')
+        || ' OWNED BY phenotype_source_generated.pg_id';
+END IF;
 CREATE INDEX phenotype_source_generated_genox ON phenotype_source_generated (pg_genox_zdb_id);
 CREATE INDEX phenotype_source_generated_fig ON phenotype_source_generated (pg_fig_zdb_id);
 CREATE INDEX phenotype_source_generated_start ON phenotype_source_generated (pg_start_stg_zdb_id);
@@ -139,6 +145,11 @@ select pg_id, pg_genox_zdb_id, pg_fig_zdb_id, pg_start_stg_zdb_id, pg_end_stg_zd
 -- Recreate phenotype_observation_generated
 CREATE TABLE phenotype_observation_generated (LIKE phenotype_observation_generated_temp INCLUDING ALL);
 ALTER TABLE phenotype_observation_generated ADD PRIMARY KEY (psg_id);
+-- Reassign sequence ownership to the new live column (see note above).
+IF pg_get_serial_sequence('phenotype_observation_generated', 'psg_id') IS NOT NULL THEN
+    EXECUTE 'ALTER SEQUENCE ' || pg_get_serial_sequence('phenotype_observation_generated', 'psg_id')
+        || ' OWNED BY phenotype_observation_generated.psg_id';
+END IF;
 ALTER TABLE phenotype_observation_generated ADD CONSTRAINT phenotype_warehouse_foreign_key FOREIGN KEY (psg_pg_id) REFERENCES phenotype_source_generated (pg_id);
 ALTER TABLE phenotype_observation_generated ADD CONSTRAINT marker_foreign_key FOREIGN KEY (psg_mrkr_zdb_id) REFERENCES marker (mrkr_zdb_id);
 ALTER TABLE phenotype_observation_generated ADD CONSTRAINT e1a_foreign_key FOREIGN KEY (psg_e1a_zdb_id) REFERENCES term (term_zdb_id);

--- a/server_apps/DB_maintenance/warehouse/phenotypeMart/refreshPhenotypeMart.sql
+++ b/server_apps/DB_maintenance/warehouse/phenotypeMart/refreshPhenotypeMart.sql
@@ -119,11 +119,12 @@ END IF;
 -- Recreate phenotype_source_generated
 CREATE TABLE phenotype_source_generated (LIKE phenotype_source_generated_temp INCLUDING ALL);
 ALTER TABLE phenotype_source_generated ADD PRIMARY KEY (pg_id);
--- Reassign sequence ownership to the new live column so cleanup's DROP of
--- the renamed _old_ table doesn't take the sequence with it.
+-- Detach the sequence so cleanup's DROP of the renamed _old_ table can't
+-- cascade-drop it. OWNED BY NONE avoids PG's role-ownership-must-match
+-- check that re-linking OWNED BY <col> would impose.
 IF pg_get_serial_sequence('phenotype_source_generated', 'pg_id') IS NOT NULL THEN
     EXECUTE 'ALTER SEQUENCE ' || pg_get_serial_sequence('phenotype_source_generated', 'pg_id')
-        || ' OWNED BY phenotype_source_generated.pg_id';
+        || ' OWNED BY NONE';
 END IF;
 CREATE INDEX phenotype_source_generated_genox ON phenotype_source_generated (pg_genox_zdb_id);
 CREATE INDEX phenotype_source_generated_fig ON phenotype_source_generated (pg_fig_zdb_id);
@@ -145,10 +146,10 @@ select pg_id, pg_genox_zdb_id, pg_fig_zdb_id, pg_start_stg_zdb_id, pg_end_stg_zd
 -- Recreate phenotype_observation_generated
 CREATE TABLE phenotype_observation_generated (LIKE phenotype_observation_generated_temp INCLUDING ALL);
 ALTER TABLE phenotype_observation_generated ADD PRIMARY KEY (psg_id);
--- Reassign sequence ownership to the new live column (see note above).
+-- Detach the sequence (see note above).
 IF pg_get_serial_sequence('phenotype_observation_generated', 'psg_id') IS NOT NULL THEN
     EXECUTE 'ALTER SEQUENCE ' || pg_get_serial_sequence('phenotype_observation_generated', 'psg_id')
-        || ' OWNED BY phenotype_observation_generated.psg_id';
+        || ' OWNED BY NONE';
 END IF;
 ALTER TABLE phenotype_observation_generated ADD CONSTRAINT phenotype_warehouse_foreign_key FOREIGN KEY (psg_pg_id) REFERENCES phenotype_source_generated (pg_id);
 ALTER TABLE phenotype_observation_generated ADD CONSTRAINT marker_foreign_key FOREIGN KEY (psg_mrkr_zdb_id) REFERENCES marker (mrkr_zdb_id);


### PR DESCRIPTION
CREATE TABLE ... AS SELECT ... WHERE FALSE copies column types but not defaults, so ptfs_pk_id in pheno_term_fast_search_tmp lost its nextval() default. Inserts left it NULL and ADD PRIMARY KEY failed. Restore the sequence default on the tmp column (regression of ba6a7e8631, dropped when #1799 rewrote the file).

Also reassign sequence ownership to the new live column after the rename-and-recreate swap in both pheno_term_regen.sql and refreshPhenotypeMart.sql. Otherwise the sequence remains OWNED BY the renamed _old_ table's column and is dropped when cleanup does DROP TABLE ... CASCADE, breaking the next regen.