### PR TITLE
ZFIN-10228: UCSC links cleaned up

### DIFF
--- a/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/pruneUcscLinks.sh
+++ b/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/pruneUcscLinks.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -eo pipefail
+
+# Prune UCSCStartEndLoader rows from sequence_feature_chromosome_location_generated
+# whose accession is not present in UCSC's danRer11 refGene track. UCSC's
+# hgTracks returns 404 for accessions it doesn't carry, so we drop those rows
+# to avoid broken links on the mapping detail page. Runs after
+# updateSequenceFeatureChromosomeLocationPostgres.sql in regenChromosomeMart.sh.
+
+CHROMOSOMEMARTDIR="$ROOT_PATH/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres"
+TSV_FILE="$CHROMOSOMEMARTDIR/ucscRefGeneAccessions.tsv"
+API_URL="https://api.genome.ucsc.edu/getData/track?genome=danRer11&track=refGene"
+MIN_ACCESSIONS=10000  # observed ~16k; bail if a transient response truncates the list
+
+rm -f "$TSV_FILE"
+
+TMP_JSON="$(mktemp)"
+trap 'rm -f "$TMP_JSON"' EXIT
+
+echo "fetching UCSC danRer11 refGene track from $API_URL"
+curl -sf --max-time 120 --retry 3 --retry-delay 5 "$API_URL" -o "$TMP_JSON"
+echo "  downloaded $(wc -c < "$TMP_JSON") bytes"
+
+jq -r '[.refGene[][].name] | unique | .[]' "$TMP_JSON" > "$TSV_FILE"
+count=$(wc -l < "$TSV_FILE" | tr -d ' ')
+echo "  extracted $count distinct accessions to $TSV_FILE"
+
+if [ "$count" -lt "$MIN_ACCESSIONS" ]; then
+  echo "ERROR: only $count accessions extracted (< $MIN_ACCESSIONS); refusing to prune"
+  exit 1
+fi
+
+echo "pruning UCSCStartEndLoader rows missing from refGene allowlist"
+psql -v ON_ERROR_STOP=1 "$DB_NAME" <<SQL
+begin;
+
+create temp table tmp_ucsc_refgene_accessions (accnum varchar(50) primary key);
+\copy tmp_ucsc_refgene_accessions (accnum) from '$TSV_FILE'
+
+select count(*) as ucsc_refgene_accessions from tmp_ucsc_refgene_accessions;
+
+select count(*) as ucsc_rows_before
+  from sequence_feature_chromosome_location_generated
+ where sfclg_location_source = 'UCSCStartEndLoader';
+
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_location_source = 'UCSCStartEndLoader'
+   and sfclg_acc_num not in (select accnum from tmp_ucsc_refgene_accessions);
+
+select count(*) as ucsc_rows_after
+  from sequence_feature_chromosome_location_generated
+ where sfclg_location_source = 'UCSCStartEndLoader';
+
+commit;
+SQL
+
+echo "UCSC link prune complete"

--- a/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/updateSequenceFeatureChromosomeLocationPostgres.sql
+++ b/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/updateSequenceFeatureChromosomeLocationPostgres.sql
@@ -1,20 +1,53 @@
+-- ============================================================================
+-- Regenerate-Chromosome-Mart_d — runs downstream of Refresh-GBrowse-Tracks_d.
+-- ============================================================================
+-- The downstream-trigger wiring is in
+-- server_apps/jenkins/jobs/Refresh-GBrowse-Tracks_d/config.xml
+-- (hudson.tasks.BuildTrigger). The refresh job runs
+-- server_apps/data_transfer/Ensembl/updateSequenceFeatureChromosomeLocation.sql,
+-- which DELETE+INSERTs the bulk of UCSC, Ensembl, Zfin, and DirectSubmission
+-- rows in sequence_feature_chromosome_location_generated. By the time this
+-- script starts, the table is already in its post-refresh state, so this
+-- script's only remaining work is the pieces the refresh path doesn't cover:
+--
+--   §E. ENSDARG-fallback EnsemblStartEndLoader rows for genes whose ENSDARG
+--       accession has no ENSDART transcript link.
+--   §H. zmp gbrowse-track tag (kept belt-and-suspenders for both ZMP pubs;
+--       the refresh handles ZDB-PUB-130425-4 — re-tagging it here is a no-op
+--       in steady state but acts as a fallback if refresh §H ever skips).
+--
+-- Section markers §A–§K below correspond to the same-named sections in the
+-- refresh script. Sections marked "REDUNDANT — handled by refresh" are
+-- commented out here; a follow-up PR will fully delete them.
+-- ============================================================================
+
 begin work;
 
-delete from sequence_feature_chromosome_location_generated
- where sfclg_location_source = 'ZfinGbrowseStartEndLoader';
+-- ----------------------------------------------------------------------------
+-- §A. REDUNDANT — handled by refresh §A
+--     Bulk DELETE of the five sources we'd otherwise own here.
+-- ----------------------------------------------------------------------------
+-- delete from sequence_feature_chromosome_location_generated
+--  where sfclg_location_source = 'ZfinGbrowseStartEndLoader';
+--
+-- delete from sequence_feature_chromosome_location_generated
+--  where sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader';
+--
+-- delete from sequence_feature_chromosome_location_generated
+--  where sfclg_location_source = 'DirectSubmission';
+--
+-- delete from sequence_feature_chromosome_location_generated
+--  where sfclg_location_source = 'EnsemblStartEndLoader';
+--
+-- delete from sequence_feature_chromosome_location_generated
+--  where sfclg_location_source = 'UCSCStartEndLoader';
 
-delete from sequence_feature_chromosome_location_generated
- where sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader';
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_location_source = 'DirectSubmission';
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_location_source = 'EnsemblStartEndLoader';
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_location_source = 'UCSCStartEndLoader';
-
+-- ----------------------------------------------------------------------------
+-- §B. ACTIVE — build tmp_gff_start_end / tmp_gene from gff3 + ensdar_mapping.
+--     Only tmp_gene.accnum1 is used downstream (by §E's "not in" filter); the
+--     start / ender columns and the full structure here mirror refresh §B and
+--     would be needed if any of §C / §D / §F were re-activated in this file.
+-- ----------------------------------------------------------------------------
 create temp table tmp_gff_start_end (accnum varchar(50),chrom varchar(20), gene varchar(50),
        start int,
        ender int
@@ -62,14 +95,14 @@ create index gene2_index on tmp_gene (accnum1)
 update tmp_gene
  set start = (select min(start)
       	      	      from tmp_gff_start_end
-		      where  gene = accnum1 
+		      where  gene = accnum1
 		      and chrom = chrom1);
 
 
 update tmp_gene
  set ender = (select max(ender)
       	      	      from tmp_gff_start_end
-		      where  gene = accnum1 
+		      where  gene = accnum1
 		      and chrom = chrom1);
 
 select count(*) from tmp_gene
@@ -78,71 +111,94 @@ select count(*) from tmp_gene
 select count(*) from tmp_gene
  where ender is null;
 
-create temp table tmp_ucsc (geneId text, 
-				chrom1 varchar(10),
-				accnum1 varchar(50),
-				source text,
-				fdb_db_pk_id int8)
-;
--- DISABLE UCSC record creation - comment out the insert
--- insert into tmp_ucsc (geneId, chrom1, accnum1, source, fdb_db_pk_id)
--- select ... (UCSC logic disabled)
-;
+-- ----------------------------------------------------------------------------
+-- §C. REDUNDANT — handled by refresh §C
+--     UCSC: build tmp_ucsc / tmp_ucsc_all and INSERT 'UCSCStartEndLoader' rows.
+--     The UCSC INSERT here was already disabled before this branch
+--     (commit 1c246db2, ZFIN-9989) because the refresh path was the canonical
+--     writer. The pruneUcscLinks.sh post-step in regenChromosomeMart.sh removes
+--     any UCSC rows whose accession isn't in UCSC's danRer11 refGene track.
+-- ----------------------------------------------------------------------------
+-- create temp table tmp_ucsc (geneId text,
+-- 				chrom1 varchar(10),
+-- 				accnum1 varchar(50),
+-- 				source text,
+-- 				fdb_db_pk_id int8)
+-- ;
+-- -- DISABLE UCSC record creation - comment out the insert
+-- -- insert into tmp_ucsc (geneId, chrom1, accnum1, source, fdb_db_pk_id)
+-- -- select ... (UCSC logic disabled)
+-- ;
+--
+-- create temp table tmp_ucsc_all (counter int,
+-- 			geneId text,
+-- 			chrom1 varchar(10),
+-- 			source text,
+-- 			subsource text,
+-- 			dblink_acc_num varchar(50));
+-- insert into tmp_ucsc_all (counter, geneId, chrom1, source, subsource, dblink_acc_num)
+-- select count(*) as counter, geneId, chrom1, source, source as subsource, dblink_acc_num
+--   from db_link, tmp_ucsc
+--  where geneId = dblink_linked_Recid
+--  and dblink_Acc_num like 'NM%'
+--  and exists (select 'x' from foreign_db_contains, foreign_db
+--      	    	    	where fdbcont_fdb_db_id = fdb_db_pk_id
+-- 			and fdb_db_name = 'RefSeq')
+-- group by geneId, chrom1, source, dblink_acc_num
+-- ;
+-- insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
+--        	    			       sfclg_chromosome,
+-- 					       sfclg_acc_num,
+-- 					       sfclg_location_source,
+-- 					       sfclg_location_Subsource,
+--                                        sfclg_evidence_code
+-- 					   )
+-- select distinct geneId, chrom1, dblink_acc_num, source, subsource, 'ZDB-TERM-170419-250'
+--   from tmp_ucsc_all;
 
-create temp table tmp_ucsc_all (counter int,
-			geneId text,
-			chrom1 varchar(10),
-			source text,
-			subsource text,
-			dblink_acc_num varchar(50));
-insert into tmp_ucsc_all (counter, geneId, chrom1, source, subsource, dblink_acc_num)
-select count(*) as counter, geneId, chrom1, source, source as subsource, dblink_acc_num
-  from db_link, tmp_ucsc
- where geneId = dblink_linked_Recid
- and dblink_Acc_num like 'NM%'
- and exists (select 'x' from foreign_db_contains, foreign_db
-     	    	    	where fdbcont_fdb_db_id = fdb_db_pk_id
-			and fdb_db_name = 'RefSeq')
-group by geneId, chrom1, source, dblink_acc_num
-;
-insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id, 
-       	    			       sfclg_chromosome,
-				       sfclg_acc_num,
-				       sfclg_location_source,
-				       sfclg_location_Subsource,
-                                       sfclg_evidence_code
-				   )
-select distinct geneId, chrom1, dblink_acc_num, source, subsource, 'ZDB-TERM-170419-250'
-  from tmp_ucsc_all;
+-- ----------------------------------------------------------------------------
+-- §D. REDUNDANT — handled by refresh §D
+--     EnsemblStartEndLoader main path: insert one row per gene/chromosome
+--     using start/ender from §B.
+-- ----------------------------------------------------------------------------
+-- insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
+--        	    			       sfclg_chromosome,
+-- 					       sfclg_start,
+-- 					       sfclg_end,
+-- 					       sfclg_acc_num,
+-- 					       sfclg_location_source,
+-- 					       sfclg_fdb_db_id,sfclg_evidence_code)
+-- select distinct dblink_linked_recid,
+--        		chrom1,
+-- 		start,
+-- 		ender,
+-- 		accnum1,
+-- 		'EnsemblStartEndLoader',
+-- 		fdb_db_pk_id, 'ZDB-TERM-170419-250'
+--   from db_link, tmp_gene, foreign_db, foreign_db_contains
+--   where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
+--   and dblink_acc_num = accnum1
+--   and fdb_db_pk_id = fdbcont_fdb_db_id
+--  and start is not null
+--  and ender is not null
+--     -- don't include fdb_db_display_name = 'ExpressionAtlas'
+--  and fdb_db_pk_id != 91
+-- ;
 
