### PR TITLE
ZFIN-10262: insert whitespace where HTML tags occur before HTMLStripC…

### DIFF
--- a/server_apps/solr/site_index/conf/schema.xml
+++ b/server_apps/solr/site_index/conf/schema.xml
@@ -69,6 +69,7 @@
             -->
         <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
             <analyzer type="index">
+                <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="&lt;[^&gt;]+&gt;" replacement=" "/>
                 <charFilter class="solr.HTMLStripCharFilterFactory"/>
                 <tokenizer class="solr.StandardTokenizerFactory"/>
                 <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
@@ -81,6 +82,7 @@
                 <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
             </analyzer>
             <analyzer type="query">
+                <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="&lt;[^&gt;]+&gt;" replacement=" "/>
                 <charFilter class="solr.HTMLStripCharFilterFactory"/>
                 <tokenizer class="solr.StandardTokenizerFactory"/>
                 <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
@@ -432,6 +434,7 @@
 
         <fieldType name="edgytext" class="solr.TextField" positionIncrementGap="100">
             <analyzer type="index">
+                <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="&lt;[^&gt;]+&gt;" replacement=" "/>
                 <charFilter class="solr.HTMLStripCharFilterFactory"/>
                 <tokenizer class="solr.StandardTokenizerFactory"/>
                 <filter class="solr.ASCIIFoldingFilterFactory"/>
@@ -439,6 +442,7 @@
                 <filter class="solr.EdgeNGramFilterFactory" minGramSize="1" maxGramSize="25" />
             </analyzer>
             <analyzer type="query">
+                <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="&lt;[^&gt;]+&gt;" replacement=" "/>
                 <charFilter class="solr.HTMLStripCharFilterFactory"/>
                 <tokenizer class="solr.StandardTokenizerFactory"/>
                 <filter class="solr.ASCIIFoldingFilterFactory"/>
@@ -448,6 +452,7 @@
 
         <fieldType name="simplified-international-text" class="solr.TextField" positionIncrementGap="100">
             <analyzer>
+                <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="&lt;[^&gt;]+&gt;" replacement=" "/>
                 <charFilter class="solr.HTMLStripCharFilterFactory"/>
                 <tokenizer class="solr.StandardTokenizerFactory"/>
                 <filter class="solr.ASCIIFoldingFilterFactory"/>


### PR DESCRIPTION
…harFilter

ZFIN-9061 (3c0a23361b, 2026-03-04) added solr.HTMLStripCharFilterFactory to text, edgytext, and simplified-international-text. That filter elides tags without inserting whitespace, so values like
"adssl<sup>hi3081Tg</sup>" became the single run-on token "adsslhi3081tg" at index time. The query "adssl hi3081Tg" still tokenized to two terms, so AND-mode searches on /fish-search (and similar handlers) stopped matching. FishServiceTest.geneStartsWithTest began failing on trunk on 2026-04-14, the day trunk's Solr core was reloaded into the post-9061 schema.

Prepend a PatternReplaceCharFilter that converts any "<...>" tag into a single space before HTMLStripCharFilter runs. This keeps the special-character handling 9061 wanted while preserving the word boundaries that "<sup>"-style tags used to provide.

Note: the live index will need to be rebuilt for existing docs to be retokenized -- a schema reload alone is not enough.