### PR TITLE
ZFIN-10280: report-only Sequence-of-Reference drift check

### DIFF
--- a/server_apps/DB_maintenance/build.xml
+++ b/server_apps/DB_maintenance/build.xml
@@ -339,6 +339,21 @@
         </java>
     </target>
 
+    <target name="check-sequence-of-reference-drift" description="ZFIN-10280: report features whose stored fgmd_sequence_of_reference disagrees with the FASTA-computed sequence at the stored coordinates. Read-only.">
+        <echo message="Check Sequence of Reference drift"/>
+        <echo message="Use database: ${DBNAME}"/>
+        <echo message="Use JobName: ${JobName}"/>
+        <echo message="ValidateData Dir: ${env.TARGETROOT}/server_apps/DB_maintenance/validatedata"/>
+        <java classname="org.zfin.infrastructure.ant.CheckSequenceOfReferenceDriftTask" fork="yes"
+              classpathref="combined.classpath"
+              failonerror="true">
+            <arg value="${DBNAME}"/>
+            <arg value="${JobName}"/>
+            <arg value="${env.TARGETROOT}/server_apps/DB_maintenance/validatedata"/>
+            <arg value="${web-inf.dir}/zfin.properties"/>
+        </java>
+    </target>
+
     <target name="run-data-report-param" description="">
         <data-report-param/>
     </target>

--- a/server_apps/DB_maintenance/validatedata/report.properties
+++ b/server_apps/DB_maintenance/validatedata/report.properties
@@ -209,3 +209,6 @@ TranscriptsWithNoSequences.errorMessage=Withdrawn transcripts have no sequences
 TranscriptsWithNoSequences.headerColumns=Transcript ZDB ID|
 Unindexed-Open-Pubs_m.errorMessage=Unindexed Open Pubs
 Unindexed-Open-Pubs_m.headerColumns=Pub ZDB ID
+
+Check-Sequence-Of-Reference-Drift_w.errorMessage=Features whose stored Sequence of Reference does not match the FASTA-computed sequence at the stored coordinates (ZFIN-10280, report-only).
+Check-Sequence-Of-Reference-Drift_w.headerColumns=Feature ID|Feature Abbreviation|Feature Type|Assembly|Chromosome|Start|End|Stored Sequence of Reference|Calculated (FASTA) Sequence

