### PR TITLE
ZFIN-10298: hide emails from search and block Community downloads

### DIFF
--- a/home/WEB-INF/tags/personList.tag
+++ b/home/WEB-INF/tags/personList.tag
@@ -46,9 +46,6 @@
                     </authz:authorize>
                 </td>
                 <td>
-                    <c:if test="${!empty person.email && person.emailPrivacyPreference.visible}">
-                        <div><a href="mailto:${person.email}">${person.email}</a></div>
-                    </c:if>
                     <c:if test="${!empty person.address}">
                         <div class="postal-address">${person.address}</div>
                     </c:if>

--- a/home/WEB-INF/tags/search/communityResultTable.tag
+++ b/home/WEB-INF/tags/search/communityResultTable.tag
@@ -3,7 +3,6 @@
 <%@ include file="/WEB-INF/jsp-include/tag-import.jsp" %>
 
 <%@attribute name="results" required="true" type="java.util.List" %>
-<c:set var="emailAttribute" value="${ResultService.EMAIL}"/>
 <c:set var="addressAttribute" value="${ResultService.ADDRESS}"/>
 <c:set var="lineDesigAttribute" value="${ResultService.LINE_DESIGNATION}"/>
 
@@ -11,7 +10,6 @@
     <c:when test="${fn:contains(result.id, 'PERS')}">
 <table class="table-results searchresults" style="display: none;">
     <th>Name</th>
-    <th>Email</th>
     <th>Address</th>
     <th>Image</th>
     <th>ZDB ID</th>
@@ -19,11 +17,6 @@
     <c:forEach var="result" items="${results}" varStatus="loop">
         <zfin:alternating-tr loopName="loop" groupBeanCollection="${results}" groupByBean="id">
             <td>${result.link}</td>
-
-            <td>${result.attributes[emailAttribute]}</td>
-
-
-
 
             <td style="word-wrap: break-word">${result.attributes[addressAttribute]}</td>
             <td>
@@ -41,7 +34,6 @@
 <c:otherwise>
     <table class="table-results searchresults" style="display: none;">
         <th>Name</th>
-        <th>Email</th>
         <th>Address</th>
         <th>Image</th>
         <th>Line Designation</th>
@@ -50,11 +42,6 @@
         <c:forEach var="result" items="${results}" varStatus="loop">
             <zfin:alternating-tr loopName="loop" groupBeanCollection="${results}" groupByBean="id">
                 <td>${result.link}</td>
-
-                <td>${result.attributes[emailAttribute]}</td>
-
-
-
 
                 <td style="word-wrap: break-word">${result.attributes[addressAttribute]}</td>
                 <td>

--- a/source/org/zfin/search/presentation/SearchPrototypeController.java
+++ b/source/org/zfin/search/presentation/SearchPrototypeController.java
@@ -358,7 +358,7 @@ public class SearchPrototypeController {
         }
         model.addAttribute("rowsUrlSeparator", rowsUrlSeparator);
         model.addAttribute("rows", rows);
-        model.addAttribute("allowDownload", solrService.allowDownload(q, filterQuery));
+        model.addAttribute("allowDownload", solrService.allowDownload(q, filterQuery, category));
         model.addAttribute("downloadUrl", baseUrl.replaceAll("^/search", "/action/quicksearch/download"));
 
         paginationBean.setPage(page.toString());
