### PR TITLE
ZFIN-9850: update omc designation institution name

### DIFF
--- a/source/org/zfin/db/postGmakePostloaddb/1182/migrations/ZFIN-9850.xml
+++ b/source/org/zfin/db/postGmakePostloaddb/1182/migrations/ZFIN-9850.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <changeSet author="cpich" id="ZFIN-9850-update-omc-institution">
+        <sql>
+            UPDATE feature_prefix
+            SET fp_institute_display = 'Osaka Medical and Pharmaceutical University'
+            WHERE fp_prefix = 'omc';
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Summary
- Update institution display for `omc` line designation from "Osaka Medical College" to "Osaka Medical and Pharmaceutical University" per [ZFIN-9850](https://zfin.atlassian.net/browse/ZFIN-9850).
- Liquibase migration in `1182/migrations/ZFIN-9850.xml` updates `feature_prefix.fp_institute_display` where `fp_prefix='omc'`.

## Test plan
- [ ] Liquibase changeSet runs cleanly on a fresh dev DB
- [ ] After migration: `SELECT fp_institute_display FROM feature_prefix WHERE fp_prefix = 'omc'` returns "Osaka Medical and Pharmaceutical University"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ZFIN-9850]: https://zfin.atlassian.net/browse/ZFIN-9850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