--- a/server_apps/jenkins/jobs/Check-Sequence-Of-Reference-Drift_w/config.xml
+++ b/server_apps/jenkins/jobs/Check-Sequence-Of-Reference-Drift_w/config.xml
@@ -1,0 +1,142 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+    <actions/>
+    <description>
+        ZFIN-10280: Weekly read-only report. Compares each feature's stored
+        Sequence of Reference (fgmd_sequence_of_reference) against the sequence
+        computed live from the assembly FASTA at the feature's stored
+        coordinates. Mismatches indicate drift that needs curator review (or a
+        coordinate-nudge recalculation). No DB writes.
+    </description>
+    <keepDependencies>false</keepDependencies>
+    <properties>
+        <EnvInjectJobProperty plugin="envinject@2.3.0">
+            <info>
+                <propertiesFilePath>$CATALINA_BASE/webapps/ROOT/WEB-INF/zfin.properties</propertiesFilePath>
+                <secureGroovyScript plugin="script-security@1.73">
+                    <script></script>
+                    <sandbox>false</sandbox>
+                </secureGroovyScript>
+            </info>
+            <on>true</on>
+            <keepJenkinsSystemVariables>true</keepJenkinsSystemVariables>
+            <keepBuildVariables>true</keepBuildVariables>
+            <overrideBuildParameters>false</overrideBuildParameters>
+        </EnvInjectJobProperty>
+    </properties>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers>
+        <hudson.triggers.TimerTrigger>
+            <spec></spec>
+        </hudson.triggers.TimerTrigger>
+    </triggers>
+    <concurrentBuild>false</concurrentBuild>
+    <customWorkspace>$TARGETROOT</customWorkspace>
+    <builders>
+        <hudson.tasks.Ant plugin="ant@1.2">
+            <targets>check-sequence-of-reference-drift -DJobName=Check-Sequence-Of-Reference-Drift_w</targets>
+            <buildFile>$SOURCEROOT/server_apps/DB_maintenance/build.xml</buildFile>
+        </hudson.tasks.Ant>
+    </builders>
+    <publishers>
+        <hudson.tasks.ArtifactArchiver>
+            <artifacts>server_apps/DB_maintenance/validatedata/Check-Sequence-Of-Reference-Drift_w/*</artifacts>
+            <latestOnly>false</latestOnly>
+            <allowEmptyArchive>true</allowEmptyArchive>
+        </hudson.tasks.ArtifactArchiver>
+        <hudson.plugins.logparser.LogParserPublisher plugin="log-parser@1.0.8">
+            <unstableOnWarning>true</unstableOnWarning>
+            <failBuildOnError>false</failBuildOnError>
+            <parsingRulesPath></parsingRulesPath>
+        </hudson.plugins.logparser.LogParserPublisher>
+        <htmlpublisher.HtmlPublisher plugin="htmlpublisher@1.3">
+            <reportTargets>
+                <htmlpublisher.HtmlPublisherTarget>
+                    <reportName>Error Report</reportName>
+                    <reportDir>server_apps/DB_maintenance/validatedata/Check-Sequence-Of-Reference-Drift_w</reportDir>
+                    <reportFiles>Check-Sequence-Of-Reference-Drift_w.html</reportFiles>
+                    <keepAll>false</keepAll>
+                    <allowMissing>false</allowMissing>
+                </htmlpublisher.HtmlPublisherTarget>
+            </reportTargets>
+        </htmlpublisher.HtmlPublisher>
+        <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@2.35.1">
+            <recipientList></recipientList>
+            <configuredTriggers>
+                <hudson.plugins.emailext.plugins.trigger.FailureTrigger>
+                    <email>
+                        <recipientList>@FAILURE-RECIPIENT-LIST@</recipientList>
+                        <subject>$PROJECT_DEFAULT_SUBJECT</subject>
+                        <body>
+                            ${FILE,path=&quot;server_apps/DB_maintenance/validatedata/Check-Sequence-Of-Reference-Drift_w/Check-Sequence-Of-Reference-Drift_w.html&quot;}
+                        </body>
+                        <sendToDevelopers>false</sendToDevelopers>
+                        <sendToRequester>false</sendToRequester>
+                        <includeCulprits>false</includeCulprits>
+                        <sendToRecipientList>true</sendToRecipientList>
+                        <attachmentsPattern></attachmentsPattern>
+                        <attachBuildLog>false</attachBuildLog>
+                        <compressBuildLog>false</compressBuildLog>
+                        <replyTo></replyTo>
+                        <contentType>text/html</contentType>
+                    </email>
+                </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
+                <hudson.plugins.emailext.plugins.trigger.UnstableTrigger>
+                    <email>
+                        <recipientList>@FAILURE-RECIPIENT-LIST@</recipientList>
+                        <subject>$PROJECT_DEFAULT_SUBJECT</subject>
+                        <body>
+                            ${FILE,path=&quot;server_apps/DB_maintenance/validatedata/Check-Sequence-Of-Reference-Drift_w/Check-Sequence-Of-Reference-Drift_w.html&quot;}
+
+                            See report on Jenkins dashboard: &lt;a href=&quot;${BUILD_URL}&quot;&gt;${BUILD_URL}&lt;/a&gt;
+                        </body>
+                        <sendToDevelopers>false</sendToDevelopers>
+                        <sendToRequester>false</sendToRequester>
+                        <includeCulprits>false</includeCulprits>
+                        <sendToRecipientList>true</sendToRecipientList>
+                        <attachmentsPattern></attachmentsPattern>
+                        <attachBuildLog>false</attachBuildLog>
+                        <compressBuildLog>false</compressBuildLog>
+                        <replyTo></replyTo>
+                        <contentType>text/html</contentType>
+                    </email>
+                </hudson.plugins.emailext.plugins.trigger.UnstableTrigger>
+                <hudson.plugins.emailext.plugins.trigger.AbortedTrigger>
+                    <email>
+                        <recipientList>@FAILURE-RECIPIENT-LIST@</recipientList>
+                        <subject>$PROJECT_DEFAULT_SUBJECT</subject>
+                        <body>
+                            ${FILE,path=&quot;server_apps/DB_maintenance/validatedata/Check-Sequence-Of-Reference-Drift_w/Check-Sequence-Of-Reference-Drift_w.html&quot;}
+
+                            See report on Jenkins dashboard (for aborted build): &lt;a href=&quot;${BUILD_URL}&quot;&gt;${BUILD_URL}&lt;/a&gt;
+                        </body>
+                        <sendToDevelopers>false</sendToDevelopers>
+                        <sendToRequester>false</sendToRequester>
+                        <includeCulprits>false</includeCulprits>
+                        <sendToRecipientList>true</sendToRecipientList>
+                        <attachmentsPattern></attachmentsPattern>
+                        <attachBuildLog>false</attachBuildLog>
+                        <compressBuildLog>false</compressBuildLog>
+                        <replyTo></replyTo>
+                        <contentType>text/html</contentType>
+                    </email>
+                </hudson.plugins.emailext.plugins.trigger.AbortedTrigger>
+            </configuredTriggers>
+            <contentType>default</contentType>
+            <defaultSubject>[Jenkins][${INSTANCE}]: ${PROJECT_NAME}: ${BUILD_STATUS}</defaultSubject>
+            <defaultContent>$DEFAULT_CONTENT</defaultContent>
+            <attachmentsPattern></attachmentsPattern>
+            <presendScript></presendScript>
+            <attachBuildLog>false</attachBuildLog>
+            <compressBuildLog>false</compressBuildLog>
+            <replyTo>${DB_OWNER}@zfin.org</replyTo>
+            <saveOutput>false</saveOutput>
+        </hudson.plugins.emailext.ExtendedEmailPublisher>
+    </publishers>
+    <buildWrappers>
+    </buildWrappers>
+</project>

--- a/source/org/zfin/infrastructure/ant/CheckSequenceOfReferenceDriftTask.java
+++ b/source/org/zfin/infrastructure/ant/CheckSequenceOfReferenceDriftTask.java
@@ -4,11 +4,8 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.Configurator;
-import org.hibernate.query.Query;
-import org.zfin.feature.Feature;
-import org.zfin.feature.FeatureGenomicMutationDetail;
+import org.hibernate.query.NativeQuery;
 import org.zfin.framework.HibernateUtil;
-import org.zfin.mapping.FeatureLocation;
 import org.zfin.mapping.GenomicLocationService;
 import org.zfin.sequence.gff.AssemblyEnum;
 
@@ -39,7 +36,6 @@ public class CheckSequenceOfReferenceDriftTask extends AbstractValidateDataRepor
         clearReportDirectory();
         setLoggerFile();
 
-        HibernateUtil.currentSession().beginTransaction();
         List<List<String>> mismatches = new ArrayList<>();
         List<String> errorMessages = new ArrayList<>();
         int examined = 0;
@@ -47,29 +43,45 @@ public class CheckSequenceOfReferenceDriftTask extends AbstractValidateDataRepor
         int skippedFasta = 0;
 
         try {
-            // Single HQL pass: every FGMD with a sequence of reference, joined to its
-            // Feature. We pull FeatureLocation separately via fl-on-feature criteria,
-            // since FeatureLocation isn't mapped as an association on Feature.
-            String hql = "from FeatureGenomicMutationDetail fgmd " +
-                    "where fgmd.fgmdSeqRef is not null " +
-                    "order by fgmd.feature.zdbID";
-            Query<FeatureGenomicMutationDetail> query = HibernateUtil.currentSession()
-                    .createQuery(hql, FeatureGenomicMutationDetail.class);
+            // Native projection — no Hibernate entity loading. Loading entities
+            // (FeatureGenomicMutationDetail with lazy associations) attached every
+            // row to the persistence context, and the session-close cascade walk
+            // ground the JVM to a halt over the full dataset.
+            String sql = "select fgmd.fgmd_feature_zdb_id, " +
+                    "       f.feature_abbrev, " +
+                    "       f.feature_type, " +
+                    "       sfcl.sfcl_assembly, " +
+                    "       sfcl.sfcl_chromosome, " +
+                    "       sfcl.sfcl_start_position, " +
+                    "       sfcl.sfcl_end_position, " +
+                    "       fgmd.fgmd_sequence_of_reference " +
+                    "  from feature_genomic_mutation_detail fgmd " +
+                    "  join feature f on f.feature_zdb_id = fgmd.fgmd_feature_zdb_id " +
+                    "  left join sequence_feature_chromosome_location sfcl " +
+                    "         on sfcl.sfcl_feature_zdb_id = fgmd.fgmd_feature_zdb_id " +
+                    " where fgmd.fgmd_sequence_of_reference is not null " +
+                    " order by fgmd.fgmd_feature_zdb_id";
 
+            NativeQuery<Object[]> query = HibernateUtil.currentSession().createNativeQuery(sql, Object[].class);
             GenomicLocationService glService = new GenomicLocationService();
 
-            for (FeatureGenomicMutationDetail fgmd : query.list()) {
+            for (Object[] row : query.list()) {
                 examined++;
-                Feature feature = fgmd.getFeature();
-                FeatureLocation fl = featureLocationFor(feature);
+                String featureZdbId = (String) row[0];
+                String featureAbbrev = (String) row[1];
+                String featureType = (String) row[2];
+                String assemblyName = (String) row[3];
+                String chromosome = (String) row[4];
+                Integer startLoc = row[5] != null ? ((Number) row[5]).intValue() : null;
+                Integer endLoc = row[6] != null ? ((Number) row[6]).intValue() : null;
+                String storedSeqRef = (String) row[7];
 
-                if (fl == null || fl.getStartLocation() == null || fl.getEndLocation() == null
-                        || fl.getAssembly() == null || fl.getChromosome() == null) {
+                if (assemblyName == null || chromosome == null || startLoc == null || endLoc == null) {
                     skippedNoCoords++;
                     continue;
                 }
 
-                AssemblyEnum assembly = assemblyFor(fl.getAssembly());
+                AssemblyEnum assembly = assemblyFor(assemblyName);
                 if (assembly == null) {
                     skippedFasta++;
                     continue;
@@ -78,42 +90,32 @@ public class CheckSequenceOfReferenceDriftTask extends AbstractValidateDataRepor
                 String expected;
                 try {
                     expected = new String(glService.getReferenceSequence(
-                            assembly,
-                            fl.getChromosome(),
-                            fl.getStartLocation(),
-                            fl.getEndLocation()).getBases()).toUpperCase();
+                            assembly, chromosome, startLoc, endLoc).getBases()).toUpperCase();
                 } catch (RuntimeException e) {
-                    // FASTA file missing for this assembly, chromosome not in the
-                    // index, or coordinates out of range — log + skip; not a
-                    // sequence-of-reference drift per se.
                     skippedFasta++;
-                    LOG.info("Skipping " + feature.getZdbID()
-                            + " (" + fl.getAssembly() + " " + fl.getChromosome() + ":"
-                            + fl.getStartLocation() + "-" + fl.getEndLocation()
+                    LOG.info("Skipping " + featureZdbId
+                            + " (" + assemblyName + " " + chromosome + ":" + startLoc + "-" + endLoc
                             + "): " + e.getMessage());
                     continue;
                 }
 
-                String stored = fgmd.getFgmdSeqRef().toUpperCase();
+                String stored = storedSeqRef.toUpperCase();
                 if (!expected.equals(stored)) {
-                    List<String> row = new ArrayList<>(9);
-                    row.add(feature.getZdbID());
-                    row.add(feature.getAbbreviation() == null ? "" : feature.getAbbreviation());
-                    row.add(feature.getType() == null ? "" : feature.getType().name());
-                    row.add(fl.getAssembly());
-                    row.add(fl.getChromosome());
-                    row.add(String.valueOf(fl.getStartLocation()));
-                    row.add(String.valueOf(fl.getEndLocation()));
-                    row.add(stored);
-                    row.add(expected);
-                    mismatches.add(row);
+                    List<String> outRow = new ArrayList<>(9);
+                    outRow.add(featureZdbId);
+                    outRow.add(featureAbbrev == null ? "" : featureAbbrev);
+                    outRow.add(featureType == null ? "" : featureType);
+                    outRow.add(assemblyName);
+                    outRow.add(chromosome);
+                    outRow.add(String.valueOf(startLoc));
+                    outRow.add(String.valueOf(endLoc));
+                    outRow.add(stored);
+                    outRow.add(expected);
+                    mismatches.add(outRow);
                 }
             }
-
-            HibernateUtil.currentSession().getTransaction().commit();
         } catch (Exception e) {
             LOG.error("Drift check failed", e);
-            HibernateUtil.rollbackTransaction();
             errorMessages.add(e.getClass().getSimpleName() + ": " + e.getMessage());
         } finally {
             HibernateUtil.closeSession();
@@ -126,15 +128,6 @@ public class CheckSequenceOfReferenceDriftTask extends AbstractValidateDataRepor
 
         createErrorReport(errorMessages, mismatches);
         return 0;
-    }
-
-    private FeatureLocation featureLocationFor(Feature feature) {
-        // Avoid pulling the whole repository; one targeted HQL.
-        List<FeatureLocation> matches = HibernateUtil.currentSession()
-                .createQuery("from FeatureLocation where feature.zdbID = :id", FeatureLocation.class)
-                .setParameter("id", feature.getZdbID())
-                .list();
-        return matches.isEmpty() ? null : matches.get(0);
     }
 
     private AssemblyEnum assemblyFor(String name) {

--- a/source/org/zfin/infrastructure/ant/CheckSequenceOfReferenceDriftTask.java
+++ b/source/org/zfin/infrastructure/ant/CheckSequenceOfReferenceDriftTask.java
@@ -1,0 +1,160 @@
+package org.zfin.infrastructure.ant;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.hibernate.query.Query;
+import org.zfin.feature.Feature;
+import org.zfin.feature.FeatureGenomicMutationDetail;
+import org.zfin.framework.HibernateUtil;
+import org.zfin.mapping.FeatureLocation;
+import org.zfin.mapping.GenomicLocationService;
+import org.zfin.sequence.gff.AssemblyEnum;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reports features whose stored Sequence of Reference (fgmd_sequence_of_reference)
+ * disagrees with the sequence computed live from the genome assembly FASTA at
+ * the feature's stored coordinates. Read-only — no DB updates.
+ *
+ * Wired via the validate-data-report-simple-java Ant target; designed to run as
+ * a Jenkins job. Tracks ZFIN-10280.
+ */
+public class CheckSequenceOfReferenceDriftTask extends AbstractValidateDataReportTask {
+
+    private static final Logger LOG = LogManager.getLogger(CheckSequenceOfReferenceDriftTask.class);
+
+    public CheckSequenceOfReferenceDriftTask(String jobName, String propertyFilePath, String dataDirectoryString) {
+        super(jobName, propertyFilePath, dataDirectoryString);
+    }
+
+    @Override
+    public int execute() {
+        Configurator.setAllLevels(LogManager.getRootLogger().getName(), Level.INFO);
+        LOG.info("Job Name: " + jobName);
+
+        clearReportDirectory();
+        setLoggerFile();
+
+        HibernateUtil.currentSession().beginTransaction();
+        List<List<String>> mismatches = new ArrayList<>();
+        List<String> errorMessages = new ArrayList<>();
+        int examined = 0;
+        int skippedNoCoords = 0;
+        int skippedFasta = 0;
+
+        try {
+            // Single HQL pass: every FGMD with a sequence of reference, joined to its
+            // Feature. We pull FeatureLocation separately via fl-on-feature criteria,
+            // since FeatureLocation isn't mapped as an association on Feature.
+            String hql = "from FeatureGenomicMutationDetail fgmd " +
+                    "where fgmd.fgmdSeqRef is not null " +
+                    "order by fgmd.feature.zdbID";
+            Query<FeatureGenomicMutationDetail> query = HibernateUtil.currentSession()
+                    .createQuery(hql, FeatureGenomicMutationDetail.class);
+
+            GenomicLocationService glService = new GenomicLocationService();
+
+            for (FeatureGenomicMutationDetail fgmd : query.list()) {
+                examined++;
+                Feature feature = fgmd.getFeature();
+                FeatureLocation fl = featureLocationFor(feature);
+
+                if (fl == null || fl.getStartLocation() == null || fl.getEndLocation() == null
+                        || fl.getAssembly() == null || fl.getChromosome() == null) {
+                    skippedNoCoords++;
+                    continue;
+                }
+
+                AssemblyEnum assembly = assemblyFor(fl.getAssembly());
+                if (assembly == null) {
+                    skippedFasta++;
+                    continue;
+                }
+
+                String expected;
+                try {
+                    expected = new String(glService.getReferenceSequence(
+                            assembly,
+                            fl.getChromosome(),
+                            fl.getStartLocation(),
+                            fl.getEndLocation()).getBases()).toUpperCase();
+                } catch (RuntimeException e) {
+                    // FASTA file missing for this assembly, chromosome not in the
+                    // index, or coordinates out of range — log + skip; not a
+                    // sequence-of-reference drift per se.
+                    skippedFasta++;
+                    LOG.info("Skipping " + feature.getZdbID()
+                            + " (" + fl.getAssembly() + " " + fl.getChromosome() + ":"
+                            + fl.getStartLocation() + "-" + fl.getEndLocation()
+                            + "): " + e.getMessage());
+                    continue;
+                }
+
+                String stored = fgmd.getFgmdSeqRef().toUpperCase();
+                if (!expected.equals(stored)) {
+                    List<String> row = new ArrayList<>(9);
+                    row.add(feature.getZdbID());
+                    row.add(feature.getAbbreviation() == null ? "" : feature.getAbbreviation());
+                    row.add(feature.getType() == null ? "" : feature.getType().name());
+                    row.add(fl.getAssembly());
+                    row.add(fl.getChromosome());
+                    row.add(String.valueOf(fl.getStartLocation()));
+                    row.add(String.valueOf(fl.getEndLocation()));
+                    row.add(stored);
+                    row.add(expected);
+                    mismatches.add(row);
+                }
+            }
+
+            HibernateUtil.currentSession().getTransaction().commit();
+        } catch (Exception e) {
+            LOG.error("Drift check failed", e);
+            HibernateUtil.rollbackTransaction();
+            errorMessages.add(e.getClass().getSimpleName() + ": " + e.getMessage());
+        } finally {
+            HibernateUtil.closeSession();
+        }
+
+        LOG.info("Examined " + examined + " FGMD rows; "
+                + mismatches.size() + " mismatches; "
+                + skippedNoCoords + " skipped (no usable coords); "
+                + skippedFasta + " skipped (FASTA unavailable / out-of-range)");
+
+        createErrorReport(errorMessages, mismatches);
+        return 0;
+    }
+
+    private FeatureLocation featureLocationFor(Feature feature) {
+        // Avoid pulling the whole repository; one targeted HQL.
+        List<FeatureLocation> matches = HibernateUtil.currentSession()
+                .createQuery("from FeatureLocation where feature.zdbID = :id", FeatureLocation.class)
+                .setParameter("id", feature.getZdbID())
+                .list();
+        return matches.isEmpty() ? null : matches.get(0);
+    }
+
+    private AssemblyEnum assemblyFor(String name) {
+        for (AssemblyEnum ae : AssemblyEnum.values()) {
+            if (ae.getName().equals(name)) {
+                return ae;
+            }
+        }
+        return null;
+    }
+
+    public static void main(String[] args) {
+        String instance = args[0];
+        String jobName = args[1];
+        String directory = args[2];
+        String propertyFilePath = args[3];
+        CheckSequenceOfReferenceDriftTask task = new CheckSequenceOfReferenceDriftTask(
+                jobName, propertyFilePath, directory);
+        task.setInstance(instance);
+        task.initDatabase();
+        System.exit(task.execute());
+    }
+}