@@ -601,7 +601,9 @@ public class SearchPrototypeController {
                                 HttpServletResponse response,
                                 HttpServletRequest request) {
 
-        if (!solrService.allowDownload(q, filterQuery)) {
+        category = getCategory(filterQuery, category);
+
+        if (!solrService.allowDownload(q, filterQuery, category)) {
             try {
                 response.sendError(403);
                 return;
@@ -614,8 +616,6 @@ public class SearchPrototypeController {
         response.setHeader("Content-Disposition", "attachment; filename=\"zfin_search_results.csv\"");
 
         SolrQuery query = new SolrQuery();
-
-        category = getCategory(filterQuery, category);
 
         if (StringUtils.isNotEmpty(category) && !category.equals("Any")) {
             query.addFilterQuery("category:\"" + category + "\"");

--- a/source/org/zfin/search/presentation/SearchResult.java
+++ b/source/org/zfin/search/presentation/SearchResult.java
@@ -10,14 +10,10 @@ import org.springframework.util.CollectionUtils;
 import org.zfin.expression.Figure;
 import org.zfin.fish.FeatureGene;
 import org.zfin.framework.presentation.ProvidesLink;
-import org.zfin.profile.Lab;
-import org.zfin.profile.Person;
 import org.zfin.search.Category;
 
 import java.util.*;
 import java.util.stream.Collectors;
-
-import static org.zfin.repository.RepositoryFactory.getProfileRepository;
 
 /*
  * This should match the fl parameter set as default in solrconfig
@@ -160,22 +156,12 @@ public class SearchResult implements ProvidesLink {
     }
 
     /**
-     * Returns true if a field should be hidden. Currently only email addresses are considered (for person or lab).
-     * @param field the field name from solr highlights map
-     * @return true if we should hide the highlight, otherwise false
+     * Returns true if a field should be hidden. Email addresses are always hidden from
+     * Person and Lab search results — see ZFIN-10298.
      */
     private boolean shouldFieldBeHidden(String field) {
-        if (SOLR_EMAIL_FIELD.equals(field) && getType().equals("Person")) {
-            Person person = getProfileRepository().getPerson(this.getId());
-            if (person.getEmailPrivacyPreference().isHidden()) {
-                return true;
-            }
-        }
-        if (SOLR_EMAIL_FIELD.equals(field) && getType().equals("Lab")) {
-            Lab lab = getProfileRepository().getLabById(this.getId());
-            if (lab.getEmailPrivacyPreference().isHidden()) {
-                return true;
-            }
+        if (SOLR_EMAIL_FIELD.equals(field) && ("Person".equals(getType()) || "Lab".equals(getType()))) {
+            return true;
         }
         return false;
     }

--- a/source/org/zfin/search/service/ResultService.java
+++ b/source/org/zfin/search/service/ResultService.java
@@ -71,7 +71,6 @@ public class ResultService {
     public static String CONSTRUCT = "Construct:";
     public static String EFG_NAME = "Engineered Foreign Gene Name:";
     public static String EISSN = "eISSN:";
-    public static String EMAIL = "Email:";
     public static String EXPRESSION = "Expression:";
     public static String FISH = "Fish:";
     public static String GENE = "Gene:";
@@ -475,10 +474,6 @@ public class ResultService {
         Person person = RepositoryFactory.getProfileRepository().getPerson(result.getId());
 
         if (person != null) {
-            if (person.getEmailPrivacyPreference().isVisible()) {
-                result.addAttribute(EMAIL, person.getEmail());
-            }
-
             if (StringUtils.isNotEmpty(person.getAddress())) {
                 result.addAttribute(ADDRESS, "<span class=\"result-street-address\">" + person.getAddress() + "</span>");
             }

--- a/source/org/zfin/search/service/SolrService.java
+++ b/source/org/zfin/search/service/SolrService.java
@@ -949,7 +949,11 @@ public class SolrService {
 
     }
 
-    public boolean allowDownload(String q, String[] filterQuery) {
+    public boolean allowDownload(String q, String[] filterQuery, String category) {
+        if (Category.COMMUNITY.getName().equals(category)) {
+            return false;
+        }
+
         if (q != null && StringUtils.isNotEmpty(q.trim()) && !StringUtils.equals(q,"*:*")) {
             return true;
         }


### PR DESCRIPTION
Stop the Faceted search from exposing email addresses:
- Refuse the Community CSV download (hide button + 403 the endpoint).
- Drop the Email attribute and column from Person search results and the community results table view.
- Always suppress the Email Address Solr highlight on Person/Lab hits.
- Drop the email cell from the person search results tag.