### PR TITLE
ZFIN-10242: Make Sequence of Variant a scrollable textarea

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1574,9 +1574,13 @@ task npmBuild(type: Exec) {
 
     commandLine 'npm', 'run', 'build'
 
-    inputs.dir 'home/javascript/react'
+    inputs.dir 'home/javascript'
+    inputs.dir 'home/css'
     inputs.file 'webpack.config.js'
     inputs.file 'package.json'
+    inputs.file 'package-lock.json'
+    inputs.file '.babelrc'
+    inputs.file 'tsconfig.json'
     outputs.dir targetroot + '/home/dist'
 }
 

--- a/home/css/zfin.css
+++ b/home/css/zfin.css
@@ -156,6 +156,17 @@ table.data_manager a.root {
     background-color: lightblue;
 }
 
+/** read-only inputs read as muted; .dirty wins via specificity below */
+input[readonly], textarea[readonly] {
+    background-color: #e8e8e8;
+    color: #888;
+}
+
+input[readonly].dirty, textarea[readonly].dirty {
+    background-color: lightblue;
+    color: inherit;
+}
+
 .search-result-table-header {
     background: rgb(204, 204, 204) none repeat scroll 0%;
     font-weight: bold;

--- a/source/org/zfin/gwt/curation/server/FeatureRPCServiceImpl.java
+++ b/source/org/zfin/gwt/curation/server/FeatureRPCServiceImpl.java
@@ -351,6 +351,7 @@ public class FeatureRPCServiceImpl extends RemoteServiceServlet implements Featu
 
             }
             DTOConversionService.updateDnaMutationDetailWithDTO(detail, featureDTO.getDnaChangeDTO());
+            validateDeletionLength(detail, fgl, feature.getType());
             if (feature.getType().equals(FeatureTypeEnum.INDEL)) {
                 if (detail.getNumberRemovedBasePair() == detail.getNumberAddedBasePair()) {
                     if (detail.getNumberRemovedBasePair() > 1) {
@@ -1225,6 +1226,24 @@ public class FeatureRPCServiceImpl extends RemoteServiceServlet implements Featu
         }
         GenomicLocationService genomicLocationService = new GenomicLocationService();
         return new String(genomicLocationService.getReferenceSequence(assemblyEnum, chromosome, start, end).getBases()).toUpperCase();
+    }
+
+    private void validateDeletionLength(FeatureDnaMutationDetail detail, FeatureLocation fgl, FeatureTypeEnum featureType) throws ValidationException {
+        if (detail == null || detail.getNumberRemovedBasePair() == null) {
+            return;
+        }
+        if (fgl == null || fgl.getStartLocation() == null || fgl.getEndLocation() == null) {
+            return;
+        }
+        if (featureType != FeatureTypeEnum.DELETION
+                && featureType != FeatureTypeEnum.INDEL
+                && featureType != FeatureTypeEnum.MNV) {
+            return;
+        }
+        int expected = fgl.getEndLocation() - fgl.getStartLocation() + 1;
+        if (detail.getNumberRemovedBasePair() != expected) {
+            throw new ValidationException("Deletion size does not match the auto-calculated value from the start/end locations");
+        }
     }
 
     private void validateReferenceSequence(FeatureGenomicMutationDetail fgmd, FeatureLocation fgl) throws ValidationException {

--- a/source/org/zfin/gwt/curation/ui/feature/AbstractFeaturePresenter.java
+++ b/source/org/zfin/gwt/curation/ui/feature/AbstractFeaturePresenter.java
@@ -231,6 +231,22 @@ public abstract class AbstractFeaturePresenter implements HandlesError {
         );
     }
 
+    public void autoCalcDeletionLength() {
+        String featureType = view.featureTypeBox.getSelected();
+        if (featureType == null) return;
+
+        boolean hasDeletionLength = featureType.equals(FeatureTypeEnum.DELETION.getName())
+                || featureType.equals(FeatureTypeEnum.INDEL.getName())
+                || featureType.equals(FeatureTypeEnum.MNV.getName());
+        if (!hasDeletionLength) return;
+
+        Integer start = view.featureStartLoc.getBoxValue();
+        Integer end = view.featureEndLoc.getBoxValue();
+        if (start == null || end == null || end < start) return;
+
+        view.mutationDetailDnaView.setDeletionLength(end - start + 1);
+    }
+
     public FeatureDTO createDTOFromGUI(AbstractFeatureView view) {
 
         FeatureDTO featureDTO = new FeatureDTO();

--- a/source/org/zfin/gwt/curation/ui/feature/AbstractFeatureView.java
+++ b/source/org/zfin/gwt/curation/ui/feature/AbstractFeatureView.java
@@ -216,12 +216,14 @@ public abstract class AbstractFeatureView extends Composite implements Revertibl
         }
         handleChanges();
         presenter.fetchReferenceSequenceIfReady();
+        presenter.autoCalcDeletionLength();
     }
 
     @UiHandler("featureEndLoc")
     void onChangeEndLocation(@SuppressWarnings("unused") ChangeEvent event) {
         handleChanges();
         presenter.fetchReferenceSequenceIfReady();
+        presenter.autoCalcDeletionLength();
     }
 
 