-
-insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id, 
-       	    			       sfclg_chromosome,
-				       sfclg_start,
-				       sfclg_end,
-				       sfclg_acc_num,
-				       sfclg_location_source,
-				       sfclg_fdb_db_id,sfclg_evidence_code)
-select distinct dblink_linked_recid,
-       		chrom1,
-		start,
-		ender,
-		accnum1,
-		'EnsemblStartEndLoader',
-		fdb_db_pk_id, 'ZDB-TERM-170419-250'
-  from db_link, tmp_gene, foreign_db, foreign_db_contains
-  where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
-  and dblink_acc_num = accnum1
-  and fdb_db_pk_id = fdbcont_fdb_db_id
- and start is not null
- and ender is not null
-    -- don't include fdb_db_display_name = 'ExpressionAtlas'
- and fdb_db_pk_id != 91
-;
-
--- Handle genes with ENSDARG accessions that don't have ENSDART links
--- These genes were deleted but not recreated by the logic above
-insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id, 
+-- ----------------------------------------------------------------------------
+-- §E. ACTIVE — ENSDARG-fallback EnsemblStartEndLoader rows.
+--     Warehouse-unique; no equivalent in refresh.sql. Introduced by ZFIN-9989
+--     (PR #1619) for genes whose ENSDARG accession has no ENSDART transcript
+--     link (so refresh §D's ENSDART path produces nothing for them).
+--
+--     The NOT EXISTS clause makes this idempotent — subsequent runs skip rows
+--     already inserted. uk_sfclg_unique_location + ON CONFLICT doesn't help
+--     here because that constraint covers sfclg_assembly and
+--     sfclg_location_subsource, both NULL in fallback rows; PostgreSQL treats
+--     NULLs in unique indexes as distinct, so the constraint doesn't fire on
+--     rerun.
+-- ----------------------------------------------------------------------------
+insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
        	    			       sfclg_chromosome,
 				       sfclg_start,
 				       sfclg_end,
@@ -162,7 +218,7 @@ select distinct dblink_linked_recid,
   and fdb_db_pk_id = fdbcont_fdb_db_id
   and dblink_acc_num like 'ENSDARG%'
   and gff_feature = 'gene'
-  -- Only include genes not already processed by the ENSDART logic above
+  -- Only include genes not already processed by the ENSDART logic in refresh §D
   and dblink_linked_recid not in (
     select distinct dblink_linked_recid
     from db_link, tmp_gene, foreign_db_contains
@@ -171,72 +227,108 @@ select distinct dblink_linked_recid,
   )
   -- don't include fdb_db_display_name = 'ExpressionAtlas'
   and fdb_db_pk_id != 91
+  -- skip rows we've already inserted (idempotence; see §E header)
+  and not exists (
+    select 1 from sequence_feature_chromosome_location_generated existing
+     where existing.sfclg_data_zdb_id = dblink_linked_recid
+       and existing.sfclg_location_source = 'EnsemblStartEndLoader'
+       and existing.sfclg_acc_num = dblink_acc_num
+       and existing.sfclg_chromosome = gff_seqname
+       and existing.sfclg_start = gff_start
+       and existing.sfclg_end = gff_end
+  )
 ;
 
-insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id, 
-       	    			       sfclg_chromosome,
-				       sfclg_start,
-				       sfclg_end,
-				       sfclg_acc_num,
-				       sfclg_location_source,
-				       sfclg_fdb_db_id,sfclg_evidence_code)
-select dblink_linked_recid,
-       		chrom1,
-		start,
-		ender,
-		accnum1,
-		'ZfinGbrowseStartEndLoader',
-		fdb_db_pk_id, 'ZDB-TERM-170419-250'
-  from db_link, tmp_gene, foreign_db, foreign_db_contains
-  where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
-  and dblink_acc_num = accnum1
-  and fdb_db_pk_id = fdbcont_fdb_db_id
- and start is not null
- and ender is not null
- and exists (select 'x' from zfin_ensembl_gene where zeg_gene_zdb_id = dblink_linked_recid)
- group by dblink_linked_recid, chrom1, start, ender, accnum1, fdb_db_pk_id
-;
+-- ----------------------------------------------------------------------------
+-- §F. REDUNDANT — handled by refresh §F
+--     ZfinGbrowseStartEndLoader from tmp_gene joined with zfin_ensembl_gene.
+-- ----------------------------------------------------------------------------
+-- insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
+--        	    			       sfclg_chromosome,
+-- 					       sfclg_start,
+-- 					       sfclg_end,
+-- 					       sfclg_acc_num,
+-- 					       sfclg_location_source,
+-- 					       sfclg_fdb_db_id,sfclg_evidence_code)
+-- select dblink_linked_recid,
+--        		chrom1,
+-- 		start,
+-- 		ender,
+-- 		accnum1,
+-- 		'ZfinGbrowseStartEndLoader',
+-- 		fdb_db_pk_id, 'ZDB-TERM-170419-250'
+--   from db_link, tmp_gene, foreign_db, foreign_db_contains
+--   where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
+--   and dblink_acc_num = accnum1
+--   and fdb_db_pk_id = fdbcont_fdb_db_id
+--  and start is not null
+--  and ender is not null
+--  and exists (select 'x' from zfin_ensembl_gene where zeg_gene_zdb_id = dblink_linked_recid)
+--  group by dblink_linked_recid, chrom1, start, ender, accnum1, fdb_db_pk_id
+-- ;
 
-insert into sequence_feature_chromosome_location_generated (
-  sfclg_chromosome, sfclg_data_zdb_id, sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_pub_zdb_id, sfclg_evidence_code)
-select sfcl_chromosome, sfcl_feature_zdb_id, sfcl_start_position, sfcl_end_position, 'DirectSubmission', '', sfcl_assembly, recattrib_source_zdb_id, sfcl_evidence_code
-  from sequence_feature_chromosome_location
-  left outer join record_attribution on recattrib_data_zdb_id = sfcl_zdb_id;
+-- ----------------------------------------------------------------------------
+-- §G. REDUNDANT — handled by refresh §G
+--     DirectSubmission re-import from sequence_feature_chromosome_location.
+-- ----------------------------------------------------------------------------
+-- insert into sequence_feature_chromosome_location_generated (
+--   sfclg_chromosome, sfclg_data_zdb_id, sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_pub_zdb_id, sfclg_evidence_code)
+-- select sfcl_chromosome, sfcl_feature_zdb_id, sfcl_start_position, sfcl_end_position, 'DirectSubmission', '', sfcl_assembly, recattrib_source_zdb_id, sfcl_evidence_code
+--   from sequence_feature_chromosome_location
+--   left outer join record_attribution on recattrib_data_zdb_id = sfcl_zdb_id;
 
+-- ----------------------------------------------------------------------------
+-- §H. ACTIVE — zmp gbrowse-track tag.
+--     Refresh §H tags ZDB-PUB-130425-4. We re-tag both ZMP pubs here as
+--     belt-and-suspenders: re-tagging ZDB-PUB-130425-4 is a no-op in steady
+--     state, but acts as a fallback if refresh §H ever silently skips, and
+--     ZDB-PUB-250905-18 is genuinely warehouse-unique work.
+-- ----------------------------------------------------------------------------
 update sequence_feature_chromosome_location_generated
 set sfclg_gbrowse_track = 'zmp'
 where sfclg_pub_zdb_id in ('ZDB-PUB-130425-4', 'ZDB-PUB-250905-18');
 
-insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
-  sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_gbrowse_track, sfclg_evidence_code)
-select gff3.gff_seqname, feature.feature_zdb_id, gff3.gff_start, gff3.gff_end, 'ZfinGbrowseZv9StartEndLoader', 'BurgessLin', 'Zv9', 'insertion', 'ZDB-TERM-170419-250'
-from gff3
-inner join feature on (gff3.gff_id || 'Tg') = feature.feature_abbrev
-where gff3.gff_source = 'BurgessLin';
+-- ----------------------------------------------------------------------------
+-- §I. REDUNDANT — handled by refresh §I
+--     BurgessLin Zv9 insertion features.
+-- ----------------------------------------------------------------------------
+-- insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
+--   sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_gbrowse_track, sfclg_evidence_code)
+-- select gff3.gff_seqname, feature.feature_zdb_id, gff3.gff_start, gff3.gff_end, 'ZfinGbrowseZv9StartEndLoader', 'BurgessLin', 'Zv9', 'insertion', 'ZDB-TERM-170419-250'
+-- from gff3
+-- inner join feature on (gff3.gff_id || 'Tg') = feature.feature_abbrev
+-- where gff3.gff_source = 'BurgessLin';
 
-insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
-  sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_evidence_code)
-select gff_seqname, gff_name, gff_start, gff_end, 'ZfinGbrowseStartEndLoader', 'KnockdownReagentLoader', 'ZDB-TERM-170419-250'
-from gff3
-where gff_source = 'ZFIN_knockdown_reagent';
+-- ----------------------------------------------------------------------------
+-- §J. REDUNDANT — handled by refresh §J
+--     KnockdownReagentLoader (ZFIN_knockdown_reagent + GRCz12tu variant in
+--     refresh; only the non-GRCz12tu variant was here historically).
+-- ----------------------------------------------------------------------------
+-- insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
+--   sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_evidence_code)
+-- select gff_seqname, gff_name, gff_start, gff_end, 'ZfinGbrowseStartEndLoader', 'KnockdownReagentLoader', 'ZDB-TERM-170419-250'
+-- from gff3
+-- where gff_source = 'ZFIN_knockdown_reagent';
 
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_chromosome in ('AB','U','0')
- and sfclg_location_source = 'UCSCStartEndLoader';
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_chromosome in ('AB','U','0')
- and (
-  sfclg_location_source = 'ZfinGbrowseStartEndLoader'
-  OR sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader'
-);
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_chromosome in ('AB','U','0')
- and sfclg_location_source = 'EnsemblStartEndLoader';
+-- ----------------------------------------------------------------------------
+-- §K. REDUNDANT — handled by refresh §K
+--     Cleanup deletes for AB / U / 0 chromosomes across the source set.
+-- ----------------------------------------------------------------------------
+-- delete from sequence_feature_chromosome_location_generated
+--  where sfclg_chromosome in ('AB','U','0')
+--  and sfclg_location_source = 'UCSCStartEndLoader';
+--
+-- delete from sequence_feature_chromosome_location_generated
+--  where sfclg_chromosome in ('AB','U','0')
+--  and (
+--   sfclg_location_source = 'ZfinGbrowseStartEndLoader'
+--   OR sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader'
+-- );
+--
+-- delete from sequence_feature_chromosome_location_generated
+--  where sfclg_chromosome in ('AB','U','0')
+--  and sfclg_location_source = 'EnsemblStartEndLoader';
 
 commit work;
 -- commit or rollback is appended externally
 --rollback work;commit work;
