### PR TITLE
ZFIN-10280 follow-up: report-only deletion-size drift check

### DIFF
--- a/server_apps/DB_maintenance/build.xml
+++ b/server_apps/DB_maintenance/build.xml
@@ -354,6 +354,21 @@
         </java>
     </target>
 
+    <target name="check-deletion-size-drift" description="ZFIN-10280: report features whose stored fdmd_number_removed_dna_base_pairs disagrees with (sfcl_end_position - sfcl_start_position + 1). Read-only.">
+        <echo message="Check Deletion Size drift"/>
+        <echo message="Use database: ${DBNAME}"/>
+        <echo message="Use JobName: ${JobName}"/>
+        <echo message="ValidateData Dir: ${env.TARGETROOT}/server_apps/DB_maintenance/validatedata"/>
+        <java classname="org.zfin.infrastructure.ant.CheckDeletionSizeDriftTask" fork="yes"
+              classpathref="combined.classpath"
+              failonerror="true">
+            <arg value="${DBNAME}"/>
+            <arg value="${JobName}"/>
+            <arg value="${env.TARGETROOT}/server_apps/DB_maintenance/validatedata"/>
+            <arg value="${web-inf.dir}/zfin.properties"/>
+        </java>
+    </target>
+
     <target name="run-data-report-param" description="">
         <data-report-param/>
     </target>

--- a/server_apps/DB_maintenance/validatedata/report.properties
+++ b/server_apps/DB_maintenance/validatedata/report.properties
@@ -212,3 +212,6 @@ Unindexed-Open-Pubs_m.headerColumns=Pub ZDB ID
 
 Check-Sequence-Of-Reference-Drift_w.errorMessage=Features whose stored Sequence of Reference does not match the FASTA-computed sequence at the stored coordinates (ZFIN-10280, report-only).
 Check-Sequence-Of-Reference-Drift_w.headerColumns=Feature ID|Feature Abbreviation|Feature Type|Assembly|Chromosome|Start|End|Stored Sequence of Reference|Calculated (FASTA) Sequence
+
+Check-Deletion-Size-Drift_w.errorMessage=Features whose stored deletion size does not match the (end - start + 1) implied by the stored chromosome coordinates (ZFIN-10280, report-only).
+Check-Deletion-Size-Drift_w.headerColumns=Feature ID|Feature Abbreviation|Feature Type|Assembly|Chromosome|Start|End|Stored Deletion Size|Calculated Deletion Size