@@ -412,6 +414,7 @@ public abstract class AbstractFeatureView extends Composite implements Revertibl
         }
 
         presenter.updateMutagenOnFeatureTypeChange(featureTypeSelected);
+        presenter.autoCalcDeletionLength();
     }
 
     public void resetGUI() {

--- a/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.java
+++ b/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.java
@@ -38,7 +38,7 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
     @UiField
     TextArea seqReference;
     @UiField
-    StringTextBox seqVariant;
+    RevertibleTextArea<String> seqVariant;
     @UiField
     Button reverseComplVarButton;
     @UiField
@@ -55,15 +55,6 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
     }
 
 
-    @UiHandler("seqVariant")
-    void onKeyDownseqVar(@SuppressWarnings("unused") KeyDownEvent event) {
-        if (event.getNativeKeyCode() == KeyCodes.KEY_ENTER)
-
-            seqVariant.setText(seqVariant.getText().toUpperCase());
-
-        handleChanges();
-
-    }
     @UiHandler("seqVariant")
     void onKeyChangeSeqVar(@SuppressWarnings("unused") KeyUpEvent event) {
         handleChanges();
@@ -119,14 +110,14 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
     public FeatureGenomeMutationDetailChangeDTO getDto() {
         String currentRefText = getRefSeqText();
         boolean hasRefSeq = currentRefText != null && !currentRefText.trim().isEmpty();
-        if (!hasEnteredValues() && !hasRefSeq)
+        String currentVarText = seqVariant.getText();
+        boolean hasVarSeq = currentVarText != null && !currentVarText.trim().isEmpty();
+        if (!hasRefSeq && !hasVarSeq)
             return null;
         FeatureGenomeMutationDetailChangeDTO dto = new FeatureGenomeMutationDetailChangeDTO();
 
-        String refText = currentRefText;
-        dto.setFgmdSeqRef(refText != null ? refText.toUpperCase() : null);
-        String varText = seqVariant.getBoxValue();
-        dto.setFgmdSeqVar(varText != null ? varText.toUpperCase() : null);
+        dto.setFgmdSeqRef(currentRefText != null ? currentRefText.toUpperCase() : null);
+        dto.setFgmdSeqVar(hasVarSeq ? currentVarText.toUpperCase() : null);
 
         return dto;
     }
@@ -167,7 +158,7 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
 
         seqReference.setText("");
         seqReferenceSmall.setText("");
-        seqVariant.clear();
+        seqVariant.setText("");
 
         clearError();
     }
@@ -236,12 +227,12 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
         if (dto == null) {
             seqReference.setText("");
             seqReferenceSmall.setText("");
-            seqVariant.clear();
+            seqVariant.setText("");
             return;
         }
         seqReference.setText(dto.getFgmdSeqRef());
         seqReferenceSmall.setText(dto.getFgmdSeqRef() != null ? dto.getFgmdSeqRef() : "");
