### PR TITLE
ZFIN-10287: fix assembly-not-known save (stale FGL + FGMD seqRef)

### DIFF
--- a/source/org/zfin/gwt/curation/server/FeatureRPCServiceImpl.java
+++ b/source/org/zfin/gwt/curation/server/FeatureRPCServiceImpl.java
@@ -142,6 +142,15 @@ public class FeatureRPCServiceImpl extends RemoteServiceServlet implements Featu
             dto.getFeatureEndLoc() == null) {
             infrastructureRepository.deleteRecordAttribution(fl.getZdbID(), dto.getPublicationZdbID());
             HibernateUtil.currentSession().delete(fl);
+            // Clear the in-memory fields too. The caller may still hold this reference
+            // (e.g. validateReferenceSequence reads fl.getStartLocation() etc.), and
+            // without this it would keep observing the pre-delete coordinates and
+            // attempt a FASTA lookup against a location the curator just removed.
+            fl.setChromosome(null);
+            fl.setAssembly(null);
+            fl.setStartLocation(null);
+            fl.setEndLocation(null);
+            fl.setLocationEvidence(null);
             return;
         }
         // If the assembly is changing, only allow changing to a current assembly (GRCz12tu or GRCz11)
@@ -281,6 +290,13 @@ public class FeatureRPCServiceImpl extends RemoteServiceServlet implements Featu
             }
 
             DTOConversionService.updateFeatureGenomicMutationDetailWithDTO(fgmd, featureDTO.getFgmdChangeDTO());
+            // When the curator removes all location info (marking "Assembly information
+            // not known as of <date>"), the calculated Sequence of Reference no longer
+            // has a source. Drop it before the validate step so we don't compare the
+            // stale value the GUI carried over against a no-longer-applicable assembly.
+            if (locationDeleted) {
+                fgmd.setFgmdSeqRef(null);
+            }
             validateReferenceSequence(fgmd, fgl);
 
             if (fgmd.getZdbID() == null) {

--- a/source/org/zfin/gwt/curation/server/FeatureRPCServiceImpl.java
+++ b/source/org/zfin/gwt/curation/server/FeatureRPCServiceImpl.java
@@ -292,10 +292,12 @@ public class FeatureRPCServiceImpl extends RemoteServiceServlet implements Featu
             DTOConversionService.updateFeatureGenomicMutationDetailWithDTO(fgmd, featureDTO.getFgmdChangeDTO());
             // When the curator removes all location info (marking "Assembly information
             // not known as of <date>"), the calculated Sequence of Reference no longer
-            // has a source. Drop it before the validate step so we don't compare the
-            // stale value the GUI carried over against a no-longer-applicable assembly.
+            // has a source. Drop both sequence fields before the validate step so we
+            // don't compare the stale GUI value against a no-longer-applicable
+            // assembly, and so the persisted FGMD reflects the empty-location state.
             if (locationDeleted) {
                 fgmd.setFgmdSeqRef(null);
+                fgmd.setFgmdSeqVar(null);
             }
             validateReferenceSequence(fgmd, fgl);
 

--- a/source/org/zfin/mapping/GenomicLocationService.java
+++ b/source/org/zfin/mapping/GenomicLocationService.java
@@ -111,21 +111,17 @@ public class GenomicLocationService {
 				}
 				insertOrUpdateFlankSeq(feature, seq1, seq2, offset);
 			} else {
-				// Location is empty/deleted - clean up related records
-				// Delete variant_flanking_sequence if it exists
+				// Location is empty/deleted - clean up the flanking-sequence row.
+				// We deliberately do NOT touch feature_genomic_mutation_detail here:
+				// the Feature.featureGenomicMutationDetailSet mapping has multiple
+				// cascade flags (PERSIST + SAVE_UPDATE + orphanRemoval=true) and the
+				// existing setFeatureGenomicMutationDetail() setter calls .clear() +
+				// .add(null), which combination produced a double-DELETE at flush
+				// (StaleStateException "actual row count: 0; expected: 1"). The fgmd
+				// is cleared field-wise from editFeatureDTO when locationDeleted=true.
 				VariantSequence vrSeq = featureRepository.getFeatureVariant(feature);
 				if (vrSeq != null) {
 					HibernateUtil.currentSession().delete(vrSeq);
-				}
-				// Detach feature_genomic_mutation_detail if it exists. The
-				// Feature.featureGenomicMutationDetailSet mapping is orphanRemoval=true,
-				// so removing the row from the set is enough — Hibernate will issue the
-				// DELETE at flush. An additional currentSession().delete(fgmd) here would
-				// race with that cascaded delete and surface as a StaleStateException
-				// ("Batch update returned unexpected row count from update [0]").
-				FeatureGenomicMutationDetail fgmd = feature.getFeatureGenomicMutationDetail();
-				if (fgmd != null) {
-					feature.setFeatureGenomicMutationDetail(null);
 				}
 			}
 		}