-

--- a/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/updateSequenceFeatureChromosomeLocationPostgres.sql
+++ b/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/updateSequenceFeatureChromosomeLocationPostgres.sql
@@ -27,20 +27,22 @@ begin work;
 -- §A. REDUNDANT — handled by refresh §A
 --     Bulk DELETE of the five sources we'd otherwise own here.
 -- ----------------------------------------------------------------------------
--- delete from sequence_feature_chromosome_location_generated
---  where sfclg_location_source = 'ZfinGbrowseStartEndLoader';
---
--- delete from sequence_feature_chromosome_location_generated
---  where sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader';
---
--- delete from sequence_feature_chromosome_location_generated
---  where sfclg_location_source = 'DirectSubmission';
---
--- delete from sequence_feature_chromosome_location_generated
---  where sfclg_location_source = 'EnsemblStartEndLoader';
---
--- delete from sequence_feature_chromosome_location_generated
---  where sfclg_location_source = 'UCSCStartEndLoader';
+/*
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_location_source = 'ZfinGbrowseStartEndLoader';
+
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader';
+
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_location_source = 'DirectSubmission';
+
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_location_source = 'EnsemblStartEndLoader';
+
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_location_source = 'UCSCStartEndLoader';
+*/
 
 -- ----------------------------------------------------------------------------
 -- §B. ACTIVE — build tmp_gff_start_end / tmp_gene from gff3 + ensdar_mapping.
@@ -95,14 +97,14 @@ create index gene2_index on tmp_gene (accnum1)
 update tmp_gene
  set start = (select min(start)
       	      	      from tmp_gff_start_end
-		      where  gene = accnum1
+		      where  gene = accnum1 
 		      and chrom = chrom1);
 
 
 update tmp_gene
  set ender = (select max(ender)
       	      	      from tmp_gff_start_end
-		      where  gene = accnum1
+		      where  gene = accnum1 
 		      and chrom = chrom1);
 
 select count(*) from tmp_gene
@@ -119,71 +121,75 @@ select count(*) from tmp_gene
 --     writer. The pruneUcscLinks.sh post-step in regenChromosomeMart.sh removes
 --     any UCSC rows whose accession isn't in UCSC's danRer11 refGene track.
 -- ----------------------------------------------------------------------------
--- create temp table tmp_ucsc (geneId text,
--- 				chrom1 varchar(10),
--- 				accnum1 varchar(50),
--- 				source text,
--- 				fdb_db_pk_id int8)
--- ;
--- -- DISABLE UCSC record creation - comment out the insert
--- -- insert into tmp_ucsc (geneId, chrom1, accnum1, source, fdb_db_pk_id)
--- -- select ... (UCSC logic disabled)
--- ;
---
--- create temp table tmp_ucsc_all (counter int,
--- 			geneId text,
--- 			chrom1 varchar(10),
--- 			source text,
--- 			subsource text,
--- 			dblink_acc_num varchar(50));
--- insert into tmp_ucsc_all (counter, geneId, chrom1, source, subsource, dblink_acc_num)
--- select count(*) as counter, geneId, chrom1, source, source as subsource, dblink_acc_num
---   from db_link, tmp_ucsc
---  where geneId = dblink_linked_Recid
---  and dblink_Acc_num like 'NM%'
---  and exists (select 'x' from foreign_db_contains, foreign_db
---      	    	    	where fdbcont_fdb_db_id = fdb_db_pk_id
--- 			and fdb_db_name = 'RefSeq')
--- group by geneId, chrom1, source, dblink_acc_num
--- ;
--- insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
---        	    			       sfclg_chromosome,
--- 					       sfclg_acc_num,
--- 					       sfclg_location_source,
--- 					       sfclg_location_Subsource,
---                                        sfclg_evidence_code
--- 					   )
--- select distinct geneId, chrom1, dblink_acc_num, source, subsource, 'ZDB-TERM-170419-250'
---   from tmp_ucsc_all;
+/*
+create temp table tmp_ucsc (geneId text,
+				chrom1 varchar(10),
+				accnum1 varchar(50),
+				source text,
+				fdb_db_pk_id int8)
+;
+-- DISABLE UCSC record creation - comment out the insert
+-- insert into tmp_ucsc (geneId, chrom1, accnum1, source, fdb_db_pk_id)
+-- select ... (UCSC logic disabled)
+;
+
+create temp table tmp_ucsc_all (counter int,
+			geneId text,
+			chrom1 varchar(10),
+			source text,
+			subsource text,
+			dblink_acc_num varchar(50));
+insert into tmp_ucsc_all (counter, geneId, chrom1, source, subsource, dblink_acc_num)
+select count(*) as counter, geneId, chrom1, source, source as subsource, dblink_acc_num
+  from db_link, tmp_ucsc
+ where geneId = dblink_linked_Recid
+ and dblink_Acc_num like 'NM%'
+ and exists (select 'x' from foreign_db_contains, foreign_db
+     	    	    	where fdbcont_fdb_db_id = fdb_db_pk_id
+			and fdb_db_name = 'RefSeq')
+group by geneId, chrom1, source, dblink_acc_num
+;
+insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id, 
+       	    			       sfclg_chromosome,
+				       sfclg_acc_num,
+				       sfclg_location_source,
+				       sfclg_location_Subsource,
+                                       sfclg_evidence_code
+				   )
+select distinct geneId, chrom1, dblink_acc_num, source, subsource, 'ZDB-TERM-170419-250'
+  from tmp_ucsc_all;
+*/
 
 -- ----------------------------------------------------------------------------
 -- §D. REDUNDANT — handled by refresh §D
 --     EnsemblStartEndLoader main path: insert one row per gene/chromosome
 --     using start/ender from §B.
 -- ----------------------------------------------------------------------------
--- insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
---        	    			       sfclg_chromosome,
--- 					       sfclg_start,
--- 					       sfclg_end,
--- 					       sfclg_acc_num,
--- 					       sfclg_location_source,
--- 					       sfclg_fdb_db_id,sfclg_evidence_code)
--- select distinct dblink_linked_recid,
---        		chrom1,
--- 		start,
--- 		ender,
--- 		accnum1,
--- 		'EnsemblStartEndLoader',
--- 		fdb_db_pk_id, 'ZDB-TERM-170419-250'
---   from db_link, tmp_gene, foreign_db, foreign_db_contains
---   where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
---   and dblink_acc_num = accnum1
---   and fdb_db_pk_id = fdbcont_fdb_db_id
---  and start is not null
---  and ender is not null
---     -- don't include fdb_db_display_name = 'ExpressionAtlas'
---  and fdb_db_pk_id != 91
--- ;
+/*
+insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
+       	    			       sfclg_chromosome,
+				       sfclg_start,
+				       sfclg_end,
+				       sfclg_acc_num,
+				       sfclg_location_source,
+				       sfclg_fdb_db_id,sfclg_evidence_code)
+select distinct dblink_linked_recid,
+       		chrom1,
+		start,
+		ender,
+		accnum1,
+		'EnsemblStartEndLoader',
+		fdb_db_pk_id, 'ZDB-TERM-170419-250'
+  from db_link, tmp_gene, foreign_db, foreign_db_contains
+  where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
+  and dblink_acc_num = accnum1
+  and fdb_db_pk_id = fdbcont_fdb_db_id
+ and start is not null
+ and ender is not null
+    -- don't include fdb_db_display_name = 'ExpressionAtlas'
+ and fdb_db_pk_id != 91
+;
+*/
 
 -- ----------------------------------------------------------------------------
 -- §E. ACTIVE — ENSDARG-fallback EnsemblStartEndLoader rows.
@@ -243,39 +249,43 @@ select distinct dblink_linked_recid,
 -- §F. REDUNDANT — handled by refresh §F
 --     ZfinGbrowseStartEndLoader from tmp_gene joined with zfin_ensembl_gene.
 -- ----------------------------------------------------------------------------
--- insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
---        	    			       sfclg_chromosome,
--- 					       sfclg_start,
--- 					       sfclg_end,
--- 					       sfclg_acc_num,
--- 					       sfclg_location_source,
--- 					       sfclg_fdb_db_id,sfclg_evidence_code)
--- select dblink_linked_recid,
---        		chrom1,
--- 		start,
--- 		ender,
--- 		accnum1,
--- 		'ZfinGbrowseStartEndLoader',
--- 		fdb_db_pk_id, 'ZDB-TERM-170419-250'
---   from db_link, tmp_gene, foreign_db, foreign_db_contains
---   where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
---   and dblink_acc_num = accnum1
---   and fdb_db_pk_id = fdbcont_fdb_db_id
---  and start is not null
---  and ender is not null
---  and exists (select 'x' from zfin_ensembl_gene where zeg_gene_zdb_id = dblink_linked_recid)
---  group by dblink_linked_recid, chrom1, start, ender, accnum1, fdb_db_pk_id
--- ;
+/*
+insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
+       	    			       sfclg_chromosome,
+				       sfclg_start,
+				       sfclg_end,
+				       sfclg_acc_num,
+				       sfclg_location_source,
+				       sfclg_fdb_db_id,sfclg_evidence_code)
+select dblink_linked_recid,
+       		chrom1,
+		start,
+		ender,
+		accnum1,
+		'ZfinGbrowseStartEndLoader',
+		fdb_db_pk_id, 'ZDB-TERM-170419-250'
+  from db_link, tmp_gene, foreign_db, foreign_db_contains
+  where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
+  and dblink_acc_num = accnum1
+  and fdb_db_pk_id = fdbcont_fdb_db_id
+ and start is not null
+ and ender is not null
+ and exists (select 'x' from zfin_ensembl_gene where zeg_gene_zdb_id = dblink_linked_recid)
+ group by dblink_linked_recid, chrom1, start, ender, accnum1, fdb_db_pk_id
+;
+*/
 
 -- ----------------------------------------------------------------------------
 -- §G. REDUNDANT — handled by refresh §G
 --     DirectSubmission re-import from sequence_feature_chromosome_location.
 -- ----------------------------------------------------------------------------
--- insert into sequence_feature_chromosome_location_generated (
---   sfclg_chromosome, sfclg_data_zdb_id, sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_pub_zdb_id, sfclg_evidence_code)
--- select sfcl_chromosome, sfcl_feature_zdb_id, sfcl_start_position, sfcl_end_position, 'DirectSubmission', '', sfcl_assembly, recattrib_source_zdb_id, sfcl_evidence_code
---   from sequence_feature_chromosome_location
---   left outer join record_attribution on recattrib_data_zdb_id = sfcl_zdb_id;
+/*
+insert into sequence_feature_chromosome_location_generated (
+  sfclg_chromosome, sfclg_data_zdb_id, sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_pub_zdb_id, sfclg_evidence_code)
+select sfcl_chromosome, sfcl_feature_zdb_id, sfcl_start_position, sfcl_end_position, 'DirectSubmission', '', sfcl_assembly, recattrib_source_zdb_id, sfcl_evidence_code
+  from sequence_feature_chromosome_location
+  left outer join record_attribution on recattrib_data_zdb_id = sfcl_zdb_id;
+*/
 
 -- ----------------------------------------------------------------------------
 -- §H. ACTIVE — zmp gbrowse-track tag.
