### PR TITLE
ZFIN-10259 Add monthly UniProt re-run job

### DIFF
--- a/server_apps/jenkins/jobs/Uniprot-Monthly-Diff-Load_m/config.xml
+++ b/server_apps/jenkins/jobs/Uniprot-Monthly-Diff-Load_m/config.xml
@@ -1,0 +1,141 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>
+    Monthly auto-run of the UniProt primary and secondary loads against the latest
+    processed UniProt release file (re-integrates changes that came from our own
+    database since the release was originally loaded).
+
+    Behavior:
+    - If an unprocessed UniProt release exists (i.e. a newer release was downloaded
+      by UniProt-Release-Check_d but not yet manually loaded), this job marks the
+      build UNSTABLE and skips the loads. The new release should be handled with the
+      manual UniProt-Diff-Load / UniProt-Secondary-Term-Load jobs instead.
+    - Otherwise, this job runs UniProtLoadTask and UniprotSecondaryTermLoadTask
+      against the latest processed release file, with changes committed.
+
+    See also: UniProt-Diff-Load, UniProt-Secondary-Term-Load, UniProt-Release-Check_d.
+  </description>
+  <keepDependencies>false</keepDependencies>
+
+  <properties/>
+
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+    <hudson.triggers.TimerTrigger>
+      <spec></spec>
+    </hudson.triggers.TimerTrigger>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>
+        <![CDATA[
+set -e
+
+UNPROCESSED_COUNT=$(psql -At -d $DBNAME -c "SELECT count(*) FROM uniprot_release WHERE upr_processed_date IS NULL")
+
+if [ "$UNPROCESSED_COUNT" != "0" ]; then
+    echo "Found $UNPROCESSED_COUNT unprocessed UniProt release(s)."
+    echo "A new release is pending - skipping monthly auto-run."
+    echo "Run UniProt-Diff-Load and UniProt-Secondary-Term-Load manually."
+    exit 2
+fi
+
+echo "No unprocessed UniProt releases - proceeding with monthly re-run against latest processed release."
+        ]]>
+      </command>
+      <unstableReturn>2</unstableReturn>
+    </hudson.tasks.Shell>
+    <hudson.tasks.Shell>
+      <command>
+        <![CDATA[
+TIMESTAMP=`date +%Y-%m-%d_%H-%M-%S`
+echo "WORKSPACE=$WORKSPACE"
+echo "PWD=$PWD"
+rm -f $PWD/uniprot_load_report*.html $PWD/uniprot_context*.json $PWD/uniprot_load_report*.html.zip $PWD/uniprot_context*.json.zip
+export UNIPROT_OUTPUT_REPORT_FILE="$PWD/uniprot_load_report_$TIMESTAMP.html.zip"
+export UNIPROT_CONTEXT_FILE="$PWD/uniprot_context_$TIMESTAMP.json.zip"
+export NCBI_FETCH_CACHE_OUTPUT_FILE="$PWD/ncbi_refseq_api_results.json"
+export UNIPROT_COMMIT_CHANGES=true
+export UNIPROT_RERUN_LATEST_PROCESSED=true
+cd $SOURCEROOT
+gradle uniprotLoadTask
+        ]]>
+      </command>
+    </hudson.tasks.Shell>
+    <hudson.tasks.Shell>
+      <command>
+        <![CDATA[
+TIMESTAMP=`date +%Y-%m-%d_%H-%M-%S`
+echo "WORKSPACE=$WORKSPACE"
+echo "PWD=$PWD"
+rm -f $PWD/uniprot_secondary_load_report.json $PWD/uniprot_secondary_load_report.json.report.html $PWD/uniprot_secondary_load_report*.json.zip $PWD/uniprot_secondary_load_report*.html.zip
+export UNIPROT_OUTPUT_FILE="$PWD/uniprot_secondary_load_report_$TIMESTAMP.json.zip"
+export UNIPROT_COMMIT_CHANGES=true
+export UNIPROT_RERUN_LATEST_PROCESSED=true
+cd $SOURCEROOT
+gradle uniprotSecondaryTermLoadTask
+        ]]>
+      </command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>*</artifacts>
+      <latestOnly>false</latestOnly>
+      <allowEmptyArchive>true</allowEmptyArchive>
+    </hudson.tasks.ArtifactArchiver>
+    <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@2.35.1">
+      <recipientList>$DEFAULT_RECIPIENTS</recipientList>
+      <configuredTriggers>
+        <hudson.plugins.emailext.plugins.trigger.FailureTrigger>
+          <email>
+            <recipientList>@FAILURE-RECIPIENT-LIST@</recipientList>
+            <subject>$PROJECT_DEFAULT_SUBJECT</subject>
+            <body>$PROJECT_DEFAULT_CONTENT</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>false</sendToRequester>
+            <includeCulprits>false</includeCulprits>
+            <sendToRecipientList>false</sendToRecipientList>
+            <attachmentsPattern></attachmentsPattern>
+            <attachBuildLog>false</attachBuildLog>
+            <compressBuildLog>false</compressBuildLog>
+            <replyTo>$PROJECT_DEFAULT_REPLYTO</replyTo>
+            <contentType>project</contentType>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
+        <hudson.plugins.emailext.plugins.trigger.UnstableTrigger>
+          <email>
+            <recipientList>@FAILURE-RECIPIENT-LIST@</recipientList>
+            <subject>$PROJECT_DEFAULT_SUBJECT</subject>
+            <body>$PROJECT_DEFAULT_CONTENT</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>false</sendToRequester>
+            <includeCulprits>false</includeCulprits>
+            <sendToRecipientList>false</sendToRecipientList>
+            <attachmentsPattern></attachmentsPattern>
+            <attachBuildLog>false</attachBuildLog>
+            <compressBuildLog>false</compressBuildLog>
+            <replyTo>$PROJECT_DEFAULT_REPLYTO</replyTo>
+            <contentType>project</contentType>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.UnstableTrigger>
+      </configuredTriggers>
+      <contentType>default</contentType>
+      <defaultSubject>[Jenkins][${INSTANCE}]: ${PROJECT_NAME}: ${BUILD_STATUS}</defaultSubject>
+      <defaultContent>$DEFAULT_CONTENT</defaultContent>
+      <attachmentsPattern></attachmentsPattern>
+      <presendScript>$DEFAULT_PRESEND_SCRIPT</presendScript>
+      <attachBuildLog>false</attachBuildLog>
+      <compressBuildLog>false</compressBuildLog>
+      <replyTo>$DEFAULT_REPLYTO</replyTo>
+      <saveOutput>false</saveOutput>
+    </hudson.plugins.emailext.ExtendedEmailPublisher>
+  </publishers>
+  <buildWrappers/>
+</project>