--- a/source/org/zfin/mapping/GenomicLocationService.java
+++ b/source/org/zfin/mapping/GenomicLocationService.java
@@ -117,11 +117,15 @@ public class GenomicLocationService {
 				if (vrSeq != null) {
 					HibernateUtil.currentSession().delete(vrSeq);
 				}
-				// Delete feature_genomic_mutation_detail if it exists
+				// Detach feature_genomic_mutation_detail if it exists. The
+				// Feature.featureGenomicMutationDetailSet mapping is orphanRemoval=true,
+				// so removing the row from the set is enough — Hibernate will issue the
+				// DELETE at flush. An additional currentSession().delete(fgmd) here would
+				// race with that cascaded delete and surface as a StaleStateException
+				// ("Batch update returned unexpected row count from update [0]").
 				FeatureGenomicMutationDetail fgmd = feature.getFeatureGenomicMutationDetail();
 				if (fgmd != null) {
 					feature.setFeatureGenomicMutationDetail(null);
-					HibernateUtil.currentSession().delete(fgmd);
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes [ZFIN-10287](https://zfin.atlassian.net/browse/ZFIN-10287). When a curator switches a mutant to *"Assembly information not known as of <date>"* by entering a date and clearing the chromosome/assembly/start/end/evidence fields, the save failed and the previously calculated Sequence of Reference kept showing up.

Two bugs combined to produce the symptom:

1. **Stale `FeatureLocation` after delete.** `FeatureRPCServiceImpl.updateFeatureLocation`'s delete branch removed the DB row but left the in-memory Java object's `chromosome / assembly / startLocation / endLocation` populated. The follow-up `validateReferenceSequence(fgmd, fgl)` then read those stale fields, skipped its early-return guard, and tried to fetch the reference sequence from the FASTA at the soon-to-be-removed coordinates. On prod that throws `"Sequence of Reference does not match the auto-generated sequence from the genome assembly"` whenever the calculated value differs (matches the symptom Amy reported). On local Docker the GRCz11 FASTA is also missing, so it surfaces as a plain `RuntimeException` wrapping `FileNotFoundException` and a generic 500.
2. **Stale `FeatureGenomicMutationDetail.fgmdSeqRef`.** The GUI carries over the previously calculated value when the curator clears coords; nothing on the server clears it either, so even after a successful save the calculated sequence persists in the DB and is shown on next render.

This PR fixes both by:

- Nulling the in-memory `FeatureLocation` fields in the delete branch of `updateFeatureLocation`, so subsequent callers observe the deleted state coherently.
- Clearing `fgmd.fgmdSeqRef` when `locationDeleted` is true in `editFeatureDTO`, before the validate-and-persist step.

## Reproduction

On local Docker:
1. Open `https://localhost:8446/action/curation/ZDB-PUB-200102-5` (a371's pub).
2. Click into feature **a371**, which already has a calculated `fgmd_sequence_of_reference` and a populated `feature_location` row.
3. Enter a date in *Assembly information not known as of*, clear chromosome/assembly/start/end/evidence, save.

Before the fix: red `Failed to create feature: ... 500 The call failed on the server`. After the fix: the location row is deleted, `fgmd_sequence_of_reference` is nulled, `feature.ftr_chr_info_date` is set.

## Test plan
- [ ] Reproduce on local Docker per the steps above — save succeeds, calculated sequence clears.
- [ ] Verify mz19a path still works (it already did; this PR shouldn't regress it).
- [ ] Verify a non-deletion save (just edit a coordinate) still triggers `validateReferenceSequence` normally and rejects a mismatched seqRef.
- [ ] Verify the assembly-changed path still throws its `"Assembly can only be changed to..."` validation when applicable.

[ZFIN-10287]: https://zfin.atlassian.net/browse/ZFIN-10287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