### PR TITLE
ZFIN-10290: propagate construct edit validation errors to curator

### DIFF
--- a/source/org/zfin/construct/presentation/ConstructEditController.java
+++ b/source/org/zfin/construct/presentation/ConstructEditController.java
@@ -85,15 +85,27 @@ public class ConstructEditController {
     ConstructUpdateResult updateConstruct(@PathVariable String constructID,
                            @RequestBody EditConstructFormFields request) throws Exception{
 
+        try {
+            HibernateUtil.createTransaction();
 
-        HibernateUtil.createTransaction();
+            constructEditService.updateConstruct(constructID, request);
+            Marker newMarker = mr.getMarkerByID(constructID);
 
-        constructEditService.updateConstruct(constructID, request);
-        Marker newMarker = mr.getMarkerByID(constructID);
+            HibernateUtil.flushAndCommitCurrentSession();
 
-        HibernateUtil.flushAndCommitCurrentSession();
-
-        return new ConstructUpdateResult(newMarker.getZdbID() + " saved as " + newMarker.getName(), newMarker.getZdbID(), true);
+            return new ConstructUpdateResult(newMarker.getZdbID() + " saved as " + newMarker.getName(), newMarker.getZdbID(), true);
+        } catch (Exception e) {
+            try {
+                HibernateUtil.rollbackTransaction();
+            } catch (HibernateException he) {
+                logger.error("Error during roll back of transaction", he);
+            }
+            logger.error("Error in Transaction", e);
+            if (e instanceof InvalidConstructNameException) {
+                return new ConstructUpdateResult(e.getMessage(), null, false);
+            }
+            return new ConstructUpdateResult("Construct could not be updated", null, false);
+        }
     }
 
 //    /action/construct/create-and-update


### PR DESCRIPTION
Wrap updateConstruct in try/catch mirroring createAndUpdate so InvalidConstructNameException returns its message in ConstructUpdateResult instead of falling through to the global handler's HTML 500 page, which the frontend could not parse as JSON. Also rolls back the transaction on failure.