--- a/server_apps/jenkins/trigger.production.properties
+++ b/server_apps/jenkins/trigger.production.properties
@@ -181,6 +181,7 @@ Undefined-Environment_m=25 05 1 * *
 Unindexed-Open-Pubs_m=15 03 1 * *
 Uninformative-Gene-Nomenclature_m=15 03 1 * *
 UniProt-Release-Check_d=H 03 * * *
+Uniprot-Monthly-Diff-Load_m=H 04 1 * *
 Unload-Database_d=30 20 * * 0-6
 Update-AccessionBank-DbLink_d=H 03 * * 1-5
 Update-DOIs_d=0 4 * * 1-5

--- a/source/org/zfin/db/postGmakePostloaddb/1183/migrations/0010-ZFIN-10259-backfill-uniprot-processed-date.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1183/migrations/0010-ZFIN-10259-backfill-uniprot-processed-date.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+--changeset rtaylor:ZFIN-10259-backfill-uniprot-processed-date
+
+UPDATE uniprot_release
+SET upr_processed_date = upr_date + INTERVAL '7 days',
+    upr_notes = COALESCE(upr_notes || E'\n\n', '')
+                || 'Backfill (ZFIN-10259): upr_processed_date set to upr_date + 7 days; original load did not record a processed_date.'
+WHERE upr_processed_date IS NULL
+  AND upr_id IN (1, 2, 3, 6, 14, 15);