@@ -292,42 +302,48 @@ where sfclg_pub_zdb_id in ('ZDB-PUB-130425-4', 'ZDB-PUB-250905-18');
 -- §I. REDUNDANT — handled by refresh §I
 --     BurgessLin Zv9 insertion features.
 -- ----------------------------------------------------------------------------
--- insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
---   sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_gbrowse_track, sfclg_evidence_code)
--- select gff3.gff_seqname, feature.feature_zdb_id, gff3.gff_start, gff3.gff_end, 'ZfinGbrowseZv9StartEndLoader', 'BurgessLin', 'Zv9', 'insertion', 'ZDB-TERM-170419-250'
--- from gff3
--- inner join feature on (gff3.gff_id || 'Tg') = feature.feature_abbrev
--- where gff3.gff_source = 'BurgessLin';
+/*
+insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
+  sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_gbrowse_track, sfclg_evidence_code)
+select gff3.gff_seqname, feature.feature_zdb_id, gff3.gff_start, gff3.gff_end, 'ZfinGbrowseZv9StartEndLoader', 'BurgessLin', 'Zv9', 'insertion', 'ZDB-TERM-170419-250'
+from gff3
+inner join feature on (gff3.gff_id || 'Tg') = feature.feature_abbrev
+where gff3.gff_source = 'BurgessLin';
+*/
 
 -- ----------------------------------------------------------------------------
 -- §J. REDUNDANT — handled by refresh §J
 --     KnockdownReagentLoader (ZFIN_knockdown_reagent + GRCz12tu variant in
 --     refresh; only the non-GRCz12tu variant was here historically).
 -- ----------------------------------------------------------------------------
--- insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
---   sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_evidence_code)
--- select gff_seqname, gff_name, gff_start, gff_end, 'ZfinGbrowseStartEndLoader', 'KnockdownReagentLoader', 'ZDB-TERM-170419-250'
--- from gff3
--- where gff_source = 'ZFIN_knockdown_reagent';
+/*
+insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
+  sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_evidence_code)
+select gff_seqname, gff_name, gff_start, gff_end, 'ZfinGbrowseStartEndLoader', 'KnockdownReagentLoader', 'ZDB-TERM-170419-250'
+from gff3
+where gff_source = 'ZFIN_knockdown_reagent';
+*/
 
 -- ----------------------------------------------------------------------------
 -- §K. REDUNDANT — handled by refresh §K
 --     Cleanup deletes for AB / U / 0 chromosomes across the source set.
 -- ----------------------------------------------------------------------------
--- delete from sequence_feature_chromosome_location_generated
---  where sfclg_chromosome in ('AB','U','0')
---  and sfclg_location_source = 'UCSCStartEndLoader';
---
--- delete from sequence_feature_chromosome_location_generated
---  where sfclg_chromosome in ('AB','U','0')
---  and (
---   sfclg_location_source = 'ZfinGbrowseStartEndLoader'
---   OR sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader'
--- );
---
--- delete from sequence_feature_chromosome_location_generated
---  where sfclg_chromosome in ('AB','U','0')
---  and sfclg_location_source = 'EnsemblStartEndLoader';
+/*
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_chromosome in ('AB','U','0')
+ and sfclg_location_source = 'UCSCStartEndLoader';
+
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_chromosome in ('AB','U','0')
+ and (
+  sfclg_location_source = 'ZfinGbrowseStartEndLoader'
+  OR sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader'
+);
+
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_chromosome in ('AB','U','0')
+ and sfclg_location_source = 'EnsemblStartEndLoader';
+*/
 
 commit work;
 -- commit or rollback is appended externally

--- a/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/updateSequenceFeatureChromosomeLocationPostgres.sql
+++ b/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/updateSequenceFeatureChromosomeLocationPostgres.sql
@@ -28,20 +28,20 @@ begin work;
 --     Bulk DELETE of the five sources we'd otherwise own here.
 -- ----------------------------------------------------------------------------
 /*
-delete from sequence_feature_chromosome_location_generated
- where sfclg_location_source = 'ZfinGbrowseStartEndLoader';
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader';
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_location_source = 'DirectSubmission';
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_location_source = 'EnsemblStartEndLoader';
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_location_source = 'UCSCStartEndLoader';
+ delete from sequence_feature_chromosome_location_generated
+  where sfclg_location_source = 'ZfinGbrowseStartEndLoader';
+ 
+ delete from sequence_feature_chromosome_location_generated
+  where sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader';
+ 
+ delete from sequence_feature_chromosome_location_generated
+  where sfclg_location_source = 'DirectSubmission';
+ 
+ delete from sequence_feature_chromosome_location_generated
+  where sfclg_location_source = 'EnsemblStartEndLoader';
+ 
+ delete from sequence_feature_chromosome_location_generated
+  where sfclg_location_source = 'UCSCStartEndLoader';
 */
 
 -- ----------------------------------------------------------------------------
@@ -122,42 +122,42 @@ select count(*) from tmp_gene
 --     any UCSC rows whose accession isn't in UCSC's danRer11 refGene track.
 -- ----------------------------------------------------------------------------
 /*
-create temp table tmp_ucsc (geneId text,
-				chrom1 varchar(10),
-				accnum1 varchar(50),
-				source text,
-				fdb_db_pk_id int8)
-;
--- DISABLE UCSC record creation - comment out the insert
--- insert into tmp_ucsc (geneId, chrom1, accnum1, source, fdb_db_pk_id)
--- select ... (UCSC logic disabled)
-;
-
-create temp table tmp_ucsc_all (counter int,
-			geneId text,
-			chrom1 varchar(10),
-			source text,
-			subsource text,
-			dblink_acc_num varchar(50));
-insert into tmp_ucsc_all (counter, geneId, chrom1, source, subsource, dblink_acc_num)
-select count(*) as counter, geneId, chrom1, source, source as subsource, dblink_acc_num
-  from db_link, tmp_ucsc
- where geneId = dblink_linked_Recid
- and dblink_Acc_num like 'NM%'
- and exists (select 'x' from foreign_db_contains, foreign_db
-     	    	    	where fdbcont_fdb_db_id = fdb_db_pk_id
-			and fdb_db_name = 'RefSeq')
-group by geneId, chrom1, source, dblink_acc_num
-;
-insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id, 
-       	    			       sfclg_chromosome,
-				       sfclg_acc_num,
-				       sfclg_location_source,
-				       sfclg_location_Subsource,
-                                       sfclg_evidence_code
-				   )
-select distinct geneId, chrom1, dblink_acc_num, source, subsource, 'ZDB-TERM-170419-250'
-  from tmp_ucsc_all;
+ create temp table tmp_ucsc (geneId text,
+ 				chrom1 varchar(10),
+ 				accnum1 varchar(50),
+ 				source text,
+ 				fdb_db_pk_id int8)
+ ;
+ -- DISABLE UCSC record creation - comment out the insert
+ -- insert into tmp_ucsc (geneId, chrom1, accnum1, source, fdb_db_pk_id)
+ -- select ... (UCSC logic disabled)
+ ;
+ 
+ create temp table tmp_ucsc_all (counter int,
+ 			geneId text,
+ 			chrom1 varchar(10),
+ 			source text,
+ 			subsource text,
+ 			dblink_acc_num varchar(50));
+ insert into tmp_ucsc_all (counter, geneId, chrom1, source, subsource, dblink_acc_num)
+ select count(*) as counter, geneId, chrom1, source, source as subsource, dblink_acc_num
+   from db_link, tmp_ucsc
+  where geneId = dblink_linked_Recid
+  and dblink_Acc_num like 'NM%'
+  and exists (select 'x' from foreign_db_contains, foreign_db
+      	    	    	where fdbcont_fdb_db_id = fdb_db_pk_id
+ 			and fdb_db_name = 'RefSeq')
+ group by geneId, chrom1, source, dblink_acc_num
+ ;
+ insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id, 
+        	    			       sfclg_chromosome,
+ 				       sfclg_acc_num,
+ 				       sfclg_location_source,
+ 				       sfclg_location_Subsource,
+                                        sfclg_evidence_code
+ 				   )
+ select distinct geneId, chrom1, dblink_acc_num, source, subsource, 'ZDB-TERM-170419-250'
+   from tmp_ucsc_all;
 */
 
 -- ----------------------------------------------------------------------------
@@ -166,29 +166,29 @@ select distinct geneId, chrom1, dblink_acc_num, source, subsource, 'ZDB-TERM-170
 --     using start/ender from §B.
 -- ----------------------------------------------------------------------------
 /*
-insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
-       	    			       sfclg_chromosome,
-				       sfclg_start,
-				       sfclg_end,
-				       sfclg_acc_num,
-				       sfclg_location_source,
-				       sfclg_fdb_db_id,sfclg_evidence_code)
-select distinct dblink_linked_recid,
-       		chrom1,
-		start,
-		ender,
-		accnum1,
-		'EnsemblStartEndLoader',
-		fdb_db_pk_id, 'ZDB-TERM-170419-250'
-  from db_link, tmp_gene, foreign_db, foreign_db_contains
-  where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
-  and dblink_acc_num = accnum1
-  and fdb_db_pk_id = fdbcont_fdb_db_id
- and start is not null
- and ender is not null
-    -- don't include fdb_db_display_name = 'ExpressionAtlas'
- and fdb_db_pk_id != 91
-;
+ insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
+        	    			       sfclg_chromosome,
+ 				       sfclg_start,
+ 				       sfclg_end,
+ 				       sfclg_acc_num,
+ 				       sfclg_location_source,
+ 				       sfclg_fdb_db_id,sfclg_evidence_code)
+ select distinct dblink_linked_recid,
+        		chrom1,
+ 		start,
+ 		ender,
+ 		accnum1,
+ 		'EnsemblStartEndLoader',
+ 		fdb_db_pk_id, 'ZDB-TERM-170419-250'
+   from db_link, tmp_gene, foreign_db, foreign_db_contains
+   where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
+   and dblink_acc_num = accnum1
+   and fdb_db_pk_id = fdbcont_fdb_db_id
+  and start is not null
+  and ender is not null
+     -- don't include fdb_db_display_name = 'ExpressionAtlas'
+  and fdb_db_pk_id != 91
+ ;
 */
 
 -- ----------------------------------------------------------------------------
