### PR TITLE
ZFIN-10245: Restore GRCz11 as a current assembly on the feature curation form

### DIFF
--- a/source/org/zfin/gwt/curation/server/FeatureRPCServiceImpl.java
+++ b/source/org/zfin/gwt/curation/server/FeatureRPCServiceImpl.java
@@ -55,7 +55,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.zfin.framework.HibernateUtil.currentSession;
-import static org.zfin.genomebrowser.GenomeBrowserBuild.CURRENT;
 import static org.zfin.repository.RepositoryFactory.*;
 
 public class FeatureRPCServiceImpl extends RemoteServiceServlet implements FeatureRPCService {
@@ -145,13 +144,14 @@ public class FeatureRPCServiceImpl extends RemoteServiceServlet implements Featu
             HibernateUtil.currentSession().delete(fl);
             return;
         }
-        // If the assembly is changing, only allow changing to GRCz12tu
+        // If the assembly is changing, only allow changing to a current assembly (GRCz12tu or GRCz11)
         String previousAssembly = fl.getAssembly();
         String newAssembly = dto.getFeatureAssembly();
         if (previousAssembly != null && newAssembly != null
                 && !previousAssembly.equals(newAssembly)
-                && !AssemblyEnum.GRCZ12TU.getName().equals(newAssembly)) {
-            throw new ValidationException("Assembly can only be changed to " + AssemblyEnum.GRCZ12TU.getName());
+                && currentAssemblyEnum(newAssembly) == null) {
+            throw new ValidationException("Assembly can only be changed to "
+                    + AssemblyEnum.GRCZ12TU.getName() + " or " + AssemblyEnum.GRCZ11.getName());
         }
         fl.setChromosome(dto.getFeatureChromosome());
         fl.setAssembly(dto.getFeatureAssembly());
@@ -307,15 +307,15 @@ public class FeatureRPCServiceImpl extends RemoteServiceServlet implements Featu
         }
 
         boolean variationExists = featureDTO.getFgmdChangeDTO() != null;
-        // calculate and save flanking sequences for GRCz12tu
-        if ((variationExists || locationUpdated) && fgl.getAssembly() != null && fgl.getAssembly().equals(CURRENT.getValue())) {
-            GenomicLocationService service = new GenomicLocationService();
-            service.upsertFlankingSequence(feature, AssemblyEnum.GRCZ12TU);
+        // calculate and save flanking sequences for current assemblies (GRCz12tu, GRCz11)
+        AssemblyEnum currentAssembly = currentAssemblyEnum(fgl.getAssembly());
+        if ((variationExists || locationUpdated) && currentAssembly != null) {
+            new GenomicLocationService().upsertFlankingSequence(feature, currentAssembly);
         }
         // clean up flanking sequences when location is deleted
-        if (locationDeleted && previousAssembly != null && previousAssembly.equals(CURRENT.getValue())) {
-            GenomicLocationService service = new GenomicLocationService();
-            service.upsertFlankingSequence(feature, AssemblyEnum.GRCZ12TU);
+        AssemblyEnum prevAssembly = currentAssemblyEnum(previousAssembly);
+        if (locationDeleted && prevAssembly != null) {
+            new GenomicLocationService().upsertFlankingSequence(feature, prevAssembly);
         }
 
 
@@ -718,9 +718,9 @@ public class FeatureRPCServiceImpl extends RemoteServiceServlet implements Featu
 
                 currentSession().save(pa);
 
-                if (fgl.getAssembly() != null && fgl.getAssembly().equals(AssemblyEnum.GRCZ12TU.getName())) {
-                    GenomicLocationService service = new GenomicLocationService();
-                    service.upsertFlankingSequence(feature, AssemblyEnum.GRCZ12TU);
+                AssemblyEnum addedAssembly = currentAssemblyEnum(fgl.getAssembly());
+                if (addedAssembly != null) {
+                    new GenomicLocationService().upsertFlankingSequence(feature, addedAssembly);
                 }
 
 
@@ -1210,6 +1210,16 @@ public class FeatureRPCServiceImpl extends RemoteServiceServlet implements Featu
             pubs.size(), pubs.size() == 1 ? "" : "s");
     }
 
+
+    // Assemblies for which we generate/refresh flanking sequences and accept new
+    // location entries on the curation form. Other AssemblyEnum values (GRCz10, Zv9)
+    // are read-only legacy options shown in the edit dropdown only.
+    private static AssemblyEnum currentAssemblyEnum(String name) {
+        if (name == null) return null;
+        if (AssemblyEnum.GRCZ12TU.getName().equals(name)) return AssemblyEnum.GRCZ12TU;
+        if (AssemblyEnum.GRCZ11.getName().equals(name)) return AssemblyEnum.GRCZ11;
+        return null;
+    }
 
     @Override
     public String getReferenceSequence(String assembly, String chromosome, int start, int end) {

--- a/source/org/zfin/gwt/curation/ui/feature/AbstractFeatureView.java
+++ b/source/org/zfin/gwt/curation/ui/feature/AbstractFeatureView.java
@@ -568,6 +568,7 @@ public abstract class AbstractFeatureView extends Composite implements Revertibl
     void setFeatureAssemblyList() {
         featureAssembly.addItem("");
         featureAssembly.addItem("GRCz12tu");
+        featureAssembly.addItem("GRCz11");
     }
 
 

--- a/source/org/zfin/gwt/curation/ui/feature/FeatureEditView.java
+++ b/source/org/zfin/gwt/curation/ui/feature/FeatureEditView.java
@@ -144,7 +144,6 @@ public class FeatureEditView extends AbstractFeatureView implements Revertible {
     @Override
     void setFeatureAssemblyList() {
         super.setFeatureAssemblyList();
-        featureAssembly.addItem("GRCz11");
         featureAssembly.addItem("GRCz10");
         featureAssembly.addItem("Zv9");
     }


### PR DESCRIPTION
Re-add GRCz11 to the Add Feature dropdown, relax the server-side "must change to GRCz12tu" rule to also accept GRCz11, and run the flanking-sequence upsert against whichever of the two current assemblies is on the saved location.