### PR TITLE
Failing Test Fix: Add schema column to zdb_object_type

### DIFF
--- a/lib/DB_functions/p_check_zdb_object_table.sql
+++ b/lib/DB_functions/p_check_zdb_object_table.sql
@@ -5,20 +5,23 @@
   --REPLACES:
   --sub zdbObjectHomeTableColumnExist 
 
-  create or replace function p_check_zdb_object_table (vTableName text, 
+  create or replace function p_check_zdb_object_table (vSchemaName text,
+	  				     vTableName text,
 	  				     vColumnName text)
   returns void as $$
   declare vOkInSystables		integer;
    vOkInSyscolumns	integer;
    vTableId		integer;
+   vSchema		text := COALESCE(NULLIF(vSchemaName, ''), 'public');
   begin
-   vTableId = (select pg_class.oid 
-		   from pg_class 
-		   where relname = vTableName);
+   vTableId = (select c.oid
+                  from pg_class c
+                  join pg_namespace n on n.oid = c.relnamespace
+                  where n.nspname = vSchema and c.relname = vTableName);
 
    vOkInSystables = (select count(*) 
 			  from pg_tables
-			  where tablename = vTableName);
+			  where schemaname = vSchema and tablename = vTableName);
   raise notice 'vOkInSystables: %', vOkInSystables;
   raise notice 'vTableid: %', vTableid;
 

--- a/lib/DB_triggers/zdb_object_type.sql
+++ b/lib/DB_triggers/zdb_object_type.sql
@@ -5,7 +5,8 @@ returns trigger as
 $BODY$
 begin
 