@@ -250,29 +250,29 @@ select distinct dblink_linked_recid,
 --     ZfinGbrowseStartEndLoader from tmp_gene joined with zfin_ensembl_gene.
 -- ----------------------------------------------------------------------------
 /*
-insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
-       	    			       sfclg_chromosome,
-				       sfclg_start,
-				       sfclg_end,
-				       sfclg_acc_num,
-				       sfclg_location_source,
-				       sfclg_fdb_db_id,sfclg_evidence_code)
-select dblink_linked_recid,
-       		chrom1,
-		start,
-		ender,
-		accnum1,
-		'ZfinGbrowseStartEndLoader',
-		fdb_db_pk_id, 'ZDB-TERM-170419-250'
-  from db_link, tmp_gene, foreign_db, foreign_db_contains
-  where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
-  and dblink_acc_num = accnum1
-  and fdb_db_pk_id = fdbcont_fdb_db_id
- and start is not null
- and ender is not null
- and exists (select 'x' from zfin_ensembl_gene where zeg_gene_zdb_id = dblink_linked_recid)
- group by dblink_linked_recid, chrom1, start, ender, accnum1, fdb_db_pk_id
-;
+ insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
+        	    			       sfclg_chromosome,
+ 				       sfclg_start,
+ 				       sfclg_end,
+ 				       sfclg_acc_num,
+ 				       sfclg_location_source,
+ 				       sfclg_fdb_db_id,sfclg_evidence_code)
+ select dblink_linked_recid,
+        		chrom1,
+ 		start,
+ 		ender,
+ 		accnum1,
+ 		'ZfinGbrowseStartEndLoader',
+ 		fdb_db_pk_id, 'ZDB-TERM-170419-250'
+   from db_link, tmp_gene, foreign_db, foreign_db_contains
+   where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
+   and dblink_acc_num = accnum1
+   and fdb_db_pk_id = fdbcont_fdb_db_id
+  and start is not null
+  and ender is not null
+  and exists (select 'x' from zfin_ensembl_gene where zeg_gene_zdb_id = dblink_linked_recid)
+  group by dblink_linked_recid, chrom1, start, ender, accnum1, fdb_db_pk_id
+ ;
 */
 
 -- ----------------------------------------------------------------------------
@@ -280,11 +280,11 @@ select dblink_linked_recid,
 --     DirectSubmission re-import from sequence_feature_chromosome_location.
 -- ----------------------------------------------------------------------------
 /*
-insert into sequence_feature_chromosome_location_generated (
-  sfclg_chromosome, sfclg_data_zdb_id, sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_pub_zdb_id, sfclg_evidence_code)
-select sfcl_chromosome, sfcl_feature_zdb_id, sfcl_start_position, sfcl_end_position, 'DirectSubmission', '', sfcl_assembly, recattrib_source_zdb_id, sfcl_evidence_code
-  from sequence_feature_chromosome_location
-  left outer join record_attribution on recattrib_data_zdb_id = sfcl_zdb_id;
+ insert into sequence_feature_chromosome_location_generated (
+   sfclg_chromosome, sfclg_data_zdb_id, sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_pub_zdb_id, sfclg_evidence_code)
+ select sfcl_chromosome, sfcl_feature_zdb_id, sfcl_start_position, sfcl_end_position, 'DirectSubmission', '', sfcl_assembly, recattrib_source_zdb_id, sfcl_evidence_code
+   from sequence_feature_chromosome_location
+   left outer join record_attribution on recattrib_data_zdb_id = sfcl_zdb_id;
 */
 
 -- ----------------------------------------------------------------------------
@@ -303,12 +303,12 @@ where sfclg_pub_zdb_id in ('ZDB-PUB-130425-4', 'ZDB-PUB-250905-18');
 --     BurgessLin Zv9 insertion features.
 -- ----------------------------------------------------------------------------
 /*
-insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
-  sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_gbrowse_track, sfclg_evidence_code)
-select gff3.gff_seqname, feature.feature_zdb_id, gff3.gff_start, gff3.gff_end, 'ZfinGbrowseZv9StartEndLoader', 'BurgessLin', 'Zv9', 'insertion', 'ZDB-TERM-170419-250'
-from gff3
-inner join feature on (gff3.gff_id || 'Tg') = feature.feature_abbrev
-where gff3.gff_source = 'BurgessLin';
+ insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
+   sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_gbrowse_track, sfclg_evidence_code)
+ select gff3.gff_seqname, feature.feature_zdb_id, gff3.gff_start, gff3.gff_end, 'ZfinGbrowseZv9StartEndLoader', 'BurgessLin', 'Zv9', 'insertion', 'ZDB-TERM-170419-250'
+ from gff3
+ inner join feature on (gff3.gff_id || 'Tg') = feature.feature_abbrev
+ where gff3.gff_source = 'BurgessLin';
 */
 
 -- ----------------------------------------------------------------------------
@@ -317,11 +317,11 @@ where gff3.gff_source = 'BurgessLin';
 --     refresh; only the non-GRCz12tu variant was here historically).
 -- ----------------------------------------------------------------------------
 /*
-insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
-  sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_evidence_code)
-select gff_seqname, gff_name, gff_start, gff_end, 'ZfinGbrowseStartEndLoader', 'KnockdownReagentLoader', 'ZDB-TERM-170419-250'
-from gff3
-where gff_source = 'ZFIN_knockdown_reagent';
+ insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
+   sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_evidence_code)
+ select gff_seqname, gff_name, gff_start, gff_end, 'ZfinGbrowseStartEndLoader', 'KnockdownReagentLoader', 'ZDB-TERM-170419-250'
+ from gff3
+ where gff_source = 'ZFIN_knockdown_reagent';
 */
 
 -- ----------------------------------------------------------------------------
@@ -329,20 +329,20 @@ where gff_source = 'ZFIN_knockdown_reagent';
 --     Cleanup deletes for AB / U / 0 chromosomes across the source set.
 -- ----------------------------------------------------------------------------
 /*
-delete from sequence_feature_chromosome_location_generated
- where sfclg_chromosome in ('AB','U','0')
- and sfclg_location_source = 'UCSCStartEndLoader';
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_chromosome in ('AB','U','0')
- and (
-  sfclg_location_source = 'ZfinGbrowseStartEndLoader'
-  OR sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader'
-);
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_chromosome in ('AB','U','0')
- and sfclg_location_source = 'EnsemblStartEndLoader';
+ delete from sequence_feature_chromosome_location_generated
+  where sfclg_chromosome in ('AB','U','0')
+  and sfclg_location_source = 'UCSCStartEndLoader';
+ 
+ delete from sequence_feature_chromosome_location_generated
+  where sfclg_chromosome in ('AB','U','0')
+  and (
+   sfclg_location_source = 'ZfinGbrowseStartEndLoader'
+   OR sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader'
+ );
+ 
+ delete from sequence_feature_chromosome_location_generated
+  where sfclg_chromosome in ('AB','U','0')
+  and sfclg_location_source = 'EnsemblStartEndLoader';
 */
 
 commit work;

--- a/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/updateSequenceFeatureChromosomeLocationPostgres.sql
+++ b/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/updateSequenceFeatureChromosomeLocationPostgres.sql
@@ -28,20 +28,20 @@ begin work;
 --     Bulk DELETE of the five sources we'd otherwise own here.
 -- ----------------------------------------------------------------------------
 /*
- delete from sequence_feature_chromosome_location_generated
-  where sfclg_location_source = 'ZfinGbrowseStartEndLoader';
- 
- delete from sequence_feature_chromosome_location_generated
-  where sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader';
- 
- delete from sequence_feature_chromosome_location_generated
-  where sfclg_location_source = 'DirectSubmission';
- 
- delete from sequence_feature_chromosome_location_generated
-  where sfclg_location_source = 'EnsemblStartEndLoader';
- 
- delete from sequence_feature_chromosome_location_generated
-  where sfclg_location_source = 'UCSCStartEndLoader';
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_location_source = 'ZfinGbrowseStartEndLoader';
+
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader';
+
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_location_source = 'DirectSubmission';
+
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_location_source = 'EnsemblStartEndLoader';
+
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_location_source = 'UCSCStartEndLoader';
 */
 
 -- ----------------------------------------------------------------------------
@@ -122,42 +122,42 @@ select count(*) from tmp_gene
 --     any UCSC rows whose accession isn't in UCSC's danRer11 refGene track.
 -- ----------------------------------------------------------------------------
 /*
- create temp table tmp_ucsc (geneId text,
- 				chrom1 varchar(10),
- 				accnum1 varchar(50),
- 				source text,
- 				fdb_db_pk_id int8)
- ;
- -- DISABLE UCSC record creation - comment out the insert
- -- insert into tmp_ucsc (geneId, chrom1, accnum1, source, fdb_db_pk_id)
- -- select ... (UCSC logic disabled)
- ;
- 
- create temp table tmp_ucsc_all (counter int,
- 			geneId text,
- 			chrom1 varchar(10),
- 			source text,
- 			subsource text,
- 			dblink_acc_num varchar(50));
- insert into tmp_ucsc_all (counter, geneId, chrom1, source, subsource, dblink_acc_num)
- select count(*) as counter, geneId, chrom1, source, source as subsource, dblink_acc_num
-   from db_link, tmp_ucsc
-  where geneId = dblink_linked_Recid
-  and dblink_Acc_num like 'NM%'
-  and exists (select 'x' from foreign_db_contains, foreign_db
-      	    	    	where fdbcont_fdb_db_id = fdb_db_pk_id
- 			and fdb_db_name = 'RefSeq')
- group by geneId, chrom1, source, dblink_acc_num
- ;
- insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id, 
-        	    			       sfclg_chromosome,
- 				       sfclg_acc_num,
- 				       sfclg_location_source,
- 				       sfclg_location_Subsource,
-                                        sfclg_evidence_code
- 				   )
- select distinct geneId, chrom1, dblink_acc_num, source, subsource, 'ZDB-TERM-170419-250'
-   from tmp_ucsc_all;
+create temp table tmp_ucsc (geneId text,
+				chrom1 varchar(10),
+				accnum1 varchar(50),
+				source text,
+				fdb_db_pk_id int8)
+;
+-- DISABLE UCSC record creation - comment out the insert
+-- insert into tmp_ucsc (geneId, chrom1, accnum1, source, fdb_db_pk_id)
+-- select ... (UCSC logic disabled)
+;
+
+create temp table tmp_ucsc_all (counter int,
+			geneId text,
+			chrom1 varchar(10),
+			source text,
+			subsource text,
+			dblink_acc_num varchar(50));
+insert into tmp_ucsc_all (counter, geneId, chrom1, source, subsource, dblink_acc_num)
+select count(*) as counter, geneId, chrom1, source, source as subsource, dblink_acc_num
+  from db_link, tmp_ucsc
+ where geneId = dblink_linked_Recid
+ and dblink_Acc_num like 'NM%'
+ and exists (select 'x' from foreign_db_contains, foreign_db
+     	    	    	where fdbcont_fdb_db_id = fdb_db_pk_id
+			and fdb_db_name = 'RefSeq')
+group by geneId, chrom1, source, dblink_acc_num
+;
+insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id, 
+       	    			       sfclg_chromosome,
+				       sfclg_acc_num,
+				       sfclg_location_source,
+				       sfclg_location_Subsource,
+                                       sfclg_evidence_code
+				   )
+select distinct geneId, chrom1, dblink_acc_num, source, subsource, 'ZDB-TERM-170419-250'
+  from tmp_ucsc_all;
 */
 
 -- ----------------------------------------------------------------------------
