### PR TITLE
ZFIN-10294 & ZFIN-10295: Add login option to captcha challenge; preserve redirect through login

### DIFF
--- a/home/WEB-INF/jsp/infrastructure/captcha-altcha-challenge.jsp
+++ b/home/WEB-INF/jsp/infrastructure/captcha-altcha-challenge.jsp
@@ -19,7 +19,7 @@
                     </p>
 
                     <form id="captcha-form" method="post" action="/action/captcha/challenge">
-                        <input type="hidden" name="redirect" value="${captchaRedirect}"/>
+                        <input type="hidden" name="redirect" value="${fn:escapeXml(captchaRedirect)}"/>
                         <altcha-widget
                                 challengeurl="/action/altcha/challenge"
                         ></altcha-widget>
@@ -27,6 +27,15 @@
                             <button type="submit" class="btn btn-primary">Submit</button>
                         </div>
                     </form>
+
+                    <hr/>
+                    <p class="mb-2">Have a ZFIN account? You can sign in instead to skip the verification.</p>
+                    <c:url var="loginUrl" value="/action/login">
+                        <c:if test="${not empty captchaRedirect}">
+                            <c:param name="redirect" value="${captchaRedirect}"/>
+                        </c:if>
+                    </c:url>
+                    <a class="btn btn-outline-secondary" href="${loginUrl}">Log in</a>
                 </div>
             </div>
         </div>

--- a/home/WEB-INF/jsp/infrastructure/captcha-altcha-challenge.jsp
+++ b/home/WEB-INF/jsp/infrastructure/captcha-altcha-challenge.jsp
@@ -8,14 +8,14 @@
         <div class="row justify-content-center">
             <div class="col-md-6">
                 <div style="display: none;" class="captcha-challenge p-4 border rounded shadow">
-                    <h3>zfin.org</h3>
-                    <p>Running verification to filter robot traffic.</p>
+                    <div class="text-center mb-3">
+                        <a href="/"><img src="/images/zfinlogo_lg.gif" alt="ZFIN" style="max-height: 48px;"></a>
+                    </div>
+                    <h3>Verify you're human</h3>
+                    <p>ZFIN is experiencing heavy traffic right now. To keep the site fast for our community of researchers, we need a quick check to confirm you're not a bot.</p>
 
-                    <p>Our site is experiencing large amounts of traffic right now.
-                        To ensure our community of researchers get the best experience, we need to make sure you are human.</p>
-
-                    <p>Please let us know if you experience any problems while we work to address this problem.<br/>
-                        <a href="https://wiki.zfin.org/display/general/ZFIN+Contact+Information">Contact Information</a>.
+                    <p class="small text-muted">
+                        Having trouble? <a href="https://wiki.zfin.org/display/general/ZFIN+Contact+Information">Let us know</a>.
                     </p>
 
                     <form id="captcha-form" method="post" action="/action/captcha/challenge">
@@ -24,18 +24,17 @@
                                 challengeurl="/action/altcha/challenge"
                         ></altcha-widget>
                         <div class="mb-3 mt-3">
-                            <button type="submit" class="btn btn-primary">Submit</button>
+                            <button type="submit" id="captcha-submit" class="btn btn-primary" disabled>Submit</button>
                         </div>
                     </form>
 
                     <hr/>
-                    <p class="mb-2">Have a ZFIN account? You can sign in instead to skip the verification.</p>
                     <c:url var="loginUrl" value="/action/login">
                         <c:if test="${not empty captchaRedirect}">
                             <c:param name="redirect" value="${captchaRedirect}"/>
                         </c:if>
                     </c:url>
-                    <a class="btn btn-outline-secondary" href="${loginUrl}">Log in</a>
+                    <p class="mb-0 small text-muted">Have a ZFIN account? <a href="${loginUrl}">Sign in</a> to skip the verification.</p>
                 </div>
             </div>
         </div>
@@ -47,10 +46,19 @@
     <link rel="stylesheet" href="${zfn:getAssetPath("bootstrap.css")}">
 
     <script>
-        // Ensure the body is visible after the CSS has been loaded
         window.onload = function() {
-            const div = document.querySelector(".captcha-challenge");
-            div.style.display = 'block';
+            document.querySelector(".captcha-challenge").style.display = 'block';
+
+            const widget = document.querySelector('altcha-widget');
+            const submitBtn = document.getElementById('captcha-submit');
+            if (widget && submitBtn) {
+                widget.addEventListener('statechange', (ev) => {
+                    submitBtn.disabled = ev.detail.state !== 'verified';
+                });
+                widget.addEventListener('expired', () => {
+                    submitBtn.disabled = true;
+                });
+            }
         };
     </script>
 

