### PR TITLE
ZFIN-10262: fix Solr search for terms containing inline HTML tags

### DIFF
--- a/server_apps/solr/site_index/conf/schema.xml
+++ b/server_apps/solr/site_index/conf/schema.xml
@@ -69,6 +69,7 @@
             -->
         <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
             <analyzer type="index">
+                <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="&lt;[^&gt;]+&gt;" replacement=" "/>
                 <charFilter class="solr.HTMLStripCharFilterFactory"/>
                 <tokenizer class="solr.StandardTokenizerFactory"/>
                 <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
@@ -81,6 +82,7 @@
                 <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
             </analyzer>
             <analyzer type="query">
+                <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="&lt;[^&gt;]+&gt;" replacement=" "/>
                 <charFilter class="solr.HTMLStripCharFilterFactory"/>
                 <tokenizer class="solr.StandardTokenizerFactory"/>
                 <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
@@ -432,6 +434,7 @@
 
         <fieldType name="edgytext" class="solr.TextField" positionIncrementGap="100">
             <analyzer type="index">
+                <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="&lt;[^&gt;]+&gt;" replacement=" "/>
                 <charFilter class="solr.HTMLStripCharFilterFactory"/>
                 <tokenizer class="solr.StandardTokenizerFactory"/>
                 <filter class="solr.ASCIIFoldingFilterFactory"/>
@@ -439,6 +442,7 @@
                 <filter class="solr.EdgeNGramFilterFactory" minGramSize="1" maxGramSize="25" />
             </analyzer>
             <analyzer type="query">
+                <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="&lt;[^&gt;]+&gt;" replacement=" "/>
                 <charFilter class="solr.HTMLStripCharFilterFactory"/>
                 <tokenizer class="solr.StandardTokenizerFactory"/>
                 <filter class="solr.ASCIIFoldingFilterFactory"/>
@@ -448,6 +452,7 @@
 
         <fieldType name="simplified-international-text" class="solr.TextField" positionIncrementGap="100">
             <analyzer>
+                <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="&lt;[^&gt;]+&gt;" replacement=" "/>
                 <charFilter class="solr.HTMLStripCharFilterFactory"/>
                 <tokenizer class="solr.StandardTokenizerFactory"/>
                 <filter class="solr.ASCIIFoldingFilterFactory"/>


### PR DESCRIPTION
HTMLStripCharFilter elides tag characters without inserting whitespace, so values like adssl<sup>hi3081Tg</sup> were collapsing to a single run-on token and AND queries returned 0 results. Prepend a PatternReplaceCharFilter that converts any <...> tag to a single space, so StandardTokenizer recovers the separate tokens. Applied to text, edgytext, and simplified-international-text field types (the three modified by ZFIN-9061).