@@ -166,29 +166,29 @@ select count(*) from tmp_gene
 --     using start/ender from §B.
 -- ----------------------------------------------------------------------------
 /*
- insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
-        	    			       sfclg_chromosome,
- 				       sfclg_start,
- 				       sfclg_end,
- 				       sfclg_acc_num,
- 				       sfclg_location_source,
- 				       sfclg_fdb_db_id,sfclg_evidence_code)
- select distinct dblink_linked_recid,
-        		chrom1,
- 		start,
- 		ender,
- 		accnum1,
- 		'EnsemblStartEndLoader',
- 		fdb_db_pk_id, 'ZDB-TERM-170419-250'
-   from db_link, tmp_gene, foreign_db, foreign_db_contains
-   where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
-   and dblink_acc_num = accnum1
-   and fdb_db_pk_id = fdbcont_fdb_db_id
-  and start is not null
-  and ender is not null
-     -- don't include fdb_db_display_name = 'ExpressionAtlas'
-  and fdb_db_pk_id != 91
- ;
+insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
+       	    			       sfclg_chromosome,
+				       sfclg_start,
+				       sfclg_end,
+				       sfclg_acc_num,
+				       sfclg_location_source,
+				       sfclg_fdb_db_id,sfclg_evidence_code)
+select distinct dblink_linked_recid,
+       		chrom1,
+		start,
+		ender,
+		accnum1,
+		'EnsemblStartEndLoader',
+		fdb_db_pk_id, 'ZDB-TERM-170419-250'
+  from db_link, tmp_gene, foreign_db, foreign_db_contains
+  where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
+  and dblink_acc_num = accnum1
+  and fdb_db_pk_id = fdbcont_fdb_db_id
+ and start is not null
+ and ender is not null
+    -- don't include fdb_db_display_name = 'ExpressionAtlas'
+ and fdb_db_pk_id != 91
+;
 */
 
 -- ----------------------------------------------------------------------------
@@ -250,29 +250,29 @@ select distinct dblink_linked_recid,
 --     ZfinGbrowseStartEndLoader from tmp_gene joined with zfin_ensembl_gene.
 -- ----------------------------------------------------------------------------
 /*
- insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
-        	    			       sfclg_chromosome,
- 				       sfclg_start,
- 				       sfclg_end,
- 				       sfclg_acc_num,
- 				       sfclg_location_source,
- 				       sfclg_fdb_db_id,sfclg_evidence_code)
- select dblink_linked_recid,
-        		chrom1,
- 		start,
- 		ender,
- 		accnum1,
- 		'ZfinGbrowseStartEndLoader',
- 		fdb_db_pk_id, 'ZDB-TERM-170419-250'
-   from db_link, tmp_gene, foreign_db, foreign_db_contains
-   where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
-   and dblink_acc_num = accnum1
-   and fdb_db_pk_id = fdbcont_fdb_db_id
-  and start is not null
-  and ender is not null
-  and exists (select 'x' from zfin_ensembl_gene where zeg_gene_zdb_id = dblink_linked_recid)
-  group by dblink_linked_recid, chrom1, start, ender, accnum1, fdb_db_pk_id
- ;
+insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
+       	    			       sfclg_chromosome,
+				       sfclg_start,
+				       sfclg_end,
+				       sfclg_acc_num,
+				       sfclg_location_source,
+				       sfclg_fdb_db_id,sfclg_evidence_code)
+select dblink_linked_recid,
+       		chrom1,
+		start,
+		ender,
+		accnum1,
+		'ZfinGbrowseStartEndLoader',
+		fdb_db_pk_id, 'ZDB-TERM-170419-250'
+  from db_link, tmp_gene, foreign_db, foreign_db_contains
+  where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
+  and dblink_acc_num = accnum1
+  and fdb_db_pk_id = fdbcont_fdb_db_id
+ and start is not null
+ and ender is not null
+ and exists (select 'x' from zfin_ensembl_gene where zeg_gene_zdb_id = dblink_linked_recid)
+ group by dblink_linked_recid, chrom1, start, ender, accnum1, fdb_db_pk_id
+;
 */
 
 -- ----------------------------------------------------------------------------
@@ -280,11 +280,11 @@ select distinct dblink_linked_recid,
 --     DirectSubmission re-import from sequence_feature_chromosome_location.
 -- ----------------------------------------------------------------------------
 /*
- insert into sequence_feature_chromosome_location_generated (
-   sfclg_chromosome, sfclg_data_zdb_id, sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_pub_zdb_id, sfclg_evidence_code)
- select sfcl_chromosome, sfcl_feature_zdb_id, sfcl_start_position, sfcl_end_position, 'DirectSubmission', '', sfcl_assembly, recattrib_source_zdb_id, sfcl_evidence_code
-   from sequence_feature_chromosome_location
-   left outer join record_attribution on recattrib_data_zdb_id = sfcl_zdb_id;
+insert into sequence_feature_chromosome_location_generated (
+  sfclg_chromosome, sfclg_data_zdb_id, sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_pub_zdb_id, sfclg_evidence_code)
+select sfcl_chromosome, sfcl_feature_zdb_id, sfcl_start_position, sfcl_end_position, 'DirectSubmission', '', sfcl_assembly, recattrib_source_zdb_id, sfcl_evidence_code
+  from sequence_feature_chromosome_location
+  left outer join record_attribution on recattrib_data_zdb_id = sfcl_zdb_id;
 */
 
 -- ----------------------------------------------------------------------------
@@ -303,12 +303,12 @@ where sfclg_pub_zdb_id in ('ZDB-PUB-130425-4', 'ZDB-PUB-250905-18');
 --     BurgessLin Zv9 insertion features.
 -- ----------------------------------------------------------------------------
 /*
- insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
-   sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_gbrowse_track, sfclg_evidence_code)
- select gff3.gff_seqname, feature.feature_zdb_id, gff3.gff_start, gff3.gff_end, 'ZfinGbrowseZv9StartEndLoader', 'BurgessLin', 'Zv9', 'insertion', 'ZDB-TERM-170419-250'
- from gff3
- inner join feature on (gff3.gff_id || 'Tg') = feature.feature_abbrev
- where gff3.gff_source = 'BurgessLin';
+insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
+  sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_gbrowse_track, sfclg_evidence_code)
+select gff3.gff_seqname, feature.feature_zdb_id, gff3.gff_start, gff3.gff_end, 'ZfinGbrowseZv9StartEndLoader', 'BurgessLin', 'Zv9', 'insertion', 'ZDB-TERM-170419-250'
+from gff3
+inner join feature on (gff3.gff_id || 'Tg') = feature.feature_abbrev
+where gff3.gff_source = 'BurgessLin';
 */
 
 -- ----------------------------------------------------------------------------
@@ -317,11 +317,11 @@ where sfclg_pub_zdb_id in ('ZDB-PUB-130425-4', 'ZDB-PUB-250905-18');
 --     refresh; only the non-GRCz12tu variant was here historically).
 -- ----------------------------------------------------------------------------
 /*
- insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
-   sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_evidence_code)
- select gff_seqname, gff_name, gff_start, gff_end, 'ZfinGbrowseStartEndLoader', 'KnockdownReagentLoader', 'ZDB-TERM-170419-250'
- from gff3
- where gff_source = 'ZFIN_knockdown_reagent';
+insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
+  sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_evidence_code)
+select gff_seqname, gff_name, gff_start, gff_end, 'ZfinGbrowseStartEndLoader', 'KnockdownReagentLoader', 'ZDB-TERM-170419-250'
+from gff3
+where gff_source = 'ZFIN_knockdown_reagent';
 */
 
 -- ----------------------------------------------------------------------------
@@ -329,20 +329,20 @@ where sfclg_pub_zdb_id in ('ZDB-PUB-130425-4', 'ZDB-PUB-250905-18');
 --     Cleanup deletes for AB / U / 0 chromosomes across the source set.
 -- ----------------------------------------------------------------------------
 /*
- delete from sequence_feature_chromosome_location_generated
-  where sfclg_chromosome in ('AB','U','0')
-  and sfclg_location_source = 'UCSCStartEndLoader';
- 
- delete from sequence_feature_chromosome_location_generated
-  where sfclg_chromosome in ('AB','U','0')
-  and (
-   sfclg_location_source = 'ZfinGbrowseStartEndLoader'
-   OR sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader'
- );
- 
- delete from sequence_feature_chromosome_location_generated
-  where sfclg_chromosome in ('AB','U','0')
-  and sfclg_location_source = 'EnsemblStartEndLoader';
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_chromosome in ('AB','U','0')
+ and sfclg_location_source = 'UCSCStartEndLoader';
+
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_chromosome in ('AB','U','0')
+ and (
+  sfclg_location_source = 'ZfinGbrowseStartEndLoader'
+  OR sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader'
+);
+
+delete from sequence_feature_chromosome_location_generated
+ where sfclg_chromosome in ('AB','U','0')
+ and sfclg_location_source = 'EnsemblStartEndLoader';
 */
 
 commit work;

--- a/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/updateSequenceFeatureChromosomeLocationPostgres.sql
+++ b/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/updateSequenceFeatureChromosomeLocationPostgres.sql
@@ -24,25 +24,9 @@
 begin work;
 
 -- ----------------------------------------------------------------------------
--- §A. REDUNDANT — handled by refresh §A
+-- §A. REDUNDANCY REMOVED — handled by Refresh-GBrowse-Tracks_d §A
 --     Bulk DELETE of the five sources we'd otherwise own here.
 -- ----------------------------------------------------------------------------
-/*
-delete from sequence_feature_chromosome_location_generated
- where sfclg_location_source = 'ZfinGbrowseStartEndLoader';
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader';
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_location_source = 'DirectSubmission';
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_location_source = 'EnsemblStartEndLoader';
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_location_source = 'UCSCStartEndLoader';
-*/
 
 -- ----------------------------------------------------------------------------
 -- §B. ACTIVE — build tmp_gff_start_end / tmp_gene from gff3 + ensdar_mapping.
@@ -114,82 +98,19 @@ select count(*) from tmp_gene
  where ender is null;
 
 -- ----------------------------------------------------------------------------
--- §C. REDUNDANT — handled by refresh §C
+-- §C. REDUNDANCY REMOVED — handled by Refresh-GBrowse-Tracks_d §C
 --     UCSC: build tmp_ucsc / tmp_ucsc_all and INSERT 'UCSCStartEndLoader' rows.
 --     The UCSC INSERT here was already disabled before this branch
 --     (commit 1c246db2, ZFIN-9989) because the refresh path was the canonical
 --     writer. The pruneUcscLinks.sh post-step in regenChromosomeMart.sh removes
 --     any UCSC rows whose accession isn't in UCSC's danRer11 refGene track.
 -- ----------------------------------------------------------------------------
-/*
-create temp table tmp_ucsc (geneId text,
-				chrom1 varchar(10),
-				accnum1 varchar(50),
-				source text,
-				fdb_db_pk_id int8)
-;
--- DISABLE UCSC record creation - comment out the insert
--- insert into tmp_ucsc (geneId, chrom1, accnum1, source, fdb_db_pk_id)
--- select ... (UCSC logic disabled)
-;
-
-create temp table tmp_ucsc_all (counter int,
-			geneId text,
-			chrom1 varchar(10),
-			source text,
-			subsource text,
-			dblink_acc_num varchar(50));
-insert into tmp_ucsc_all (counter, geneId, chrom1, source, subsource, dblink_acc_num)
-select count(*) as counter, geneId, chrom1, source, source as subsource, dblink_acc_num
-  from db_link, tmp_ucsc
- where geneId = dblink_linked_Recid
- and dblink_Acc_num like 'NM%'
- and exists (select 'x' from foreign_db_contains, foreign_db
-     	    	    	where fdbcont_fdb_db_id = fdb_db_pk_id
-			and fdb_db_name = 'RefSeq')
-group by geneId, chrom1, source, dblink_acc_num
-;
-insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id, 
-       	    			       sfclg_chromosome,
-				       sfclg_acc_num,
-				       sfclg_location_source,
-				       sfclg_location_Subsource,
-                                       sfclg_evidence_code
-				   )
-select distinct geneId, chrom1, dblink_acc_num, source, subsource, 'ZDB-TERM-170419-250'
-  from tmp_ucsc_all;
-*/
 
 -- ----------------------------------------------------------------------------