--- a/source/org/zfin/uniprot/task/UniProtLoadTask.java
+++ b/source/org/zfin/uniprot/task/UniProtLoadTask.java
@@ -43,6 +43,7 @@ public class UniProtLoadTask extends AbstractScriptWrapper {
     private final String outputJsonName;
     private final String outputReportName;
     private final boolean commitChanges;
+    private final boolean rerunLatestProcessed;
     private final String contextOutputFile;
     private final String contextInputFile;
     private UniProtLoadContext context;
@@ -69,6 +70,12 @@ public class UniProtLoadTask extends AbstractScriptWrapper {
      *  4. UNIPROT_COMMIT_CHANGES
      *  5. UNIPROT_CONTEXT_FILE
      *
+     *  Additional environment variables (no positional argument):
+     *  - UNIPROT_RERUN_LATEST_PROCESSED: if "true" and no unprocessed release exists,
+     *    re-run the load against the most recently processed release's file. Used by
+     *    the monthly auto-run job to re-integrate DB-side changes against the same
+     *    UniProt release file when no new release is available.
+     *
      * @param args Command line arguments
      *
      */
@@ -83,8 +90,9 @@ public class UniProtLoadTask extends AbstractScriptWrapper {
         String outputReportName = getArgOrEnvironmentVar(args, 3, "UNIPROT_OUTPUT_REPORT_FILE", calculateDefaultOutputFileName(startTime, "report.html"));
         String contextOutputFile = getArgOrEnvironmentVar(args, 4, "UNIPROT_CONTEXT_FILE", "");
         String contextInputFile = getArgOrEnvironmentVar(args, 5, "UNIPROT_CONTEXT_INPUT_FILE", "");
+        String rerunLatestProcessed = getArgOrEnvironmentVar(args, 6, "UNIPROT_RERUN_LATEST_PROCESSED", "false");
 
-        UniProtLoadTask task = new UniProtLoadTask(inputFileName, outputJsonName, outputReportName, "true".equals(commitChanges), contextOutputFile, contextInputFile);
+        UniProtLoadTask task = new UniProtLoadTask(inputFileName, outputJsonName, outputReportName, "true".equals(commitChanges), contextOutputFile, contextInputFile, "true".equals(rerunLatestProcessed));
         task.runTask();
     }
 
@@ -93,12 +101,17 @@ public class UniProtLoadTask extends AbstractScriptWrapper {
     }
 
     public UniProtLoadTask(String inputFileName, String outputJsonName, String outputReportName, boolean commitChanges, String contextOutputFile, String contextInputFile) {
+        this(inputFileName, outputJsonName, outputReportName, commitChanges, contextOutputFile, contextInputFile, false);
+    }
+
+    public UniProtLoadTask(String inputFileName, String outputJsonName, String outputReportName, boolean commitChanges, String contextOutputFile, String contextInputFile, boolean rerunLatestProcessed) {
         this.inputFileName = inputFileName;
         this.outputJsonName = outputJsonName;
         this.outputReportName = outputReportName;
         this.commitChanges = commitChanges;
         this.contextOutputFile = contextOutputFile;
         this.contextInputFile = contextInputFile;
+        this.rerunLatestProcessed = rerunLatestProcessed;
     }
 
     public void runTask() throws IOException, BioException, SQLException {
@@ -176,6 +189,17 @@ public class UniProtLoadTask extends AbstractScriptWrapper {
             log.info("No input file specified, using latest unprocessed UniProt release: " + latestUnprocessedUniProtRelease.get().getLocalFile().getAbsolutePath() + ".");
             inputFileName = latestUnprocessedUniProtRelease.get().getLocalFile().getAbsolutePath();
             release = latestUnprocessedUniProtRelease.get();
+            if (!new File(inputFileName).exists() || new File(inputFileName).length() == 0) {
+                throw new RuntimeException("No such file (or empty): " + inputFileName);
+            }
+        } else if (inputFileName.isEmpty() && rerunLatestProcessed) {
+            UniProtRelease latestProcessed = getInfrastructureRepository().getLatestProcessedUniProtRelease();
+            if (latestProcessed == null) {
+                throw new RuntimeException("No input file specified, no unprocessed release, and no processed UniProt release to re-run against.");
+            }
+            log.info("No unprocessed UniProt release; re-running against latest processed release: " + latestProcessed.getLocalFile().getAbsolutePath() + ".");
+            inputFileName = latestProcessed.getLocalFile().getAbsolutePath();
+            release = latestProcessed;
             if (!new File(inputFileName).exists() || new File(inputFileName).length() == 0) {
                 throw new RuntimeException("No such file (or empty): " + inputFileName);
             }

--- a/source/org/zfin/uniprot/task/UniprotSecondaryTermLoadTask.java
+++ b/source/org/zfin/uniprot/task/UniprotSecondaryTermLoadTask.java
@@ -71,6 +71,7 @@ public class UniprotSecondaryTermLoadTask extends AbstractScriptWrapper {
     private List<InterProProteinDTO> downloadedInterproDomainRecords;
 
     private SecondaryTermLoadPipeline pipeline;
+    private final boolean rerunLatestProcessed;
 
     public static void main(String[] args) throws Exception {
 
@@ -105,6 +106,7 @@ public class UniprotSecondaryTermLoadTask extends AbstractScriptWrapper {
             }
         }
 
+        boolean rerunLatestProcessed = false;
         if (mode.equals(LoadTaskMode.REPORT) || mode.equals(LoadTaskMode.REPORT_AND_LOAD)) {
             inputFileName = getArgOrEnvironmentVar(args, 1, "UNIPROT_INPUT_FILE", "");
             ipToGoTranslationFile = getArgOrEnvironmentVar(args, 2, "IP2GO_FILE", "");
@@ -113,12 +115,13 @@ public class UniprotSecondaryTermLoadTask extends AbstractScriptWrapper {
             domainFile = getArgOrEnvironmentVar(args, 4, "DOMAIN_FILE", "");
             outputJsonName = getArgOrEnvironmentVar(args, 5, "UNIPROT_OUTPUT_FILE", defaultOutputFileName(inputFileName));
             contextInputFile = getArgOrEnvironmentVar(args, 6, "CONTEXT_INPUT_FILE", "");
+            rerunLatestProcessed = "true".equals(getArgOrEnvironmentVar(args, 7, "UNIPROT_RERUN_LATEST_PROCESSED", "false"));
         } else {
             printUsage();
             System.exit(1);
         }
 
-        UniprotSecondaryTermLoadTask task = new UniprotSecondaryTermLoadTask(mode, inputFileName, outputJsonName, ipToGoTranslationFile, ecToGoTranslationFile, upToGoTranslationFile, domainFile, contextInputFile, actionsFileName);
+        UniprotSecondaryTermLoadTask task = new UniprotSecondaryTermLoadTask(mode, inputFileName, outputJsonName, ipToGoTranslationFile, ecToGoTranslationFile, upToGoTranslationFile, domainFile, contextInputFile, actionsFileName, rerunLatestProcessed);
         task.runTask();
     }
 
@@ -142,6 +145,10 @@ public class UniprotSecondaryTermLoadTask extends AbstractScriptWrapper {
     }
 
     public UniprotSecondaryTermLoadTask(LoadTaskMode mode, String inputFileName, String outputJsonName, String ipToGoTranslationFile, String ecToGoTranslationFile, String upToGoTranslationFile, String domainFile, String contextInputFile, String actionsFileName) {
+        this(mode, inputFileName, outputJsonName, ipToGoTranslationFile, ecToGoTranslationFile, upToGoTranslationFile, domainFile, contextInputFile, actionsFileName, false);
+    }
+
+    public UniprotSecondaryTermLoadTask(LoadTaskMode mode, String inputFileName, String outputJsonName, String ipToGoTranslationFile, String ecToGoTranslationFile, String upToGoTranslationFile, String domainFile, String contextInputFile, String actionsFileName, boolean rerunLatestProcessed) {
         this.mode = mode;
         this.inputFileName = inputFileName;
         this.outputJsonName = outputJsonName;
@@ -165,6 +172,7 @@ public class UniprotSecondaryTermLoadTask extends AbstractScriptWrapper {
         this.domainFile = domainFile;
         this.contextInputFile = contextInputFile;
         this.actionsFileName = actionsFileName;
+        this.rerunLatestProcessed = rerunLatestProcessed;
     }
 
     public void runTask() throws IOException, BioException, SQLException {
@@ -418,6 +426,14 @@ public class UniprotSecondaryTermLoadTask extends AbstractScriptWrapper {
                 log.info("Loading from latest UniProt release: " + releaseOptional.get().getPath() + "(md5:" + releaseOptional.get().getMd5() + ")" );
                 inputFileName = releaseOptional.get().getLocalFile().getAbsolutePath();
                 release = releaseOptional.get();
+            } else if (inputFileName.isEmpty() && rerunLatestProcessed) {
+                UniProtRelease latestProcessed = getInfrastructureRepository().getLatestProcessedUniProtRelease();
+                if (latestProcessed == null) {
+                    throw new RuntimeException("No input file specified, no release pending secondary load, and no processed UniProt release to re-run against.");
+                }
+                log.info("No release pending secondary load; re-running against latest processed release: " + latestProcessed.getPath() + " (md5:" + latestProcessed.getMd5() + ")");
+                inputFileName = latestProcessed.getLocalFile().getAbsolutePath();
+                release = latestProcessed;
             } else if (inputFileName.isEmpty()) {
                 throw new RuntimeException("No input file specified and no unprocessed UniProt release found.");
             }


### PR DESCRIPTION
Schedule a new Jenkins job, Uniprot-Monthly-Diff-Load_m, that runs on the 1st of each month and re-runs the UniProt primary and secondary loads against the latest processed release file so DB-side changes get integrated even when no new UniProt release is available. If an unprocessed release exists, the job marks the build UNSTABLE and skips the loads so the manual UniProt-Diff-Load / UniProt-Secondary-Term-Load flow handles the new release.

UniProtLoadTask and UniprotSecondaryTermLoadTask gain a UNIPROT_RERUN_LATEST_PROCESSED env flag that falls back to the latest processed release (and assigns the release entity so the relevant upr_*_date column is refreshed on the re-run).