--- a/home/WEB-INF/jsp/login_form.jsp
+++ b/home/WEB-INF/jsp/login_form.jsp
@@ -22,6 +22,9 @@
         <form id="login" name="login" action="/action/j_security-check" method="POST" accept-charset="UTF-8">
             <input type='hidden' name='_spring_security_remember_me' value="true"/>
             <input type="hidden" name="page" value="Main"/>
+            <c:if test="${not empty param.redirect}">
+                <input type="hidden" name="redirect" value="${fn:escapeXml(param.redirect)}"/>
+            </c:if>
             <div class="form-group">
                 <label for="username">Username</label>
                 <input type="text" class="form-control" name="username" id="username">

--- a/home/WEB-INF/spring/security.xml
+++ b/home/WEB-INF/spring/security.xml
@@ -15,6 +15,7 @@
 
     <bean id="apgAuthenticationSuccessHandler" class="org.zfin.security.ApgAuthenticationSuccessHandler">
         <property name="sessionRegistry" ref="sessionRegistry"/>
+        <property name="targetUrlParameter" value="redirect"/>
     </bean>
 
     <bean id="userDetailsService" class="org.zfin.security.UserDetailServiceImpl"/>

--- a/home/WEB-INF/tags/layout/pageHeader.tag
+++ b/home/WEB-INF/tags/layout/pageHeader.tag
@@ -322,7 +322,7 @@
             if (!link) return;
             var here = window.location.pathname + window.location.search + window.location.hash;
             // Skip on the auth pages themselves to avoid redirect loops.
-            if (/^\/action\/(login|logout|j_security-check|expired-password)/.test(window.location.pathname)) return;
+            if (/^\/action\/(login|logout|j_security-check|profile\/expired-password)/.test(window.location.pathname)) return;
             link.href = '/action/login?redirect=' + encodeURIComponent(here);
         })();
     </script>

--- a/home/WEB-INF/tags/layout/pageHeader.tag
+++ b/home/WEB-INF/tags/layout/pageHeader.tag
@@ -307,10 +307,23 @@
                 </c:when>
                 <c:otherwise>
                     <li class="no-border">
-                        <a href="/action/login">Sign In</a>
+                        <a href="/action/login" data-zfin-signin-link>Sign In</a>
                     </li>
                 </c:otherwise>
             </c:choose>
         </ul>
     </div>
+    <script>
+        // Add the current page URL as a redirect param to the Sign In link so the user
+        // returns here after logging in. If JS is disabled, the bare /action/login href
+        // still works (user just lands on the default page after login).
+        (function () {
+            var link = document.querySelector('a[data-zfin-signin-link]');
+            if (!link) return;
+            var here = window.location.pathname + window.location.search + window.location.hash;
+            // Skip on the auth pages themselves to avoid redirect loops.
+            if (/^\/action\/(login|logout|j_security-check)/.test(window.location.pathname)) return;
+            link.href = '/action/login?redirect=' + encodeURIComponent(here);
+        })();
+    </script>
 </header>

--- a/home/WEB-INF/tags/layout/pageHeader.tag
+++ b/home/WEB-INF/tags/layout/pageHeader.tag
@@ -322,7 +322,7 @@
             if (!link) return;
             var here = window.location.pathname + window.location.search + window.location.hash;
             // Skip on the auth pages themselves to avoid redirect loops.
-            if (/^\/action\/(login|logout|j_security-check)/.test(window.location.pathname)) return;
+            if (/^\/action\/(login|logout|j_security-check|expired-password)/.test(window.location.pathname)) return;
             link.href = '/action/login?redirect=' + encodeURIComponent(here);
         })();
     </script>

--- a/source/org/zfin/framework/presentation/LoginController.java
+++ b/source/org/zfin/framework/presentation/LoginController.java
@@ -1,9 +1,12 @@
 package org.zfin.framework.presentation;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Simple controller that serves the developers home page.
@@ -26,6 +29,12 @@ public class LoginController {
         // that's why we check both cases.
         if (accessDenied != null || (queryString != null && queryString.startsWith(ACCESS_DENIED)))
             return "access_denied";
+
+        String redirect = request.getParameter("redirect");
+        if (StringUtils.isNotEmpty(redirect)) {
+            return "redirect:/action/login-redirect?redirect="
+                    + URLEncoder.encode(redirect, StandardCharsets.UTF_8);
+        }
         return "redirect:/action/login-redirect";
     }
 

