### PR TITLE
ZFIN-10296: add Apache URL map for ZDB-LINESUBMISSION

### DIFF
--- a/server_apps/apache/view-page-url-map.txt
+++ b/server_apps/apache/view-page-url-map.txt
@@ -55,6 +55,7 @@ GTCONSTRCT	/action/marker/construct/view/ZDB-GTCONSTRCT
 JRNL    /action/publication/journal/ZDB-JRNL
 IMAGE    /action/image/view/ZDB-IMAGE
 LAB	/action/profile/view/ZDB-LAB
+LINESUBMISSION	/action/zirc/line-submission/ZDB-LINESUBMISSION
 LINK /action/mapping/linkage/ZDB-LINK
 MRPHLNO	/action/marker/str/view/ZDB-MRPHLNO
 NBO	/action/ontology/term/NBO


### PR DESCRIPTION
## Summary

Adds the Apache URL map entry for `ZDB-LINESUBMISSION` per [ZFIN-10296](https://zfin.atlassian.net/browse/ZFIN-10296), so URLs of the form `zfin.org/ZDB-LINESUBMISSION-YYMMDD-N` get rewritten to the existing `ZircDashboardController` detail endpoint.

```diff
+LINESUBMISSION  /action/zirc/line-submission/ZDB-LINESUBMISSION
```

## Notes
- The destination URL (`/action/zirc/line-submission/{zdbID}`) is provided by `ZircDashboardController` on the `zirc-submission-form` branch (ZFIN-10264..10268). Until that branch is merged the rewrite target 404s — the entry can land independently because the URL-map only affects the Apache prefix routing, not whether the destination exists.
- The whole `/action/zirc/**` subtree requires authentication (ZFIN-10219 / security.xml `intercept-url`), so unauthenticated hits to the short URL will land on the login redirect like every other curator endpoint.

## Test plan
- [ ] Once deployed, `curl -I https://zfin.org/ZDB-LINESUBMISSION-260513-1` returns a 200/302 routed via `/action/zirc/line-submission/...` (rather than the generic 404).
- [ ] After `zirc-submission-form` is merged, browse to a real ZDB-LINESUBMISSION ID short URL and confirm it renders the detail page.

[ZFIN-10296]: https://zfin.atlassian.net/browse/ZFIN-10296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