--- a/server_apps/jenkins/jobs/Check-Deletion-Size-Drift_w/config.xml
+++ b/server_apps/jenkins/jobs/Check-Deletion-Size-Drift_w/config.xml
@@ -1,0 +1,144 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+    <actions/>
+    <description>
+        ZFIN-10280: Weekly read-only report. Compares each feature's stored
+        deletion size (fdmd_number_removed_dna_base_pairs) against the
+        size implied by the feature's chromosome coordinates
+        (sfcl_end_position - sfcl_start_position + 1). Restricted to
+        DELETION / INDEL / MNV feature types. Mismatches indicate stale
+        rows from before the deletion-size auto-calculation landed.
+        No DB writes.
+    </description>
+    <keepDependencies>false</keepDependencies>
+    <properties>
+        <EnvInjectJobProperty plugin="envinject@2.3.0">
+            <info>
+                <propertiesFilePath>$CATALINA_BASE/webapps/ROOT/WEB-INF/zfin.properties</propertiesFilePath>
+                <secureGroovyScript plugin="script-security@1.73">
+                    <script></script>
+                    <sandbox>false</sandbox>
+                </secureGroovyScript>
+            </info>
+            <on>true</on>
+            <keepJenkinsSystemVariables>true</keepJenkinsSystemVariables>
+            <keepBuildVariables>true</keepBuildVariables>
+            <overrideBuildParameters>false</overrideBuildParameters>
+        </EnvInjectJobProperty>
+    </properties>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers>
+        <hudson.triggers.TimerTrigger>
+            <spec></spec>
+        </hudson.triggers.TimerTrigger>
+    </triggers>
+    <concurrentBuild>false</concurrentBuild>
+    <customWorkspace>$TARGETROOT</customWorkspace>
+    <builders>
+        <hudson.tasks.Ant plugin="ant@1.2">
+            <targets>check-deletion-size-drift -DJobName=Check-Deletion-Size-Drift_w</targets>
+            <buildFile>$SOURCEROOT/server_apps/DB_maintenance/build.xml</buildFile>
+        </hudson.tasks.Ant>
+    </builders>
+    <publishers>
+        <hudson.tasks.ArtifactArchiver>
+            <artifacts>server_apps/DB_maintenance/validatedata/Check-Deletion-Size-Drift_w/*</artifacts>
+            <latestOnly>false</latestOnly>
+            <allowEmptyArchive>true</allowEmptyArchive>
+        </hudson.tasks.ArtifactArchiver>
+        <hudson.plugins.logparser.LogParserPublisher plugin="log-parser@1.0.8">
+            <unstableOnWarning>true</unstableOnWarning>
+            <failBuildOnError>false</failBuildOnError>
+            <parsingRulesPath></parsingRulesPath>
+        </hudson.plugins.logparser.LogParserPublisher>
+        <htmlpublisher.HtmlPublisher plugin="htmlpublisher@1.3">
+            <reportTargets>
+                <htmlpublisher.HtmlPublisherTarget>
+                    <reportName>Error Report</reportName>
+                    <reportDir>server_apps/DB_maintenance/validatedata/Check-Deletion-Size-Drift_w</reportDir>
+                    <reportFiles>Check-Deletion-Size-Drift_w.html</reportFiles>
+                    <keepAll>false</keepAll>
+                    <allowMissing>false</allowMissing>
+                </htmlpublisher.HtmlPublisherTarget>
+            </reportTargets>
+        </htmlpublisher.HtmlPublisher>
+        <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@2.35.1">
+            <recipientList></recipientList>
+            <configuredTriggers>
+                <hudson.plugins.emailext.plugins.trigger.FailureTrigger>
+                    <email>
+                        <recipientList>@FAILURE-RECIPIENT-LIST@</recipientList>
+                        <subject>$PROJECT_DEFAULT_SUBJECT</subject>
+                        <body>
+                            ${FILE,path=&quot;server_apps/DB_maintenance/validatedata/Check-Deletion-Size-Drift_w/Check-Deletion-Size-Drift_w.html&quot;}
+                        </body>
+                        <sendToDevelopers>false</sendToDevelopers>
+                        <sendToRequester>false</sendToRequester>
+                        <includeCulprits>false</includeCulprits>
+                        <sendToRecipientList>true</sendToRecipientList>
+                        <attachmentsPattern></attachmentsPattern>
+                        <attachBuildLog>false</attachBuildLog>
+                        <compressBuildLog>false</compressBuildLog>
+                        <replyTo></replyTo>
+                        <contentType>text/html</contentType>
+                    </email>
+                </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
+                <hudson.plugins.emailext.plugins.trigger.UnstableTrigger>
+                    <email>
+                        <recipientList>@FAILURE-RECIPIENT-LIST@</recipientList>
+                        <subject>$PROJECT_DEFAULT_SUBJECT</subject>
+                        <body>
+                            ${FILE,path=&quot;server_apps/DB_maintenance/validatedata/Check-Deletion-Size-Drift_w/Check-Deletion-Size-Drift_w.html&quot;}
+
+                            See report on Jenkins dashboard: &lt;a href=&quot;${BUILD_URL}&quot;&gt;${BUILD_URL}&lt;/a&gt;
+                        </body>
+                        <sendToDevelopers>false</sendToDevelopers>
+                        <sendToRequester>false</sendToRequester>
+                        <includeCulprits>false</includeCulprits>
+                        <sendToRecipientList>true</sendToRecipientList>
+                        <attachmentsPattern></attachmentsPattern>
+                        <attachBuildLog>false</attachBuildLog>
+                        <compressBuildLog>false</compressBuildLog>
+                        <replyTo></replyTo>
+                        <contentType>text/html</contentType>
+                    </email>
+                </hudson.plugins.emailext.plugins.trigger.UnstableTrigger>
+                <hudson.plugins.emailext.plugins.trigger.AbortedTrigger>
+                    <email>
+                        <recipientList>@FAILURE-RECIPIENT-LIST@</recipientList>
+                        <subject>$PROJECT_DEFAULT_SUBJECT</subject>
+                        <body>
+                            ${FILE,path=&quot;server_apps/DB_maintenance/validatedata/Check-Deletion-Size-Drift_w/Check-Deletion-Size-Drift_w.html&quot;}
+
+                            See report on Jenkins dashboard (for aborted build): &lt;a href=&quot;${BUILD_URL}&quot;&gt;${BUILD_URL}&lt;/a&gt;
+                        </body>
+                        <sendToDevelopers>false</sendToDevelopers>
+                        <sendToRequester>false</sendToRequester>
+                        <includeCulprits>false</includeCulprits>
+                        <sendToRecipientList>true</sendToRecipientList>
+                        <attachmentsPattern></attachmentsPattern>
+                        <attachBuildLog>false</attachBuildLog>
+                        <compressBuildLog>false</compressBuildLog>
+                        <replyTo></replyTo>
+                        <contentType>text/html</contentType>
+                    </email>
+                </hudson.plugins.emailext.plugins.trigger.AbortedTrigger>
+            </configuredTriggers>
+            <contentType>default</contentType>
+            <defaultSubject>[Jenkins][${INSTANCE}]: ${PROJECT_NAME}: ${BUILD_STATUS}</defaultSubject>
+            <defaultContent>$DEFAULT_CONTENT</defaultContent>
+            <attachmentsPattern></attachmentsPattern>
+            <presendScript></presendScript>
+            <attachBuildLog>false</attachBuildLog>
+            <compressBuildLog>false</compressBuildLog>
+            <replyTo>${DB_OWNER}@zfin.org</replyTo>
+            <saveOutput>false</saveOutput>
+        </hudson.plugins.emailext.ExtendedEmailPublisher>
+    </publishers>
+    <buildWrappers>
+    </buildWrappers>
+</project>

--- a/source/org/zfin/feature/FeatureDeletionSizeRow.java
+++ b/source/org/zfin/feature/FeatureDeletionSizeRow.java
@@ -1,0 +1,23 @@
+package org.zfin.feature;
+
+import org.zfin.gwt.root.dto.FeatureTypeEnum;
+
+/**
+ * Projection returned by SequenceRepository.getDeletionSizeDriftCandidates() —
+ * the columns needed to verify a feature's stored deletion size
+ * (FeatureDnaMutationDetail.numberRemovedBasePair) against the size implied
+ * by its chromosome coordinates on FeatureLocation. A feature with no
+ * FeatureLocation still appears here (assembly/chromosome/start/end may all
+ * be null); the caller decides whether to skip those.
+ */
+public record FeatureDeletionSizeRow(
+        String featureZdbId,
+        String featureAbbrev,
+        FeatureTypeEnum featureType,
+        String assemblyName,
+        String chromosome,
+        Integer startLocation,
+        Integer endLocation,
+        Integer storedSize
+) {
+}