--- §D. REDUNDANT — handled by refresh §D
+-- §D. REDUNDANCY REMOVED — handled by Refresh-GBrowse-Tracks_d §D
 --     EnsemblStartEndLoader main path: insert one row per gene/chromosome
 --     using start/ender from §B.
 -- ----------------------------------------------------------------------------
-/*
-insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
-       	    			       sfclg_chromosome,
-				       sfclg_start,
-				       sfclg_end,
-				       sfclg_acc_num,
-				       sfclg_location_source,
-				       sfclg_fdb_db_id,sfclg_evidence_code)
-select distinct dblink_linked_recid,
-       		chrom1,
-		start,
-		ender,
-		accnum1,
-		'EnsemblStartEndLoader',
-		fdb_db_pk_id, 'ZDB-TERM-170419-250'
-  from db_link, tmp_gene, foreign_db, foreign_db_contains
-  where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
-  and dblink_acc_num = accnum1
-  and fdb_db_pk_id = fdbcont_fdb_db_id
- and start is not null
- and ender is not null
-    -- don't include fdb_db_display_name = 'ExpressionAtlas'
- and fdb_db_pk_id != 91
-;
-*/
 
 -- ----------------------------------------------------------------------------
 -- §E. ACTIVE — ENSDARG-fallback EnsemblStartEndLoader rows.
@@ -246,46 +167,14 @@ select distinct dblink_linked_recid,
 ;
 
 -- ----------------------------------------------------------------------------
--- §F. REDUNDANT — handled by refresh §F
+-- §F. REDUNDANCY REMOVED — handled by Refresh-GBrowse-Tracks_d §F
 --     ZfinGbrowseStartEndLoader from tmp_gene joined with zfin_ensembl_gene.
 -- ----------------------------------------------------------------------------
-/*
-insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
-       	    			       sfclg_chromosome,
-				       sfclg_start,
-				       sfclg_end,
-				       sfclg_acc_num,
-				       sfclg_location_source,
-				       sfclg_fdb_db_id,sfclg_evidence_code)
-select dblink_linked_recid,
-       		chrom1,
-		start,
-		ender,
-		accnum1,
-		'ZfinGbrowseStartEndLoader',
-		fdb_db_pk_id, 'ZDB-TERM-170419-250'
-  from db_link, tmp_gene, foreign_db, foreign_db_contains
-  where dblink_Fdbcont_zdb_id = fdbcont_Zdb_id
-  and dblink_acc_num = accnum1
-  and fdb_db_pk_id = fdbcont_fdb_db_id
- and start is not null
- and ender is not null
- and exists (select 'x' from zfin_ensembl_gene where zeg_gene_zdb_id = dblink_linked_recid)
- group by dblink_linked_recid, chrom1, start, ender, accnum1, fdb_db_pk_id
-;
-*/
 
 -- ----------------------------------------------------------------------------
--- §G. REDUNDANT — handled by refresh §G
+-- §G. REDUNDANCY REMOVED — handled by Refresh-GBrowse-Tracks_d §G
 --     DirectSubmission re-import from sequence_feature_chromosome_location.
 -- ----------------------------------------------------------------------------
-/*
-insert into sequence_feature_chromosome_location_generated (
-  sfclg_chromosome, sfclg_data_zdb_id, sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_pub_zdb_id, sfclg_evidence_code)
-select sfcl_chromosome, sfcl_feature_zdb_id, sfcl_start_position, sfcl_end_position, 'DirectSubmission', '', sfcl_assembly, recattrib_source_zdb_id, sfcl_evidence_code
-  from sequence_feature_chromosome_location
-  left outer join record_attribution on recattrib_data_zdb_id = sfcl_zdb_id;
-*/
 
 -- ----------------------------------------------------------------------------
 -- §H. ACTIVE — zmp gbrowse-track tag.
@@ -299,51 +188,20 @@ set sfclg_gbrowse_track = 'zmp'
 where sfclg_pub_zdb_id in ('ZDB-PUB-130425-4', 'ZDB-PUB-250905-18');
 
 -- ----------------------------------------------------------------------------
--- §I. REDUNDANT — handled by refresh §I
+-- §I. REDUNDANCY REMOVED — handled by Refresh-GBrowse-Tracks_d §I
 --     BurgessLin Zv9 insertion features.
 -- ----------------------------------------------------------------------------
-/*
-insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
-  sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_gbrowse_track, sfclg_evidence_code)
-select gff3.gff_seqname, feature.feature_zdb_id, gff3.gff_start, gff3.gff_end, 'ZfinGbrowseZv9StartEndLoader', 'BurgessLin', 'Zv9', 'insertion', 'ZDB-TERM-170419-250'
-from gff3
-inner join feature on (gff3.gff_id || 'Tg') = feature.feature_abbrev
-where gff3.gff_source = 'BurgessLin';
-*/
 
 -- ----------------------------------------------------------------------------
--- §J. REDUNDANT — handled by refresh §J
+-- §J. REDUNDANCY REMOVED — handled by Refresh-GBrowse-Tracks_d §J
 --     KnockdownReagentLoader (ZFIN_knockdown_reagent + GRCz12tu variant in
 --     refresh; only the non-GRCz12tu variant was here historically).
 -- ----------------------------------------------------------------------------
-/*
-insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
-  sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_evidence_code)
-select gff_seqname, gff_name, gff_start, gff_end, 'ZfinGbrowseStartEndLoader', 'KnockdownReagentLoader', 'ZDB-TERM-170419-250'
-from gff3
-where gff_source = 'ZFIN_knockdown_reagent';
-*/
 
 -- ----------------------------------------------------------------------------
--- §K. REDUNDANT — handled by refresh §K
+-- §K. REDUNDANCY REMOVED — handled by Refresh-GBrowse-Tracks_d §K
 --     Cleanup deletes for AB / U / 0 chromosomes across the source set.
 -- ----------------------------------------------------------------------------
-/*
-delete from sequence_feature_chromosome_location_generated
- where sfclg_chromosome in ('AB','U','0')
- and sfclg_location_source = 'UCSCStartEndLoader';
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_chromosome in ('AB','U','0')
- and (
-  sfclg_location_source = 'ZfinGbrowseStartEndLoader'
-  OR sfclg_location_source = 'ZfinGbrowseZv9StartEndLoader'
-);
-
-delete from sequence_feature_chromosome_location_generated
- where sfclg_chromosome in ('AB','U','0')
- and sfclg_location_source = 'EnsemblStartEndLoader';
-*/
 
 commit work;
 -- commit or rollback is appended externally

--- a/server_apps/DB_maintenance/warehouse/regenChromosomeMart.sh
+++ b/server_apps/DB_maintenance/warehouse/regenChromosomeMart.sh
@@ -6,6 +6,7 @@ rm -f "$ROOT_PATH/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/ru
 rm -f "$ROOT_PATH/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/regenChromosomeMartReportPostgres.txt"
 rm -f "$ROOT_PATH/reports/tests/chromosomeMartUnitTestsPostgres.txt"
 rm -f "$ROOT_PATH/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/chromosomeMartUnitTestsPostgres.txt"
+rm -f "$ROOT_PATH/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/pruneUcscLinksReport.txt"
 
 echo "done with file delete"
 
@@ -19,6 +20,19 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "done with runchromosomemart on $DB_NAME"
+
+# Drop UCSCStartEndLoader rows whose accession isn't in UCSC's danRer11 refGene
+# track (those would 404 on the mapping detail page).
+chmod +x "$ROOT_PATH/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/pruneUcscLinks.sh"
+"$ROOT_PATH/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/pruneUcscLinks.sh" \
+  &> "$ROOT_PATH/server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/pruneUcscLinksReport.txt"
+
+if [ $? -ne 0 ]; then
+  echo "UCSC link prune failed; see pruneUcscLinksReport.txt"
+  exit 1
+fi
+
+echo "done pruning UCSC links"
 
 # Run the validation tests via Ant
 cd "$SOURCEROOT" || exit 1

--- a/server_apps/data_transfer/Ensembl/updateSequenceFeatureChromosomeLocation.sql
+++ b/server_apps/data_transfer/Ensembl/updateSequenceFeatureChromosomeLocation.sql
@@ -1,5 +1,26 @@
+-- ============================================================================
+-- Refresh-GBrowse-Tracks_d — daily refresh of generated location rows.
+-- ============================================================================
+-- Invoked by load_knockdown_reagents.sh (in the parent
+-- server_apps/data_transfer/Downloads/GFF3/knockdown_reagents/ directory),
+-- which is the script the Refresh-GBrowse-Tracks_d Jenkins job runs.
+--
+-- This file is the canonical writer for UCSC, Ensembl, Zfin, and
+-- DirectSubmission rows in sequence_feature_chromosome_location_generated.
+-- The warehouse-side script
+-- (server_apps/DB_maintenance/warehouse/chromosomeMartPostgres/
+-- updateSequenceFeatureChromosomeLocationPostgres.sql) runs downstream of
+-- this job and adds two extra pieces (ENSDARG-fallback Ensembl rows + zmp
+-- track tag for an additional ZMP pub).
+--
+-- Section markers §A–§L below correspond to the same-named sections in the
+-- warehouse script. Sections marked there as "REDUNDANT — handled by
+-- refresh §X" point back here.
+-- ============================================================================
+
 begin work;
 
+-- §A. Bulk DELETE of the five sources this script owns. -----------------------
 delete from sequence_feature_chromosome_location_generated
  where sfclg_location_source = 'ZfinGbrowseStartEndLoader';
 
@@ -16,11 +37,15 @@ delete from sequence_feature_chromosome_location_generated
  where sfclg_location_source = 'UCSCStartEndLoader';
 
 
-create temp table 
+-- §B. Build tmp_gff_start_end / tmp_gene from gff3 + ensdart_name_mapping. ---
+-- Keys off gff_id (= ENSDART transcript ID), then derives transcript spans
+-- via a self-join on gff_name. See the warehouse script's §B for an
+-- alternative implementation keyed on gff_parent + ensdar_mapping.
+create temp table
   tmp_gff_start_end (accnum varchar(50),chrom varchar(20), gene varchar(50),
        start int,
        endVal int
-); 
+);
 
 
 insert into tmp_gff_start_end (accnum,chrom, gene)
@@ -63,18 +88,19 @@ create index gene2_index on tmp_gene (accnum1);
 update tmp_gene
  set start = (select min(start)
       	      	      from tmp_gff_start_end
-		      where  gene = accnum1 
+		      where  gene = accnum1
 		      and chrom = chrom1);
 
 
 update tmp_gene
  set endVal = (select max(endVal)
       	      	      from tmp_gff_start_end
-		      where  gene = accnum1 
+		      where  gene = accnum1
 		      and chrom = chrom1);
 
 
 
