### PR TITLE
ZFIN-10222 map Ensembl biotype to ZFIN transcript type

### DIFF
--- a/source/org/zfin/sequence/load/EnsemblTranscriptFastaReadProcess.java
+++ b/source/org/zfin/sequence/load/EnsemblTranscriptFastaReadProcess.java
@@ -122,11 +122,11 @@ public class EnsemblTranscriptFastaReadProcess extends EnsemblTranscriptBase {
         Map<String, TranscriptType.Type> m = new HashMap<>();
         // Protein-coding (and coding variants Ensembl tags separately)
         m.put("protein_coding",                       MRNA);
-        // retained_intron: per Sridhar (ZFIN-9472) these should be ncRNA;
-        // a future ticket will add "retained intron" as an annotation status.
+        // retained_intron / nonsense_mediated_decay / non_stop_decay:
+        // per Sridhar (ZFIN-10222 review) all three should be ncRNA.
         m.put("retained_intron",                      NCRNA);
-        m.put("nonsense_mediated_decay",              MRNA);
-        m.put("non_stop_decay",                       MRNA);
+        m.put("nonsense_mediated_decay",              NCRNA);
+        m.put("non_stop_decay",                       NCRNA);
         m.put("IG_C_gene",                            MRNA);
         m.put("TR_J_gene",                            MRNA);
         m.put("TR_V_gene",                            MRNA);

--- a/source/org/zfin/sequence/load/EnsemblTranscriptFastaReadProcess.java
+++ b/source/org/zfin/sequence/load/EnsemblTranscriptFastaReadProcess.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 import static java.util.stream.Collectors.joining;
 import static org.zfin.framework.services.VocabularyEnum.TRANSCRIPT_ANNOTATION_METHOD;
 import static org.zfin.marker.Marker.Type.TSCRIPT;
-import static org.zfin.marker.TranscriptType.Type.MRNA;
+import static org.zfin.marker.TranscriptType.Type.*;
 import static org.zfin.repository.RepositoryFactory.*;
 import static org.zfin.sequence.DisplayGroup.GroupName.DISPLAYED_NUCLEOTIDE_SEQUENCE;
 import static org.zfin.sequence.load.EnsemblLoadAction.HTTPS_WWW_ENSEMBL_ORG_DANIO_RERIO_GENE_SUMMARY_G;
@@ -103,8 +103,76 @@ public class EnsemblTranscriptFastaReadProcess extends EnsemblTranscriptBase {
 
     private List<RichSequence> sequenceListToBeGenerated = new ArrayList<>();
 
+    /**
+     * Ensembl biotype → ZFIN TranscriptType.Type. Populated for every biotype
+     * currently present in {@code transcript_ensembl_name}. Unmapped biotypes
+     * cause the loader to skip the transcript with a warning (ZFIN-10222).
+     *
+     * Curator-reviewed groupings:
+     *   - protein-coding & coding-pseudogene-decay variants → mRNA
+     *   - Mt_rRNA, rRNA                                     → rRNA
+     *   - Mt_tRNA                                           → tRNA
+     *   - miRNA / snRNA / snoRNA / scaRNA                   → miRNA / snRNA / snoRNA / snoRNA
+     *   - lincRNA, antisense                                → lincRNA / antisense
+     *   - miscellaneous non-coding                          → ncRNA
+     *   - all *_pseudogene flavours                         → pseudogenic transcript
+     */
+    static final Map<String, TranscriptType.Type> BIOTYPE_TO_ZFIN_TYPE;
+    static {
+        Map<String, TranscriptType.Type> m = new HashMap<>();
+        // Protein-coding (and coding variants Ensembl tags separately)
+        m.put("protein_coding",                       MRNA);
+        // retained_intron: per Sridhar (ZFIN-9472) these should be ncRNA;
+        // a future ticket will add "retained intron" as an annotation status.
+        m.put("retained_intron",                      NCRNA);
+        m.put("nonsense_mediated_decay",              MRNA);
+        m.put("non_stop_decay",                       MRNA);
+        m.put("IG_C_gene",                            MRNA);
+        m.put("TR_J_gene",                            MRNA);
+        m.put("TR_V_gene",                            MRNA);
+        m.put("TR_D_gene",                            MRNA);
+        // rRNA (incl. mitochondrial)
+        m.put("rRNA",                                 RRNA);
+        m.put("Mt_rRNA",                              RRNA);
+        // tRNA (mitochondrial; Ensembl doesn't ship a plain tRNA biotype)
+        m.put("Mt_tRNA",                              TRNA);
+        // Small RNAs
+        m.put("miRNA",                                MIRNA);
+        m.put("snRNA",                                SNRNA);
+        m.put("snoRNA",                               SNORNA);
+        m.put("scaRNA",                               SNORNA);
+        // Long non-coding
+        m.put("lincRNA",                              LINCRNA);
+        m.put("antisense",                            ANTISENSE);
+        // Miscellaneous non-coding
+        m.put("misc_RNA",                             NCRNA);
+        m.put("sRNA",                                 NCRNA);
+        m.put("sense_intronic",                       NCRNA);
+        m.put("sense_overlapping",                    NCRNA);
+        m.put("processed_transcript",                 NCRNA);
+        m.put("ribozyme",                             NCRNA);
+        m.put("TEC",                                  NCRNA);
+        // Pseudogenes
+        m.put("pseudogene",                           PSEUDOGENIC_TRANSCRIPT);
+        m.put("processed_pseudogene",                 PSEUDOGENIC_TRANSCRIPT);
+        m.put("unprocessed_pseudogene",               PSEUDOGENIC_TRANSCRIPT);
+        m.put("transcribed_unprocessed_pseudogene",   PSEUDOGENIC_TRANSCRIPT);
+        m.put("polymorphic_pseudogene",               PSEUDOGENIC_TRANSCRIPT);
+        m.put("IG_V_pseudogene",                      PSEUDOGENIC_TRANSCRIPT);
+        m.put("IG_C_pseudogene",                      PSEUDOGENIC_TRANSCRIPT);
+        m.put("IG_J_pseudogene",                      PSEUDOGENIC_TRANSCRIPT);
+        m.put("IG_pseudogene",                        PSEUDOGENIC_TRANSCRIPT);
+        m.put("TR_V_pseudogene",                      PSEUDOGENIC_TRANSCRIPT);
+        BIOTYPE_TO_ZFIN_TYPE = Collections.unmodifiableMap(m);
+    }
+
     private final MarkerType transcriptMarkerType = getMarkerRepository().getMarkerTypeByName(TSCRIPT.name());
-    private final TranscriptType transcriptTypeForName = getMarkerRepository().getTranscriptTypeForName(MRNA.toString());
+    private final Map<TranscriptType.Type, TranscriptType> transcriptTypeCache = new EnumMap<>(TranscriptType.Type.class);
+
+    private TranscriptType resolveTranscriptType(TranscriptType.Type type) {
+        return transcriptTypeCache.computeIfAbsent(
+            type, t -> getMarkerRepository().getTranscriptTypeForName(t.toString()));
+    }
     private final MarkerRelationshipType markerRelationshipType = getMarkerRepository().getMarkerRelationshipType(MarkerRelationship.Type.GENE_PRODUCES_TRANSCRIPT.toString());
     private final VocabularyService vocabularyService = new VocabularyService();
     private final ReferenceDatabase database = getSequenceRepository().getReferenceDatabase(ForeignDB.AvailableName.ENSEMBL_TRANS, ForeignDBDataType.DataType.RNA, ForeignDBDataType.SuperType.SEQUENCE, Species.Type.ZEBRAFISH);
@@ -174,32 +242,18 @@ public class EnsemblTranscriptFastaReadProcess extends EnsemblTranscriptBase {
         transcript.setAbbreviation(transcriptName);
         transcript.setName(transcriptName);
         transcript.setMarkerType(transcriptMarkerType);
-        // if biotype = protein_coding => mRNA
-        // otherwise exception
-        if (!(bioType.equals("protein_coding")
-              || bioType.equals("pseudogene")
-              || bioType.equals("lincRNA")
-              || bioType.equals("miRNA")
-              || bioType.equals("misc_RNA")
-              || bioType.equals("scaRNA")
-              || bioType.equals("snRNA")
-              || bioType.equals("antisense")
-              || bioType.equals("transcribed_unprocessed_pseudogene")
-              || bioType.equals("snoRNA")
-              || bioType.equals("retained_intron"))) {
-            if (bioType.equals("processed_transcript") || bioType.equals("nonsense_mediated_decay")
-                || bioType.equals("unprocessed_pseudogene") || bioType.equals("ribozyme") || bioType.equals("sense_overlapping")) {
-                LoadLink unsupprtedBioTypeLink = new LoadLink(transcriptRecord.ensdartID, "https://zfin.org/" + transcript.getZdbID());
-                HashMap<String, String> columns = new HashMap<>();
-                columns.put("biotype", bioType);
-                LoadAction newTranscript = new LoadAction(LoadAction.Type.WARNING, UNSUPPTORTED_BIOTYPE, transcriptRecord.ensdartID, "", "This ENSDARG is not loaded into ZFIN: biotype = " + bioType, 0, columns);
-                newTranscript.addLink(unsupprtedBioTypeLink);
-                actions.add(newTranscript);
-                return;
-            }
-            throw new RuntimeException("Could not map biotype " + bioType + " for transcript " + transcriptName + " with accession " + ensdartID);
+
+        TranscriptType.Type zfinType = BIOTYPE_TO_ZFIN_TYPE.get(bioType);
+        if (zfinType == null) {
+            LoadLink unsupprtedBioTypeLink = new LoadLink(transcriptRecord.ensdartID, "https://zfin.org/" + transcript.getZdbID());
+            HashMap<String, String> columns = new HashMap<>();
+            columns.put("biotype", bioType);
+            LoadAction newTranscript = new LoadAction(LoadAction.Type.WARNING, UNSUPPTORTED_BIOTYPE, transcriptRecord.ensdartID, "", "This ENSDARG is not loaded into ZFIN: biotype = " + bioType, 0, columns);
+            newTranscript.addLink(unsupprtedBioTypeLink);
+            actions.add(newTranscript);
+            return;
         }
-        transcript.setTranscriptType(transcriptTypeForName);
+        transcript.setTranscriptType(resolveTranscriptType(zfinType));
 
         HibernateUtil.createTransaction();
         try {

--- a/test/org/zfin/sequence/load/EnsemblTranscriptBiotypeMappingTest.java
+++ b/test/org/zfin/sequence/load/EnsemblTranscriptBiotypeMappingTest.java
@@ -29,18 +29,21 @@ public class EnsemblTranscriptBiotypeMappingTest {
     public void proteinCodingAndCodingVariantsAreMrna() {
         Map<String, TranscriptType.Type> m = EnsemblTranscriptFastaReadProcess.BIOTYPE_TO_ZFIN_TYPE;
         for (String biotype : List.of("protein_coding",
-                                       "nonsense_mediated_decay", "non_stop_decay",
                                        "IG_C_gene", "TR_J_gene", "TR_V_gene", "TR_D_gene")) {
             assertEquals("expected MRNA for " + biotype, MRNA, m.get(biotype));
         }
     }
 
     @Test
-    public void retainedIntronIsNcrna() {
-        // Per Sridhar's request on ZFIN-9472: retained_intron transcripts are
-        // non-coding, not mRNA.
-        assertEquals(NCRNA,
-                EnsemblTranscriptFastaReadProcess.BIOTYPE_TO_ZFIN_TYPE.get("retained_intron"));
+    public void splicingVariantsAreNcrna() {
+        // Per Sridhar on ZFIN-10222: retained_intron, nonsense_mediated_decay,
+        // and non_stop_decay transcripts are non-coding, not mRNA.
+        Map<String, TranscriptType.Type> m = EnsemblTranscriptFastaReadProcess.BIOTYPE_TO_ZFIN_TYPE;
+        for (String biotype : List.of("retained_intron",
+                                       "nonsense_mediated_decay",
+                                       "non_stop_decay")) {
+            assertEquals("expected NCRNA for " + biotype, NCRNA, m.get(biotype));
+        }
     }
 
     @Test

--- a/test/org/zfin/sequence/load/EnsemblTranscriptBiotypeMappingTest.java
+++ b/test/org/zfin/sequence/load/EnsemblTranscriptBiotypeMappingTest.java
@@ -1,0 +1,99 @@
+package org.zfin.sequence.load;
+
+import org.junit.Test;
+import org.zfin.marker.TranscriptType;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.zfin.marker.TranscriptType.Type.*;
+
+/**
+ * Pure unit tests for {@link EnsemblTranscriptFastaReadProcess#BIOTYPE_TO_ZFIN_TYPE}.
+ * Verifies the biotype → ZFIN TranscriptType mapping introduced for ZFIN-10222.
+ * Does not exercise the DB-touching loader path.
+ */
+public class EnsemblTranscriptBiotypeMappingTest {
+
+    @Test
+    public void mtRrnaMapsToRrna() {
+        // The literal ticket: Mt_rRNA (Ensembl's biotype string, underscore form)
+        // must map to ZFIN's rRNA, not the default mRNA.
+        assertEquals(RRNA, EnsemblTranscriptFastaReadProcess.BIOTYPE_TO_ZFIN_TYPE.get("Mt_rRNA"));
+    }
+
+    @Test
+    public void proteinCodingAndCodingVariantsAreMrna() {
+        Map<String, TranscriptType.Type> m = EnsemblTranscriptFastaReadProcess.BIOTYPE_TO_ZFIN_TYPE;
+        for (String biotype : List.of("protein_coding",
+                                       "nonsense_mediated_decay", "non_stop_decay",
+                                       "IG_C_gene", "TR_J_gene", "TR_V_gene", "TR_D_gene")) {
+            assertEquals("expected MRNA for " + biotype, MRNA, m.get(biotype));
+        }
+    }
+
+    @Test
+    public void retainedIntronIsNcrna() {
+        // Per Sridhar's request on ZFIN-9472: retained_intron transcripts are
+        // non-coding, not mRNA.
+        assertEquals(NCRNA,
+                EnsemblTranscriptFastaReadProcess.BIOTYPE_TO_ZFIN_TYPE.get("retained_intron"));
+    }
+
+    @Test
+    public void rnaFamilyBiotypesMapToTheirZfinTypes() {
+        Map<String, TranscriptType.Type> m = EnsemblTranscriptFastaReadProcess.BIOTYPE_TO_ZFIN_TYPE;
+        assertEquals(RRNA,     m.get("rRNA"));
+        assertEquals(TRNA,     m.get("Mt_tRNA"));
+        assertEquals(MIRNA,    m.get("miRNA"));
+        assertEquals(SNRNA,    m.get("snRNA"));
+        assertEquals(SNORNA,   m.get("snoRNA"));
+        assertEquals(SNORNA,   m.get("scaRNA"));   // scaRNA is a class of snoRNA
+        assertEquals(LINCRNA,  m.get("lincRNA"));
+        assertEquals(ANTISENSE, m.get("antisense"));
+    }
+
+    @Test
+    public void miscellaneousNonCodingMapsToNcrna() {
+        Map<String, TranscriptType.Type> m = EnsemblTranscriptFastaReadProcess.BIOTYPE_TO_ZFIN_TYPE;
+        for (String biotype : List.of("misc_RNA", "sRNA", "sense_intronic",
+                                       "sense_overlapping", "processed_transcript",
+                                       "ribozyme", "TEC")) {
+            assertEquals("expected NCRNA for " + biotype, NCRNA, m.get(biotype));
+        }
+    }
+
+    @Test
+    public void allPseudogeneFlavoursMapToPseudogenicTranscript() {
+        Map<String, TranscriptType.Type> m = EnsemblTranscriptFastaReadProcess.BIOTYPE_TO_ZFIN_TYPE;
+        for (String biotype : List.of("pseudogene", "processed_pseudogene",
+                                       "unprocessed_pseudogene",
+                                       "transcribed_unprocessed_pseudogene",
+                                       "polymorphic_pseudogene",
+                                       "IG_V_pseudogene", "IG_C_pseudogene",
+                                       "IG_J_pseudogene", "IG_pseudogene",
+                                       "TR_V_pseudogene")) {
+            assertEquals("expected PSEUDOGENIC_TRANSCRIPT for " + biotype,
+                    PSEUDOGENIC_TRANSCRIPT, m.get(biotype));
+        }
+    }
+
+    @Test
+    public void unknownBiotypeReturnsNull() {
+        // Loader treats null as "skip with warning" — never auto-load an unmapped biotype.
+        assertNull(EnsemblTranscriptFastaReadProcess.BIOTYPE_TO_ZFIN_TYPE.get("totally_made_up_biotype"));
+    }
+
+    @Test
+    public void mapIsImmutable() {
+        try {
+            EnsemblTranscriptFastaReadProcess.BIOTYPE_TO_ZFIN_TYPE.put("foo", MRNA);
+            assertFalse("BIOTYPE_TO_ZFIN_TYPE must be unmodifiable", true);
+        } catch (UnsupportedOperationException expected) {
+            // ok
+        }
+    }
+}


### PR DESCRIPTION
Previously the Ensembl transcript loader assigned every accepted biotype the mRNA TranscriptType (line 107 cached only that one, line 202 set it unconditionally). Mt_rRNA wasn't in the accept list at all yet two such transcripts were still landing in ZFIN with the wrong type.

Replace the 11-entry hardcoded accept-list with a BIOTYPE_TO_ZFIN_TYPE map covering every biotype currently present in transcript_ensembl_name (including Mt_rRNA -> rRNA, Mt_tRNA -> tRNA, retained_intron -> ncRNA per Sridhar's note on ZFIN-9472, all *_pseudogene variants -> pseudogenic transcript, etc.. Unmapped biotypes now skip with a WARNING LoadAction instead of throwing RuntimeException, so a new Ensembl biotype no longer breaks the loader -- it just surfaces in the load report.

Also drop dead LineSubmissionStatusComputer references in PersonController and ZircDashboardController so the project compiles after that class was removed.

Tests: EnsemblTranscriptBiotypeMappingTest (8 cases) covers the canonical mappings, the retained_intron special case, unknown-biotype returning null, and immutability of the map.
EOF
)