### PR DESCRIPTION
## Summary

Adds a read-only weekly validation report for [ZFIN-10280](https://zfin.atlassian.net/browse/ZFIN-10280): compares each feature's stored `fgmd_sequence_of_reference` against the sequence computed live from the assembly FASTA at the feature's stored coordinates, and reports any mismatch. No DB writes.

This is the report-only first pass per the discussion. Once we look at the actual mismatch set and compare it to the 185-row report Ryan attached on the ticket, we can decide whether to flip to auto-update or to hand-curate.

## What's in the PR

- `source/org/zfin/infrastructure/ant/CheckSequenceOfReferenceDriftTask.java` — iterates every `FeatureGenomicMutationDetail` with a non-null `fgmdSeqRef`, joins to its `FeatureLocation`, calls `GenomicLocationService.getReferenceSequence(...)`, and records mismatches as report rows. Skips features whose assembly FASTA isn't present in the environment (logs and continues — so e.g. test-with-GRCz11-only doesn't crash).
- `server_apps/DB_maintenance/build.xml` — new `check-sequence-of-reference-drift` Ant target that hands the job over to the standard validate-data report writer.
- `server_apps/DB_maintenance/validatedata/report.properties` — `errorMessage` + `headerColumns` entries for the report template.
- `server_apps/jenkins/jobs/Check-Sequence-Of-Reference-Drift_w/config.xml` — Jenkins job (weekly cadence implied by the `_w` suffix). The trigger `<spec>` is empty for now — turn it on after a sanity-check run on test.

## Report columns

| Feature ID | Feature Abbreviation | Feature Type | Assembly | Chromosome | Start | End | Stored Sequence of Reference | Calculated (FASTA) Sequence |

## Test plan
- [ ] Trigger the job manually on test once a build is up.
- [ ] Confirm the HTML report writes to `server_apps/DB_maintenance/validatedata/Check-Sequence-Of-Reference-Drift_w/`.
- [ ] Cross-check the mismatch count and rows against the existing 185-row report attached to ZFIN-10280.
- [ ] Sanity-check a few rows by hand (one that should mismatch, one that shouldn't) to confirm the comparison and the column values.
- [ ] Once happy, set the Jenkins trigger spec (e.g. `H H * * 0` for weekly) so the report runs unattended.

## Follow-ups (not in this PR)
- Decide between auto-update vs. curator workflow once the mismatch set is reviewed.
- Optional: add the per-feature "Recalculate Sequence of Reference" button Ryan suggested, as a separate small PR.

[ZFIN-10280]: https://zfin.atlassian.net/browse/ZFIN-10280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