+-- §C. UCSC: tmp_ucsc + tmp_ucsc_all + INSERT 'UCSCStartEndLoader' rows. ------
 CREATE temp TABLE tmp_ucsc AS
   SELECT dblink_linked_recid          AS geneId,
     chrom1,
@@ -102,7 +128,7 @@ select count(*) as counter, geneId, chrom1, source, source as subsource, dblink_
 group by geneId, chrom1, source, dblink_acc_num;
 
 
-insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id, 
+insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
        	    			       sfclg_chromosome,
 				       sfclg_acc_num,
 				       sfclg_location_source,
@@ -113,6 +139,7 @@ select distinct geneId, chrom1, dblink_acc_num, source, subsource
 
 
 
+-- §D. EnsemblStartEndLoader main path: one row per gene/chromosome from §B. --
 INSERT INTO sequence_feature_chromosome_location_generated
 (sfclg_data_zdb_id,
  sfclg_chromosome,
@@ -139,6 +166,10 @@ INSERT INTO sequence_feature_chromosome_location_generated
          AND start IS NOT NULL
          AND endval IS NOT NULL;
 
+-- §E lives only in the warehouse script (ENSDARG fallback for genes without
+-- ENSDART transcripts). No equivalent here.
+
+-- §F. ZfinGbrowseStartEndLoader from tmp_gene. ------------------------------
 INSERT INTO sequence_feature_chromosome_location_generated
 (sfclg_data_zdb_id,
  sfclg_chromosome,
@@ -165,16 +196,21 @@ INSERT INTO sequence_feature_chromosome_location_generated
          AND fdbcont_zdb_id !='ZDB-FDBCONT-200123-1'
          AND endval IS NOT NULL;
 
+-- §G. DirectSubmission re-import from sequence_feature_chromosome_location. -
 insert into sequence_feature_chromosome_location_generated (
   sfclg_chromosome, sfclg_data_zdb_id, sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_pub_zdb_id)
 select sfcl_chromosome, sfcl_feature_zdb_id, sfcl_start_position, sfcl_end_position, 'DirectSubmission', '', sfcl_assembly, recattrib_source_zdb_id
   from sequence_feature_chromosome_location
   left outer join record_attribution on recattrib_data_zdb_id = sfcl_zdb_id;
 
+-- §H. zmp gbrowse-track tag for ZDB-PUB-130425-4. The warehouse script's §H
+-- re-tags both ZMP pubs (belt-and-suspenders); the additional pub
+-- ZDB-PUB-250905-18 is genuinely warehouse-unique work.
 update sequence_feature_chromosome_location_generated
 set sfclg_gbrowse_track = 'zmp'
 where sfclg_pub_zdb_id = 'ZDB-PUB-130425-4';
 
+-- §I. BurgessLin Zv9 insertion features. ------------------------------------
 insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
   sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_gbrowse_track)
 select gff3.gff_seqname, feature.feature_zdb_id, gff3.gff_start, gff3.gff_end, 'ZfinGbrowseZv9StartEndLoader', 'BurgessLin', 'Zv9', 'insertion'
@@ -182,6 +218,7 @@ from gff3
 inner join feature on (gff3.gff_id || 'Tg') = feature.feature_abbrev
 where gff3.gff_source = 'BurgessLin';
 
+-- §J. KnockdownReagentLoader (ZFIN_knockdown_reagent + GRCz12tu variant). --
 insert into sequence_feature_chromosome_location_generated (sfclg_chromosome, sfclg_data_zdb_id,
   sfclg_start, sfclg_end, sfclg_location_source, sfclg_location_subsource)
 select gff_seqname, gff_name, gff_start, gff_end, 'ZfinGbrowseStartEndLoader', 'KnockdownReagentLoader'
@@ -195,6 +232,7 @@ from gff3
 where gff_source = 'ZFIN_knockdown_reagent_GRCz12tu';
 
 
+-- §K. AB / U / 0 chromosome cleanup deletes. -------------------------------
 delete from sequence_feature_chromosome_location_generated
  where sfclg_chromosome in ('AB','U','0')
  and sfclg_location_source = 'UCSCStartEndLoader';
@@ -210,6 +248,7 @@ delete from sequence_feature_chromosome_location_generated
  where sfclg_chromosome in ('AB','U','0')
  and sfclg_location_source = 'EnsemblStartEndLoader';
 
+-- §L. GRCv10 → GRCz11 assembly migration update. ---------------------------
 update sequence_feature_chromosome_location_generated
   set sfclg_assembly = 'GRCz11'
 where sfclg_assembly = 'GRCv10'

--- a/server_apps/data_transfer/Ensembl/updateSequenceFeatureChromosomeLocation.sql
+++ b/server_apps/data_transfer/Ensembl/updateSequenceFeatureChromosomeLocation.sql
@@ -45,7 +45,7 @@ create temp table
   tmp_gff_start_end (accnum varchar(50),chrom varchar(20), gene varchar(50),
        start int,
        endVal int
-);
+); 
 
 
 insert into tmp_gff_start_end (accnum,chrom, gene)
@@ -88,14 +88,14 @@ create index gene2_index on tmp_gene (accnum1);
 update tmp_gene
  set start = (select min(start)
       	      	      from tmp_gff_start_end
-		      where  gene = accnum1
+		      where  gene = accnum1 
 		      and chrom = chrom1);
 
 
 update tmp_gene
  set endVal = (select max(endVal)
       	      	      from tmp_gff_start_end
-		      where  gene = accnum1
+		      where  gene = accnum1 
 		      and chrom = chrom1);
 
 
@@ -128,7 +128,7 @@ select count(*) as counter, geneId, chrom1, source, source as subsource, dblink_
 group by geneId, chrom1, source, dblink_acc_num;
 
 
-insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id,
+insert into sequence_feature_chromosome_location_generated (sfclg_data_Zdb_id, 
        	    			       sfclg_chromosome,
 				       sfclg_acc_num,
 				       sfclg_location_source,

--- a/server_apps/jenkins/jobs/Refresh-GBrowse-Tracks_d/config.xml
+++ b/server_apps/jenkins/jobs/Refresh-GBrowse-Tracks_d/config.xml
@@ -28,6 +28,15 @@
     </hudson.tasks.Shell>
   </builders>
   <publishers>
+    <hudson.tasks.BuildTrigger>
+      <childProjects>Regenerate-Chromosome-Mart_d</childProjects>
+      <threshold>
+        <name>SUCCESS</name>
+        <ordinal>0</ordinal>
+        <color>BLUE</color>
+        <completeBuild>true</completeBuild>
+      </threshold>
+    </hudson.tasks.BuildTrigger>
     <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@2.35.1">
       <recipientList></recipientList>
       <configuredTriggers>

--- a/server_apps/jenkins/jobs/Refresh-GBrowse-Tracks_d/config.xml
+++ b/server_apps/jenkins/jobs/Refresh-GBrowse-Tracks_d/config.xml
@@ -5,6 +5,7 @@
   &lt;li&gt;Merges static Burgess-Lin and ZMP data with active ZFIN data and loads that information into gff3 table.&lt;/li&gt;&#xd;
   &lt;li&gt;Runs Bowtie alignment on STRs and loads that information into gff3 table.&lt;/li&gt;&#xd;
   &lt;li&gt;Pulls info from gff3 table into sequence_feature_chromosome_location_generated table&lt;/li&gt;&#xd;
+  &lt;li&gt;On success, triggers Regenerate-Chromosome-Mart_d, which adds ENSDARG-fallback rows, tags additional zmp track pubs, and prunes UCSC links whose accession is missing from UCSC's danRer11 refGene track.&lt;/li&gt;&#xd;
 &lt;/ul&gt;</description>
   <keepDependencies>false</keepDependencies>
   <properties/>

--- a/server_apps/jenkins/jobs/Regenerate-Chromosome-Mart_d/config.xml
+++ b/server_apps/jenkins/jobs/Regenerate-Chromosome-Mart_d/config.xml
@@ -1,7 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <project>
   <actions/>
-  <description></description>
+  <description>&lt;ul&gt;&#xd;
+  &lt;li&gt;Triggered downstream of Refresh-GBrowse-Tracks_d (no own cron). Runs as an additive layer on top of that job's writes to sequence_feature_chromosome_location_generated.&lt;/li&gt;&#xd;
+  &lt;li&gt;Regenerates the chromosome_mart aggregation tables (regenChromosomeMart.sh -&amp;gt; runChromosomeMart.sh against the chromosomeMartPostgres scripts).&lt;/li&gt;&#xd;
+  &lt;li&gt;Adds ENSDARG-fallback EnsemblStartEndLoader rows for genes whose ENSDARG accession has no ENSDART transcript link (warehouse-unique work).&lt;/li&gt;&#xd;
+  &lt;li&gt;Re-tags the zmp gbrowse-track for both ZMP pubs (belt-and-suspenders for ZDB-PUB-130425-4, which Refresh-GBrowse-Tracks_d also tags; sole tagger of ZDB-PUB-250905-18).&lt;/li&gt;&#xd;
+  &lt;li&gt;Prunes UCSCStartEndLoader rows whose accession is missing from UCSC's danRer11 refGene track (those would 404 on the mapping detail page). The allowlist is fetched live from api.genome.ucsc.edu; the prune step bails without deleting if the API is unreachable or returns &amp;lt; 10000 accessions.&lt;/li&gt;&#xd;
+&lt;/ul&gt;</description>
   <keepDependencies>false</keepDependencies>
   <properties/>
   <scm class="hudson.scm.NullSCM"/>

--- a/server_apps/jenkins/trigger.production.properties
+++ b/server_apps/jenkins/trigger.production.properties
@@ -158,8 +158,11 @@ Publication-Not-Complete-Author-Link_q=00 05 1 1,4,9 *
 Pull-FPBase-Proteins_m=H 3 5 * *
 Refresh-GBrowse-Tracks_d=15 0 * * *
 Regen-Construct_d=H 9-16/2 * * 1-5
-# Remove Regenerate-Chromosome-Mart_d until fixed. See ZFIN-9688
-# Regenerate-Chromosome-Mart_d=0 H * * *
+# Regenerate-Chromosome-Mart_d has no cron — it is triggered downstream of
+# Refresh-GBrowse-Tracks_d via hudson.tasks.BuildTrigger in that job's
+# config.xml so the warehouse SQL always lands on top of fresh gbrowse-refresh
+# output. The warehouse SQL is additive-only (ENSDARG-fallback rows + zmp tag
+# for ZDB-PUB-250905-18) so it doesn't race with the daily refresh.
 Regenerate-Ensembl-BlastDBs_w=30 09 * * 4
 Regenerate-UI-Tables_d=0 H * * *
 Regenerate-WebHost-Curated-Databases_d=0 2 * * *


### PR DESCRIPTION
The problem encountered in zfin-10228 was that we were showing links to UCSC that went to a page at UCSC that doesn't exist (due to them not having GRCz12 data yet). To solve that issue, I added a step to the UCSC link generation that cross-references existing IDs as UCSC and only loads them if they are in that set.

The other changes are for a related issue. The UCSC data load has been paused (Regenerate-Chromosome-Mart_d commented out of triggers).  We needed to re-enable it. However, some of the logic is redundant to Refresh-GBrowse-Tracks_d.  So I removed the redundant parts of the code from Regenerate-Chromosome-Mart_d and now it is triggered immediately after Refresh-GBrowse-Tracks_d runs.