### PR TITLE
ZFIN-10074: paginate SPTrEMBL UniProt downloads

### DIFF
--- a/server_apps/data_transfer/BLAST/SPTrEMBL/downloadSPTrEMBL.sh
+++ b/server_apps/data_transfer/BLAST/SPTrEMBL/downloadSPTrEMBL.sh
@@ -1,20 +1,69 @@
 #!/bin/bash -e
 #
 # Download SwissProt and TrEMBL zebrafish, mouse, and human FASTA files
-# from UniProt REST API.
+# from UniProt's REST API, using cursor-paginated /search rather than
+# /stream so a mid-download connection drop only forfeits the current
+# page rather than the whole file.
 #
-# UniProt migrated from www.uniprot.org/uniprot/ to rest.uniprot.org in 2022.
-# See: https://www.uniprot.org/help/api
+# See: https://www.uniprot.org/help/pagination
+#      https://www.uniprot.org/help/api_queries
 
 source "../config.sh"
 
-BASE_URL="https://rest.uniprot.org/uniprotkb/stream"
+SEARCH_URL="https://rest.uniprot.org/uniprotkb/search"
+PAGE_SIZE=500     # UniProt-recommended page size for paginated downloads
+
+taxonomy_id_for() {
+    case "$1" in
+        zebrafish) echo 7955  ;;
+        mouse)     echo 10090 ;;
+        human)     echo 9606  ;;
+        *) error_exit "unknown organism: $1" ;;
+    esac
+}
+
+download_organism_fasta() {
+    local organism="$1"
+    local taxonomy_id; taxonomy_id=$(taxonomy_id_for "${organism}")
+    local output="${organism}.fasta"
+    local headers; headers=$(mktemp)
+
+    log_message "== Downloading ${organism} (organism_id:${taxonomy_id}) via paginated /search =="
+    : > "${output}"
+
+    local url="${SEARCH_URL}?query=organism_id:${taxonomy_id}&format=fasta&size=${PAGE_SIZE}"
+    local page=0
+    while [[ -n "${url}" ]]; do
+        page=$((page + 1))
+        curl --silent --show-error --fail --compressed \
+             --max-time 300 --retry 3 --retry-delay 5 \
+             -D "${headers}" \
+             "${url}" >> "${output}"
+
+        local total
+        total=$(awk 'BEGIN{IGNORECASE=1} /^x-total-results:/ {print $2}' "${headers}" | tr -d '\r')
+        local link
+        link=$(awk 'BEGIN{IGNORECASE=1} /^link:/ {sub(/^[^:]*:[ \t]*/,""); print}' "${headers}" | tr -d '\r')
+
+        if [[ "${link}" =~ \<([^\>]+)\>\;\ *rel=\"next\" ]]; then
+            url="${BASH_REMATCH[1]}"
+        else
+            url=""
+        fi
+
+        if (( page == 1 || page % 20 == 0 )) || [[ -z "${url}" ]]; then
+            log_message "  ${organism} page ${page}: $(grep -c '^>' "${output}")/${total:-?} sequences ($(du -h "${output}" | cut -f1))"
+        fi
+    done
+
+    rm -f "${headers}"
+    log_message "Rewriting >tr to >sp in ${organism}.fasta"
+    sed -i 's/>tr/>sp/g' "${output}"
+    log_message "Done with ${organism}: $(grep -c '^>' "${output}") sequences"
+}
 
 for organism in zebrafish mouse human; do
-    echo "== Downloading ${organism} FASTA (compressed) =="
-    wget -q -O ${organism}.fasta.gz "${BASE_URL}?query=organism_name:${organism}&format=fasta&compressed=true"
-    gunzip -f ${organism}.fasta.gz
-    sed -i 's/>tr/>sp/g' ${organism}.fasta
+    download_organism_fasta "${organism}"
 done
 
-echo "==| done downloading SPTrEMBL |=="
+log_message "==| done downloading SPTrEMBL |=="


### PR DESCRIPTION
Replaced the wget-based /uniprotkb/stream call with curl-driven cursor pagination over /uniprotkb/search at size=500. The /stream endpoint was reproducibly truncating the zebrafish download with an SSL "unexpected eof" partway through, causing the Jenkins job to hang for hours; UniProt's docs explicitly recommend paginated /search for any large result set because each page failure is recoverable.

Also switches the query from organism_name:<name> (full-text) to organism_id:<taxid> (exact taxonomy match), and adds timestamped progress logging every 20 pages so a future stall is visible in the build log instead of silent.

The output filenames, sed >tr->sp rewrite, and downstream convertSPTrEMBL.sh / pushSPTrEMBL.sh contracts are unchanged.