--- a/source/org/zfin/security/ApgAuthenticationSuccessHandler.java
+++ b/source/org/zfin/security/ApgAuthenticationSuccessHandler.java
@@ -100,4 +100,31 @@ public class ApgAuthenticationSuccessHandler extends SavedRequestAwareAuthentica
         this.sessionRegistry = sessionRegistry;
     }
 
+    @Override
+    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response) {
+        String url = super.determineTargetUrl(request, response);
+        if (!isLocalUrl(url, request)) {
+            return getDefaultTargetUrl();
+        }
+        return url;
+    }
+
+    private static boolean isLocalUrl(String url, HttpServletRequest request) {
+        // Prevent open redirects via the targetUrlParameter. Accept either a site-relative
+        // path or an absolute URL whose host matches the current request's host.
+        if (url == null) {
+            return false;
+        }
+        if (url.startsWith("/") && !url.startsWith("//") && !url.startsWith("/\\")) {
+            return true;
+        }
+        try {
+            java.net.URI uri = java.net.URI.create(url);
+            String host = uri.getHost();
+            return host != null && host.equalsIgnoreCase(request.getServerName());
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
 }

--- a/source/org/zfin/security/MigratingAuthenticationFailureHandler.java
+++ b/source/org/zfin/security/MigratingAuthenticationFailureHandler.java
@@ -1,16 +1,17 @@
 package org.zfin.security;
 
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.zfin.framework.featureflag.FeatureFlagEnum;
-import org.zfin.framework.featureflag.FeatureFlags;
-import org.zfin.profile.service.ProfileService;
-
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.zfin.profile.service.ProfileService;
+
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 public class MigratingAuthenticationFailureHandler
         extends SimpleUrlAuthenticationFailureHandler {
@@ -23,21 +24,24 @@ public class MigratingAuthenticationFailureHandler
             AuthenticationException exception)
             throws IOException, ServletException {
 
-        handleRedirectForExpiredPassword(request);
-        super.onAuthenticationFailure(request, response, exception);
-
+        // Determine the failure URL per-request rather than mutating the shared
+        // defaultFailureUrl field, which would race across concurrent failed logins.
+        String failureUrl = determineFailureUrl(request);
+        saveException(request, exception);
+        getRedirectStrategy().sendRedirect(request, response, failureUrl);
     }
 
-    /**
-     * If the user's password has expired, redirect them to the change password page.
-     */
-    private void handleRedirectForExpiredPassword(HttpServletRequest request) {
+    private String determineFailureUrl(HttpServletRequest request) {
         String username = request.getParameter(UsernamePasswordAuthenticationFilter.SPRING_SECURITY_FORM_USERNAME_KEY);
         if (ProfileService.isPasswordDeprecatedFor(username)) {
             request.getSession().setAttribute(LAST_USERNAME_ATTEMPTED, username);
-            setDefaultFailureUrl("/action/profile/expired-password");
-        } else {
-            setDefaultFailureUrl("/action/login-redirect?error=true");
+            return "/action/profile/expired-password";
         }
+        String redirect = request.getParameter("redirect");
+        if (StringUtils.isNotEmpty(redirect)) {
+            return "/action/login-redirect?error=true&redirect="
+                    + URLEncoder.encode(redirect, StandardCharsets.UTF_8);
+        }
+        return "/action/login-redirect?error=true";
     }
 }


### PR DESCRIPTION
Logged-in users bypass the captcha. Give visitors a way out without solving altcha by adding a "Log in" button to the challenge page that carries the original URL through the login flow and back.

To make redirect-after-login work generally, also rewrite the header "Sign In" link client-side to include the current page URL, so signing in from any page returns the user to that page.

The redirect parameter flows: link/button -> /action/login -> login form hidden input -> j_security-check -> success handler. Wire it up by:

  - LoginController: forward redirect when bouncing /login -> /login-redirect
  - login_form.jsp: render hidden redirect input from param
  - security.xml: set targetUrlParameter=redirect on success handler
  - ApgAuthenticationSuccessHandler: override determineTargetUrl to reject anything that isn't a site-relative path or same-host URL, closing the open-redirect vector the targetUrlParameter would otherwise expose
  - MigratingAuthenticationFailureHandler: preserve redirect on failure so a retry still lands on the original page, and stop mutating the shared defaultFailureUrl field (the previous setDefaultFailureUrl pattern raced across concurrent failed logins)