-   perform p_check_zdb_object_table(NEW.zobjtype_home_table,
+   perform p_check_zdb_object_table(NEW.zobjtype_home_schema,
+				NEW.zobjtype_home_table,
 				NEW.zobjtype_home_zdb_id_column);
 
 

--- a/server_apps/DB_maintenance/validatedata/Check-Get_Object_Type-Function_d.sqlj
+++ b/server_apps/DB_maintenance/validatedata/Check-Get_Object_Type-Function_d.sqlj
@@ -1,5 +1,5 @@
 SELECT zobjtype_name,
-       zobjtype_home_table,
+       zobjtype_home_schema || '.' || zobjtype_home_table,
        zobjtype_home_zdb_id_column
 FROM   zdb_object_type
 subquery
@@ -7,4 +7,4 @@ list query
 not exists
 select get_obj_name($2)
 from $1 limit 1;
-              
+

--- a/server_apps/DB_maintenance/validatedata/Check-Zdb-Home-Column-Exists_d.sql
+++ b/server_apps/DB_maintenance/validatedata/Check-Zdb-Home-Column-Exists_d.sql
@@ -1,12 +1,19 @@
+-- Find zdb_object_type rows whose home table or home zdb-id column does not
+-- exist in the database. zobjtype_home_schema (default 'public') and
+-- zobjtype_home_table together identify the table.
 SELECT zobjtype_name,
+       zobjtype_home_schema,
        zobjtype_home_table,
        zobjtype_home_zdb_id_column
-FROM   zdb_object_type
-WHERE  zobjtype_home_table NOT IN (SELECT table_name
-                                   FROM   information_schema.tables
-                                   WHERE table_schema = 'public')
-        OR zobjtype_home_zdb_id_column NOT IN (SELECT column_name
-                                               FROM   zdb_object_type a,
-                                                      information_schema.columns b
-                                               WHERE
-           zobjtype_home_table = b.table_name);
+FROM   zdb_object_type ot
+WHERE  NOT EXISTS (
+           SELECT 1
+           FROM   information_schema.tables t
+           WHERE  t.table_schema = ot.zobjtype_home_schema
+             AND  t.table_name   = ot.zobjtype_home_table)
+   OR  NOT EXISTS (
+           SELECT 1
+           FROM   information_schema.columns c
+           WHERE  c.table_schema = ot.zobjtype_home_schema
+             AND  c.table_name   = ot.zobjtype_home_table
+             AND  c.column_name  = ot.zobjtype_home_zdb_id_column);

--- a/source/org/zfin/db/postGmakePostloaddb/1182/migrations/01-zdb-object-type-home-schema.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1182/migrations/01-zdb-object-type-home-schema.sql
@@ -1,0 +1,18 @@
+--liquibase formatted sql
+
+-- Add a schema column to zdb_object_type so each home_table value is fully
+-- qualified by its (schema, table) pair instead of relying on a search-path
+-- lookup. Required as soon as any zfin schema other than `public` is used
+-- (introduced by the ZIRC line-submission feature, where line_submission
+-- lives in the `zirc` schema).
+--
+-- Default 'public' backfills every existing row, matching the historical
+-- assumption that every zdb_object_type-tracked table lived in public.
+-- This must be the first changeset in the 1182/migrations directory because
+-- the redeployed p_check_zdb_object_table function (3-arg signature) reads
+-- NEW.zobjtype_home_schema from row triggers; any INSERT/UPDATE on
+-- zdb_object_type after the trigger redeploys but before this column exists
+-- would error.
+--changeset cmpich:add-zobjtype-home-schema
+ALTER TABLE zdb_object_type
+    ADD COLUMN IF NOT EXISTS zobjtype_home_schema TEXT NOT NULL DEFAULT 'public';

--- a/source/org/zfin/db/postGmakePostloaddb/1182/migrations/zirc-line-submission.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1182/migrations/zirc-line-submission.sql
@@ -210,14 +210,20 @@ CREATE INDEX line_submission_person_person_idx     ON zirc.line_submission_perso
 -- in zdb_object_type and a matching <type>_seq sequence; without these the
 -- ZdbIdGenerator throws at the SQL level and the controller returns 500
 -- (manifesting as an empty 200 response after the global exception handler).
--- Idempotent so it's safe to run on environments where the wiring was already
--- applied manually (e.g. via the sample-data script).
---changeset cmpich:ZIRC-line-submission-id-wiring
+-- The home_table lives in the zirc schema, so zobjtype_home_schema must be
+-- set explicitly; the column was added by 01-zdb-object-type-home-schema.sql.
+-- runOnChange:true so environments that applied an earlier version of this
+-- changeset (which omitted zobjtype_home_schema) re-run with the corrected
+-- body — the ON CONFLICT clause makes the re-run idempotent.
+--changeset cmpich:ZIRC-line-submission-id-wiring runOnChange:true
 INSERT INTO zdb_object_type (
-    zobjtype_name, zobjtype_day, zobjtype_home_table,
+    zobjtype_name, zobjtype_day, zobjtype_home_schema, zobjtype_home_table,
     zobjtype_home_zdb_id_column, zobjtype_is_data, zobjtype_is_source)
-VALUES ('LINESUBMISSION', current_date - 1, 'line_submission',
+VALUES ('LINESUBMISSION', current_date - 1, 'zirc', 'line_submission',
         'ls_zdb_id', true, false)
-ON CONFLICT (zobjtype_name) DO NOTHING;
+ON CONFLICT (zobjtype_name) DO UPDATE SET
+    zobjtype_home_schema = EXCLUDED.zobjtype_home_schema,
+    zobjtype_home_table = EXCLUDED.zobjtype_home_table,
+    zobjtype_home_zdb_id_column = EXCLUDED.zobjtype_home_zdb_id_column;
 
 CREATE SEQUENCE IF NOT EXISTS linesubmission_seq START 1;

--- a/source/org/zfin/db/postGmakePostloaddb/1182/zirc-line-submission-sample-data.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1182/zirc-line-submission-sample-data.sql
@@ -21,15 +21,17 @@
 -- Prerequisites for get_id('LINESUBMISSION'): the type must exist in
 -- zdb_object_type and have a matching <type>_seq sequence. Both are created
 -- here so this seed is self-contained.
--- The trigger on zdb_object_type validates the home-table name against
--- pg_tables.tablename (unqualified). Pass just 'line_submission'; it resolves
--- to zirc.line_submission via pg_tables regardless of schema.
+-- The trigger on zdb_object_type validates the (schema, table) pair against
+-- pg_tables, so zobjtype_home_schema = 'zirc' is required for line_submission.
 INSERT INTO zdb_object_type (
-    zobjtype_name, zobjtype_day, zobjtype_home_table,
+    zobjtype_name, zobjtype_day, zobjtype_home_schema, zobjtype_home_table,
     zobjtype_home_zdb_id_column, zobjtype_is_data, zobjtype_is_source)
-VALUES ('LINESUBMISSION', current_date - 1, 'line_submission',
+VALUES ('LINESUBMISSION', current_date - 1, 'zirc', 'line_submission',
         'ls_zdb_id', true, false)
-ON CONFLICT (zobjtype_name) DO NOTHING;
+ON CONFLICT (zobjtype_name) DO UPDATE SET
+    zobjtype_home_schema = EXCLUDED.zobjtype_home_schema,
+    zobjtype_home_table = EXCLUDED.zobjtype_home_table,
+    zobjtype_home_zdb_id_column = EXCLUDED.zobjtype_home_zdb_id_column;
 
 CREATE SEQUENCE IF NOT EXISTS linesubmission_seq START 1;
 

--- a/test/dbTestScript.sqlj
+++ b/test/dbTestScript.sqlj
@@ -1,7 +1,7 @@
 --begin work;
 
 select zobjtype_name,
-       zobjtype_home_table,
+       zobjtype_home_schema || '.' || zobjtype_home_table,
        zobjtype_home_zdb_id_column
 from  zdb_object_type
 subquery


### PR DESCRIPTION
We are getting a failing test on trunk because it doesn't account for schema:

```
DbUnitTests > org.zfin.infrastructure.InfrastructureRepositoryTest.runDynamicDbScript2 FAILED
    java.lang.RuntimeException: org.postgresql.util.PSQLException: ERROR: relation "line_submission" does not exist
      Position: 46
        at org.zfin.infrastructure.repository.HibernateInfrastructureRepository.lambda$executeNativeQuery$2(HibernateInfrastructureRepository.java:1208)
        at org.hibernate.jdbc.WorkExecutor.executeReturningWork(WorkExecutor.java:58)
        at org.hibernate.internal.AbstractSharedSessionContract.lambda$doReturningWork$5(AbstractSharedSessionContract.java:1049)
        at org.hibernate.engine.jdbc.internal.JdbcCoordinatorImpl.coordinateWork(JdbcCoordinatorImpl.java:303)
        at org.hibernate.internal.AbstractSharedSessionContract.doWork(AbstractSharedSessionContract.java:1053)
        at org.hibernate.internal.AbstractSharedSessionContract.doReturningWork(AbstractSharedSessionContract.java:1049)
        at org.zfin.infrastructure.repository.HibernateInfrastructureRepository.executeNativeQuery(HibernateInfrastructureRepository.java:1190)
        at org.zfin.infrastructure.repository.HibernateInfrastructureRepository.executeNativeQuery(HibernateInfrastructureRepository.java:1182)
        at org.zfin.infrastructure.repository.HibernateInfrastructureRepository.executeNativeDynamicQuery(HibernateInfrastructureRepository.java:1240)
        at org.zfin.infrastructure.InfrastructureRepositoryTest.runDynamicDbScript2(InfrastructureRepositoryTest.java:310)

        Caused by:
        org.postgresql.util.PSQLException: ERROR: relation "line_submission" does not exist
          Position: 46
            at app//org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2736)
            at app//org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2421)
            at app//org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:372)
            at app//org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:525)
            at app//org.postgresql.jdbc.PgStatement.execute(PgStatement.java:435)
            at app//org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:357)
            at app//org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:342)
            at app//org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:318)
            at app//org.postgresql.jdbc.PgStatement.executeQuery(PgStatement.java:268)
            at app//com.mchange.v2.c3p0.impl.NewProxyStatement.executeQuery(NewProxyStatement.java:327)
            at app//org.zfin.infrastructure.repository.HibernateInfrastructureRepository.lambda$executeNativeQuery$2(HibernateInfrastructureRepository.java:1195)
            ... 9 more
```