-        seqVariant.setText(dto.getFgmdSeqVar());
+        seqVariant.setText(dto.getFgmdSeqVar() != null ? dto.getFgmdSeqVar() : "");
         switch (type) {
             case POINT_MUTATION:
 

--- a/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.java
+++ b/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.java
@@ -40,6 +40,8 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
     @UiField
     RevertibleTextArea<String> seqVariant;
     @UiField
+    StringTextBox seqVariantSmall;
+    @UiField
     Button reverseComplVarButton;
     @UiField
     TableRowElement sequenceOfReferenceRow;
@@ -49,6 +51,8 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
     TextBox seqReferenceSmall;
     @UiField
     TableRowElement sequenceOfVariantRow;
+    @UiField
+    TableRowElement sequenceOfVariantSmallRow;
 
     public GenomicMutationDetailView() {
         initWidget(uiBinder.createAndBindUi(this));
@@ -57,13 +61,21 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
 
     @UiHandler("seqVariant")
     void onKeyChangeSeqVar(@SuppressWarnings("unused") KeyUpEvent event) {
+        seqVariantSmall.setText(seqVariant.getText());
+        handleChanges();
+    }
+
+    @UiHandler("seqVariantSmall")
+    void onKeyChangeSeqVarSmall(@SuppressWarnings("unused") KeyUpEvent event) {
+        seqVariant.setText(seqVariantSmall.getText());
         handleChanges();
     }
 
     @UiHandler("reverseComplVarButton")
     void onClickComplSeqButton(@SuppressWarnings("unused") ClickEvent event) {
-        seqVariant.setText(reverseComplement(seqVariant.getText().toUpperCase()));
-
+        String complemented = reverseComplement(seqVariant.getText().toUpperCase());
+        seqVariant.setText(complemented);
+        seqVariantSmall.setText(complemented);
     }
 
 
@@ -107,10 +119,18 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
         return seqReference.getText();
     }
 
+    private String getVarSeqText() {
+        boolean smallVisible = sequenceOfVariantSmallRow.getStyle().getDisplay().equals(Style.Display.TABLE_ROW.getCssName());
+        if (smallVisible) {
+            return seqVariantSmall.getText();
+        }
+        return seqVariant.getText();
+    }
+
     public FeatureGenomeMutationDetailChangeDTO getDto() {
         String currentRefText = getRefSeqText();
         boolean hasRefSeq = currentRefText != null && !currentRefText.trim().isEmpty();
-        String currentVarText = seqVariant.getText();
+        String currentVarText = getVarSeqText();
         boolean hasVarSeq = currentVarText != null && !currentVarText.trim().isEmpty();
         if (!hasRefSeq && !hasVarSeq)
             return null;
@@ -159,6 +179,7 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
         seqReference.setText("");
         seqReferenceSmall.setText("");
         seqVariant.setText("");
+        seqVariantSmall.setText("");
 
         clearError();
     }
@@ -176,12 +197,14 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
         showRow(sequenceOfReferenceRow, false);
         showRow(sequenceOfReferenceSmallRow, false);
         showRow(sequenceOfVariantRow, true);
+        showRow(sequenceOfVariantSmallRow, false);
 
     }
 
     public void showReferenceSeq() {
 
         showRow(sequenceOfVariantRow, false);
+        showRow(sequenceOfVariantSmallRow, false);
         showRow(sequenceOfReferenceSmallRow, false);
         showRow(sequenceOfReferenceRow, true);
 
@@ -190,6 +213,7 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
     public void showBoth() {
 
         showRow(sequenceOfVariantRow, true);
+        showRow(sequenceOfVariantSmallRow, false);
         showRow(sequenceOfReferenceSmallRow, false);
         showRow(sequenceOfReferenceRow, true);
 
@@ -197,7 +221,8 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
 
     public void showBothPointMutation() {
 
-        showRow(sequenceOfVariantRow, true);
+        showRow(sequenceOfVariantRow, false);
+        showRow(sequenceOfVariantSmallRow, true);
         showRow(sequenceOfReferenceRow, false);
         showRow(sequenceOfReferenceSmallRow, true);
 
@@ -206,6 +231,7 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
     public void showTgFields() {
 
         showRow(sequenceOfVariantRow, false);
+        showRow(sequenceOfVariantSmallRow, false);
         showRow(sequenceOfReferenceRow, false);
         showRow(sequenceOfReferenceSmallRow, false);
 
@@ -228,11 +254,14 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
             seqReference.setText("");
             seqReferenceSmall.setText("");
             seqVariant.setText("");
+            seqVariantSmall.setText("");
             return;
         }
         seqReference.setText(dto.getFgmdSeqRef());
         seqReferenceSmall.setText(dto.getFgmdSeqRef() != null ? dto.getFgmdSeqRef() : "");
-        seqVariant.setText(dto.getFgmdSeqVar() != null ? dto.getFgmdSeqVar() : "");
+        String varValue = dto.getFgmdSeqVar() != null ? dto.getFgmdSeqVar() : "";
+        seqVariant.setText(varValue);
+        seqVariantSmall.setText(varValue);
         switch (type) {
             case POINT_MUTATION:
 

--- a/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.ui.xml
+++ b/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.ui.xml
@@ -85,7 +85,7 @@
 
                             <tr ui:field="sequenceOfVariantRow">
                                 <td class="{style.seq-label-column}">Sequence of Variant<br/><i>Please enter data from the + strand</i></td>
-                                <td><zfin:StringTextBox ui:field="seqVariant" addStyleNames="{style.uppercase}"/></td>
+                                <td><zfin:RevertibleTextArea ui:field="seqVariant" addStyleNames="{style.uppercase} {style.seq-textarea}"/></td>
                                 <td><g:Button ui:field="reverseComplVarButton" text="Reverse Complement" /></td>
                             </tr>
                         </table>

--- a/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.ui.xml
+++ b/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.ui.xml
@@ -88,6 +88,11 @@
                                 <td><zfin:RevertibleTextArea ui:field="seqVariant" addStyleNames="{style.uppercase} {style.seq-textarea}"/></td>
                                 <td><g:Button ui:field="reverseComplVarButton" text="Reverse Complement" /></td>
                             </tr>
+
+                            <tr ui:field="sequenceOfVariantSmallRow">
+                                <td class="{style.seq-label-column}">Sequence of Variant<br/><i>Please enter data from the + strand</i></td>
+                                <td colspan="2"><zfin:StringTextBox ui:field="seqVariantSmall" visibleLength="4" addStyleNames="{style.uppercase}"/></td>
+                            </tr>
                         </table>
                     </g:HTMLPanel>
                 </g:customCell>

--- a/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.ui.xml
+++ b/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.ui.xml
@@ -38,6 +38,12 @@
             text-transform: uppercase;
         }
 
+        .grey-text {
+            color: darkgrey;
+            font-style: italic;
+            font-size: small;
+        }
+
         @external .seq-detail-table;
         .seq-detail-table {
             width: 100%;
@@ -74,12 +80,12 @@
                     <g:HTMLPanel visible="true">
                         <table class="{style.seq-detail-table}">
                             <tr ui:field="sequenceOfReferenceRow">
-                                <td class="{style.seq-label-column}">Sequence of Reference (auto-generated)</td>
+                                <td class="{style.seq-label-column}">Sequence of Reference<br/><span class="{style.grey-text}">(auto-calculated)</span></td>
                                 <td colspan="2"><g:TextArea ui:field="seqReference" readOnly="true" addStyleNames="{style.uppercase} {style.seq-textarea}"/></td>
                             </tr>
 
                             <tr ui:field="sequenceOfReferenceSmallRow">
-                                <td class="{style.seq-label-column}">Sequence of Reference (auto-generated)</td>
+                                <td class="{style.seq-label-column}">Sequence of Reference<br/><span class="{style.grey-text}">(auto-calculated)</span></td>
                                 <td colspan="2"><g:TextBox ui:field="seqReferenceSmall" readOnly="true" addStyleNames="{style.uppercase}"/></td>
                             </tr>
 

--- a/source/org/zfin/gwt/curation/ui/feature/MutationDetailDNAView.java
+++ b/source/org/zfin/gwt/curation/ui/feature/MutationDetailDNAView.java
@@ -249,6 +249,10 @@ public class MutationDetailDNAView extends AbstractViewComposite {
         row.getStyle().setDisplay(show ? Style.Display.TABLE_ROW : Style.Display.NONE);
     }
 
+    public void setDeletionLength(Integer length) {
+        minusBasePair.setNumber(length);
+    }
+
     public MutationDetailDnaChangeDTO getDto() {
         if (!hasEnteredValues())
             return null;

--- a/source/org/zfin/gwt/curation/ui/feature/MutationDetailDNAView.ui.xml
+++ b/source/org/zfin/gwt/curation/ui/feature/MutationDetailDNAView.ui.xml
@@ -33,6 +33,12 @@
         .green {
             color: green;
         }
+
+        .grey-text {
+            color: darkgrey;
+            font-style: italic;
+            font-size: small;
+        }
     </ui:style>
 
     <g:FlowPanel ui:field="changePanel" visible="false">
@@ -73,8 +79,8 @@
                                 <td><zfin:StringTextBox ui:field="insertedSequence" /></td>
                             </tr>-->
                             <tr ui:field="deletionLengthRow">
-                                <td>deletion</td>
-                                <td><zfin:NumberTextBox ui:field="minusBasePair" visibleLength="4" readOnly="true"/> bp</td>
+                                <td>deletion<br/><span class="{style.grey-text}">(auto-calculated)</span></td>
+                                <td><zfin:NumberTextBox ui:field="minusBasePair" visibleLength="4" readOnly="true" addStyleNames="{style.grey-background}"/> bp</td>
                             </tr>
                             <!--<tr ui:field="deletionSequenceRow">
                                 <td>deleted sequence</td>

--- a/source/org/zfin/gwt/curation/ui/feature/MutationDetailDNAView.ui.xml
+++ b/source/org/zfin/gwt/curation/ui/feature/MutationDetailDNAView.ui.xml
@@ -74,7 +74,7 @@
                             </tr>-->
                             <tr ui:field="deletionLengthRow">
                                 <td>deletion</td>
-                                <td><zfin:NumberTextBox ui:field="minusBasePair" visibleLength="4"/> bp</td>
+                                <td><zfin:NumberTextBox ui:field="minusBasePair" visibleLength="4" readOnly="true"/> bp</td>
                             </tr>
                             <!--<tr ui:field="deletionSequenceRow">
                                 <td>deleted sequence</td>

--- a/source/org/zfin/gwt/curation/ui/feature/MutationDetailDNAView.ui.xml
+++ b/source/org/zfin/gwt/curation/ui/feature/MutationDetailDNAView.ui.xml
@@ -80,7 +80,7 @@
                             </tr>-->
                             <tr ui:field="deletionLengthRow">
                                 <td>deletion<br/><span class="{style.grey-text}">(auto-calculated)</span></td>
-                                <td><zfin:NumberTextBox ui:field="minusBasePair" visibleLength="4" readOnly="true" addStyleNames="{style.grey-background}"/> bp</td>
+                                <td><zfin:NumberTextBox ui:field="minusBasePair" visibleLength="4" readOnly="true"/> bp</td>
                             </tr>
                             <!--<tr ui:field="deletionSequenceRow">
                                 <td>deleted sequence</td>


### PR DESCRIPTION
The reference sequence was converted to a TextArea in 73a99c92a9 but the variant sequence stayed a single-line StringTextBox, so insertions and indels had no way to view long variant sequences. Swap seqVariant to a RevertibleTextArea sized like the reference textarea, and switch the empty-check in getDto to inspect the field directly since hasEnteredValues only matches instanceof TextBox.