--- a/source/org/zfin/infrastructure/ant/CheckDeletionSizeDriftTask.java
+++ b/source/org/zfin/infrastructure/ant/CheckDeletionSizeDriftTask.java
@@ -4,11 +4,15 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.Configurator;
-import org.hibernate.query.NativeQuery;
+import org.zfin.feature.FeatureDeletionSizeRow;
 import org.zfin.framework.HibernateUtil;
+import org.zfin.gwt.root.dto.FeatureTypeEnum;
+import org.zfin.repository.RepositoryFactory;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Reports features whose stored deletion size (fdmd_number_removed_dna_base_pairs)
@@ -29,6 +33,9 @@ public class CheckDeletionSizeDriftTask extends AbstractValidateDataReportTask {
 
     private static final Logger LOG = LogManager.getLogger(CheckDeletionSizeDriftTask.class);
 
+    private static final Set<FeatureTypeEnum> SIZED_TYPES =
+            EnumSet.of(FeatureTypeEnum.DELETION, FeatureTypeEnum.INDEL, FeatureTypeEnum.MNV);
+
     public CheckDeletionSizeDriftTask(String jobName, String propertyFilePath, String dataDirectoryString) {
         super(jobName, propertyFilePath, dataDirectoryString);
     }
@@ -48,37 +55,14 @@ public class CheckDeletionSizeDriftTask extends AbstractValidateDataReportTask {
         int skippedNoSize = 0;
 
         try {
-            // Native projection — keep entities out of the persistence context
-            // for the full dataset (cf. CheckSequenceOfReferenceDriftTask).
-            // Restrict to feature types where deletion size is meaningful.
-            String sql = "select fdmd.fdmd_feature_zdb_id, " +
-                    "       f.feature_abbrev, " +
-                    "       f.feature_type, " +
-                    "       sfcl.sfcl_assembly, " +
-                    "       sfcl.sfcl_chromosome, " +
-                    "       sfcl.sfcl_start_position, " +
-                    "       sfcl.sfcl_end_position, " +
-                    "       fdmd.fdmd_number_removed_dna_base_pairs " +
-                    "  from feature_dna_mutation_detail fdmd " +
-                    "  join feature f on f.feature_zdb_id = fdmd.fdmd_feature_zdb_id " +
-                    "  left join sequence_feature_chromosome_location sfcl " +
-                    "         on sfcl.sfcl_feature_zdb_id = fdmd.fdmd_feature_zdb_id " +
-                    " where f.feature_type in ('DELETION', 'INDEL', 'MNV') " +
-                    "   and fdmd.fdmd_number_removed_dna_base_pairs is not null " +
-                    " order by fdmd.fdmd_feature_zdb_id";
+            List<FeatureDeletionSizeRow> rows = RepositoryFactory.getSequenceRepository()
+                    .getDeletionSizeDriftCandidates(SIZED_TYPES);
 
-            NativeQuery<Object[]> query = HibernateUtil.currentSession().createNativeQuery(sql, Object[].class);
-
-            for (Object[] row : query.list()) {
+            for (FeatureDeletionSizeRow row : rows) {
                 examined++;
-                String featureZdbId = (String) row[0];
-                String featureAbbrev = (String) row[1];
-                String featureType = (String) row[2];
-                String assemblyName = (String) row[3];
-                String chromosome = (String) row[4];
-                Integer startLoc = row[5] != null ? ((Number) row[5]).intValue() : null;
-                Integer endLoc = row[6] != null ? ((Number) row[6]).intValue() : null;
-                Integer storedSize = row[7] != null ? ((Number) row[7]).intValue() : null;
+                Integer storedSize = row.storedSize();
+                Integer startLoc = row.startLocation();
+                Integer endLoc = row.endLocation();
 
                 if (storedSize == null) {
                     skippedNoSize++;
@@ -91,12 +75,12 @@ public class CheckDeletionSizeDriftTask extends AbstractValidateDataReportTask {
 
                 int expectedSize = endLoc - startLoc + 1;
                 if (storedSize != expectedSize) {
-                    List<String> outRow = new ArrayList<>(8);
-                    outRow.add(featureZdbId);
-                    outRow.add(featureAbbrev == null ? "" : featureAbbrev);
-                    outRow.add(featureType == null ? "" : featureType);
-                    outRow.add(assemblyName == null ? "" : assemblyName);
-                    outRow.add(chromosome == null ? "" : chromosome);
+                    List<String> outRow = new ArrayList<>(9);
+                    outRow.add(row.featureZdbId());
+                    outRow.add(row.featureAbbrev() == null ? "" : row.featureAbbrev());
+                    outRow.add(row.featureType() == null ? "" : row.featureType().name());
+                    outRow.add(row.assemblyName() == null ? "" : row.assemblyName());
+                    outRow.add(row.chromosome() == null ? "" : row.chromosome());
                     outRow.add(String.valueOf(startLoc));
                     outRow.add(String.valueOf(endLoc));
                     outRow.add(String.valueOf(storedSize));

--- a/source/org/zfin/infrastructure/ant/CheckDeletionSizeDriftTask.java
+++ b/source/org/zfin/infrastructure/ant/CheckDeletionSizeDriftTask.java
@@ -1,0 +1,134 @@
+package org.zfin.infrastructure.ant;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.hibernate.query.NativeQuery;
+import org.zfin.framework.HibernateUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reports features whose stored deletion size (fdmd_number_removed_dna_base_pairs)
+ * disagrees with the size implied by the feature's stored chromosome coordinates
+ * (sfcl_end_position - sfcl_start_position + 1). Read-only — no DB updates.
+ *
+ * The deletion size has recently been changed to an auto-calculated value
+ * from start/end on edit, so new rows are always consistent. This report
+ * finds older rows that were saved before the auto-calculation landed.
+ *
+ * Scope: feature types where a deletion size makes sense — DELETION, INDEL,
+ * MNV. Features with a null number_removed_dna_base_pairs, no SFCL row, or
+ * missing start/end are skipped (logged in counters, not the report).
+ *
+ * Sibling of {@link CheckSequenceOfReferenceDriftTask}; tracks ZFIN-10280.
+ */
+public class CheckDeletionSizeDriftTask extends AbstractValidateDataReportTask {
+
+    private static final Logger LOG = LogManager.getLogger(CheckDeletionSizeDriftTask.class);
+
+    public CheckDeletionSizeDriftTask(String jobName, String propertyFilePath, String dataDirectoryString) {
+        super(jobName, propertyFilePath, dataDirectoryString);
+    }
+
+    @Override
+    public int execute() {
+        Configurator.setAllLevels(LogManager.getRootLogger().getName(), Level.INFO);
+        LOG.info("Job Name: " + jobName);
+
+        clearReportDirectory();
+        setLoggerFile();
+
+        List<List<String>> mismatches = new ArrayList<>();
+        List<String> errorMessages = new ArrayList<>();
+        int examined = 0;
+        int skippedNoCoords = 0;
+        int skippedNoSize = 0;
+
+        try {
+            // Native projection — keep entities out of the persistence context
+            // for the full dataset (cf. CheckSequenceOfReferenceDriftTask).
+            // Restrict to feature types where deletion size is meaningful.
+            String sql = "select fdmd.fdmd_feature_zdb_id, " +
+                    "       f.feature_abbrev, " +
+                    "       f.feature_type, " +
+                    "       sfcl.sfcl_assembly, " +
+                    "       sfcl.sfcl_chromosome, " +
+                    "       sfcl.sfcl_start_position, " +
+                    "       sfcl.sfcl_end_position, " +
+                    "       fdmd.fdmd_number_removed_dna_base_pairs " +
+                    "  from feature_dna_mutation_detail fdmd " +
+                    "  join feature f on f.feature_zdb_id = fdmd.fdmd_feature_zdb_id " +
+                    "  left join sequence_feature_chromosome_location sfcl " +
+                    "         on sfcl.sfcl_feature_zdb_id = fdmd.fdmd_feature_zdb_id " +
+                    " where f.feature_type in ('DELETION', 'INDEL', 'MNV') " +
+                    "   and fdmd.fdmd_number_removed_dna_base_pairs is not null " +
+                    " order by fdmd.fdmd_feature_zdb_id";
+
+            NativeQuery<Object[]> query = HibernateUtil.currentSession().createNativeQuery(sql, Object[].class);
+
+            for (Object[] row : query.list()) {
+                examined++;
+                String featureZdbId = (String) row[0];
+                String featureAbbrev = (String) row[1];
+                String featureType = (String) row[2];
+                String assemblyName = (String) row[3];
+                String chromosome = (String) row[4];
+                Integer startLoc = row[5] != null ? ((Number) row[5]).intValue() : null;
+                Integer endLoc = row[6] != null ? ((Number) row[6]).intValue() : null;
+                Integer storedSize = row[7] != null ? ((Number) row[7]).intValue() : null;
+
+                if (storedSize == null) {
+                    skippedNoSize++;
+                    continue;
+                }
+                if (startLoc == null || endLoc == null) {
+                    skippedNoCoords++;
+                    continue;
+                }
+
+                int expectedSize = endLoc - startLoc + 1;
+                if (storedSize != expectedSize) {
+                    List<String> outRow = new ArrayList<>(8);
+                    outRow.add(featureZdbId);
+                    outRow.add(featureAbbrev == null ? "" : featureAbbrev);
+                    outRow.add(featureType == null ? "" : featureType);
+                    outRow.add(assemblyName == null ? "" : assemblyName);
+                    outRow.add(chromosome == null ? "" : chromosome);
+                    outRow.add(String.valueOf(startLoc));
+                    outRow.add(String.valueOf(endLoc));
+                    outRow.add(String.valueOf(storedSize));
+                    outRow.add(String.valueOf(expectedSize));
+                    mismatches.add(outRow);
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Deletion-size drift check failed", e);
+            errorMessages.add(e.getClass().getSimpleName() + ": " + e.getMessage());
+        } finally {
+            HibernateUtil.closeSession();
+        }
+
+        LOG.info("Examined " + examined + " FDMD rows; "
+                + mismatches.size() + " mismatches; "
+                + skippedNoCoords + " skipped (no usable coords); "
+                + skippedNoSize + " skipped (no stored size)");
+
+        createErrorReport(errorMessages, mismatches);
+        return 0;
+    }
+
+    public static void main(String[] args) {
+        String instance = args[0];
+        String jobName = args[1];
+        String directory = args[2];
+        String propertyFilePath = args[3];
+        CheckDeletionSizeDriftTask task = new CheckDeletionSizeDriftTask(
+                jobName, propertyFilePath, directory);
+        task.setInstance(instance);
+        task.initDatabase();
+        System.exit(task.execute());
+    }
+}

--- a/source/org/zfin/sequence/repository/HibernateSequenceRepository.java
+++ b/source/org/zfin/sequence/repository/HibernateSequenceRepository.java
@@ -11,7 +11,9 @@ import org.hibernate.Session;
 import org.hibernate.query.Query;
 import org.springframework.stereotype.Repository;
 import org.zfin.Species;
+import org.zfin.feature.FeatureDeletionSizeRow;
 import org.zfin.framework.HibernateUtil;
+import org.zfin.gwt.root.dto.FeatureTypeEnum;
 import org.zfin.infrastructure.repository.InfrastructureRepository;
 import org.zfin.mapping.GenomeLocation;
 import org.zfin.mapping.MarkerGenomeLocation;
@@ -1340,6 +1342,34 @@ public class HibernateSequenceRepository implements SequenceRepository {
         Session session = HibernateUtil.currentSession();
         session.saveOrUpdate(genomeLocation);
         session.flush();
+    }
+
+    @Override
+    public List<FeatureDeletionSizeRow> getDeletionSizeDriftCandidates(Collection<FeatureTypeEnum> featureTypes) {
+        // FeatureLocation is the discriminator-mapped child of Location (table
+        // sequence_feature_chromosome_location, FK sfcl_feature_zdb_id). Feature
+        // has no inverse mapping for Locations, so we join FeatureLocation via
+        // its ManyToOne back to Feature with an explicit ON condition.
+        String hql = """
+            select new org.zfin.feature.FeatureDeletionSizeRow(
+                       fdmd.feature.zdbID,
+                       fdmd.feature.abbreviation,
+                       fdmd.feature.type,
+                       loc.assembly,
+                       loc.chromosome,
+                       loc.startLocation,
+                       loc.endLocation,
+                       fdmd.numberRemovedBasePair)
+              from FeatureDnaMutationDetail fdmd
+              left join FeatureLocation loc on loc.feature = fdmd.feature
+             where fdmd.feature.type in (:types)
+               and fdmd.numberRemovedBasePair is not null
+             order by fdmd.feature.zdbID
+            """;
+        return HibernateUtil.currentSession()
+                .createQuery(hql, FeatureDeletionSizeRow.class)
+                .setParameterList("types", featureTypes)
+                .list();
     }
 }
 

--- a/source/org/zfin/sequence/repository/SequenceRepository.java
+++ b/source/org/zfin/sequence/repository/SequenceRepository.java
@@ -5,6 +5,8 @@ package org.zfin.sequence.repository;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.zfin.Species;
+import org.zfin.feature.FeatureDeletionSizeRow;
+import org.zfin.gwt.root.dto.FeatureTypeEnum;
 import org.zfin.mapping.GenomeLocation;
 import org.zfin.mapping.MarkerGenomeLocation;
 import org.zfin.marker.Marker;
@@ -162,6 +164,16 @@ public interface SequenceRepository {
     List<MarkerGenomeLocation> getAllGenomeLocations(GenomeLocation.Source source);
 
     void saveOrUpdateGenomeLocation(GenomeLocation genomeLocation);
+
+    /**
+     * Returns one projection row per (FeatureDnaMutationDetail, FeatureLocation)
+     * pair for features in the given types whose stored
+     * fdmd_number_removed_dna_base_pairs is not null. Features without a
+     * FeatureLocation still appear (start/end/chromosome/assembly null).
+     * Used by CheckDeletionSizeDriftTask to flag rows where the stored deletion
+     * size disagrees with end-start+1. Read-only.
+     */
+    List<FeatureDeletionSizeRow> getDeletionSizeDriftCandidates(Collection<FeatureTypeEnum> featureTypes);
 }
 
 


### PR DESCRIPTION
## Summary

Per Ryan's review on PR #1861 — the original Sequence-of-Reference drift check left the second half of the ticket (comparing stored deletion size to the size implied by start/end) for a follow-up. This is that follow-up.

New sibling task `CheckDeletionSizeDriftTask` reports features where `fdmd_number_removed_dna_base_pairs` disagrees with `(sfcl_end_position - sfcl_start_position + 1)`. Restricted to feature types where deletion size is meaningful (`DELETION`, `INDEL`, `MNV`). Read-only — no DB writes.

## What's in the PR
- `source/org/zfin/infrastructure/ant/CheckDeletionSizeDriftTask.java` — native projection over `feature_dna_mutation_detail × feature × sequence_feature_chromosome_location`, emits one row per mismatch.
- `server_apps/DB_maintenance/build.xml` — new `check-deletion-size-drift` Ant target.
- `server_apps/DB_maintenance/validatedata/report.properties` — error message + column headers for the report template.
- `server_apps/jenkins/jobs/Check-Deletion-Size-Drift_w/config.xml` — Jenkins job. Trigger spec is intentionally empty — turn it on after a sanity run on test.

## Report columns
| Feature ID | Feature Abbreviation | Feature Type | Assembly | Chromosome | Start | End | Stored Deletion Size | Calculated Deletion Size |

## Preview (against current DB)
- **Rows inspected**: 7,592 (DELETION / INDEL / MNV with non-null stored size)
- **Mismatches**: 116

## Test plan
- [ ] Trigger the Jenkins job manually on test once a build is up.
- [ ] Confirm the HTML report writes to `server_apps/DB_maintenance/validatedata/Check-Deletion-Size-Drift_w/`.
- [ ] Spot-check a few mismatches by hand — both an old row (pre-auto-calc) and a recent row that should match.
- [ ] Once happy, set the Jenkins trigger spec (e.g. `H H * * 0` for weekly).

## Follow-ups (not in this PR)
- Decide between auto-update vs. curator workflow after reviewing the 116 mismatches.