### PR TITLE
ZFIN-10278: skip feedback-form captcha for logged-in / already-verified users

### DIFF
--- a/home/WEB-INF/tags/yourInputWelcome.tag
+++ b/home/WEB-INF/tags/yourInputWelcome.tag
@@ -41,7 +41,12 @@
                         <label for="input-welcome-comments">Comments:</label>
                         <textarea id="input-welcome-comments" name="yiw-comments"></textarea>
                     </div>
-                    <div class="control" style="padding-left: 135px; height: 80px;">
+                    <%-- captcha is hidden by default; your-input-welcome.js reveals it only when the
+                         server says this visitor needs to pass one (anonymous, not yet verified). --%>
+                    <div class="control" id="input-welcome-captcha-message" style="display: none;">
+                        Please complete the verification below and resend your comments.
+                    </div>
+                    <div class="control" id="input-welcome-captcha" style="padding-left: 135px; height: 80px; display: none;">
                         <altcha-widget id="altcha-widget" challengeurl="/action/altcha/challenge"></altcha-widget>
                     </div>
                     <div class="control">
@@ -61,12 +66,3 @@
 </div>
 
 <script async defer src="https://cdn.jsdelivr.net/npm/altcha/dist/altcha.min.js" type="module"></script>
-<script>
-    document.addEventListener('DOMContentLoaded', () => {
-        document.querySelector("#altcha-widget").addEventListener("statechange", (ev) => {
-            if (ev.detail.state === "verified") {
-                document.querySelector("#input-welcome-submit").disabled = false;
-            }
-        });
-    });
-</script>

--- a/home/javascript/zfin-common/your-input-welcome.js
+++ b/home/javascript/zfin-common/your-input-welcome.js
@@ -7,7 +7,14 @@ $(function () {
         $formInputs = jQuery(":input", $form),
         $submitButton = jQuery("#input-welcome-submit", $form),
         $formValidate = jQuery("#input-welcome-validate"),
+        $captcha = jQuery("#input-welcome-captcha"),
+        $captchaMessage = jQuery("#input-welcome-captcha-message"),
+        captchaWidget = document.querySelector("#altcha-widget"),
+        // whether the server says this visitor must pass a captcha, and whether they've done so
+        captchaRequired = false,
+        captchaVerified = false,
         url = "/action/user-comment",
+        captchaCheckUrl = "/action/captcha/required",
         stringNotEmpty = function (str) {
             return str.length > 0 && str.trim();
         },
@@ -22,12 +29,50 @@ $(function () {
             "#input-welcome-comments": stringNotEmpty
         };
 
+    // the submit button is enabled unless we're still waiting on a required captcha
+    function updateSubmitEnabled() {
+        $submitButton.attr("disabled", captchaRequired && !captchaVerified);
+    }
+
+    function showCaptcha(withMessage) {
+        captchaRequired = true;
+        $captcha.show();
+        $captchaMessage.toggle(!!withMessage);
+        updateSubmitEnabled();
+    }
+
+    function hideCaptcha() {
+        captchaRequired = false;
+        $captcha.hide();
+        $captchaMessage.hide();
+        updateSubmitEnabled();
+    }
+
+    // force a fresh challenge so a stale/expired solution isn't reused
+    function resetCaptcha() {
+        captchaVerified = false;
+        if (captchaWidget && typeof captchaWidget.reset === "function") {
+            captchaWidget.reset();
+        }
+    }
+
+    if (captchaWidget) {
+        captchaWidget.addEventListener("statechange", function (ev) {
+            if (ev.detail.state === "verified") {
+                captchaVerified = true;
+                updateSubmitEnabled();
+            }
+        });
+    }
+
     // move the overlay up to the body tag so that it doesn't get caught up
     // in other CSS rules
     $overlay.appendTo(jQuery("body"));
     $successMessage.hide();
     $errorMessage.hide();
     $formValidate.hide();
+    $captcha.hide();
+    $captchaMessage.hide();
     // hide the spam-preventer input
     jQuery("#input-welcome-email2-ctrl").hide();
 
@@ -36,13 +81,33 @@ $(function () {
         $errorMessage.hide();
         $form.show();
         $formInputs.attr("disabled", false);
-        $submitButton.attr("disabled", true);
         $formValidate.hide();
+        $captchaMessage.hide();
         $formInputs.removeClass("invalid");
+        updateSubmitEnabled();
     });
 
     $triggerButton.click(function(evt) {
         evt.preventDefault();
+        // Ask the server whether this visitor needs to pass a captcha (logged-in or already
+        // verified users don't). Default to not requiring it if the check fails; the server
+        // still enforces captcha on submit and we recover gracefully in the error handler.
+        jQuery.ajax({
+            url: captchaCheckUrl,
+            type: "GET",
+            dataType: "json",
+            cache: false, // captcha requirement changes with login/session state; never serve a stale answer
+            success: function(data) {
+                if (data && data.required) {
+                    showCaptcha(false);
+                } else {
+                    hideCaptcha();
+                }
+            },
+            error: function() {
+                hideCaptcha();
+            }
+        });
         $overlay.modal({
             fadeDuration: 100
         });
@@ -69,23 +134,40 @@ $(function () {
             return;
         }
 
+        $formValidate.hide();
+        $captchaMessage.hide();
+        $formInputs.removeClass("invalid");
+
+        // Serialize BEFORE disabling inputs: jQuery's .serialize() skips disabled fields,
+        // so disabling first would drop every value (yiw-name, etc.) from the request.
+        var formData = $form.serialize();
+        $formInputs.attr("disabled", true);
+
         jQuery.ajax({
             url: url,
             type: "POST",
-            data: $form.serialize(),
+            data: formData,
             success: function() {
                 $form.hide();
                 $form[0].reset();
                 $successMessage.show();
-                $submitButton.attr("disabled", true);
+                captchaVerified = false;
+                updateSubmitEnabled();
             },
-            error: function() {
-                $form.hide();
-                $errorMessage.show();
+            error: function(jqXHR) {
+                // If the captcha became required since the form was opened (e.g. the session
+                // expired), surface the widget and let the user resend without losing their
+                // comment, instead of showing a generic error.
+                var response = jqXHR.responseJSON;
+                if (response && response.status === "CaptchaRequired") {
+                    $formInputs.attr("disabled", false);
+                    resetCaptcha();
+                    showCaptcha(true);
+                } else {
+                    $form.hide();
+                    $errorMessage.show();
+                }
             }
         });
-        $formValidate.hide();
-        $formInputs.removeClass("invalid");
-        $formInputs.attr("disabled", true);
     });
 });

--- a/source/org/zfin/infrastructure/captcha/CaptchaService.java
+++ b/source/org/zfin/infrastructure/captcha/CaptchaService.java
@@ -81,6 +81,30 @@ public class CaptchaService {
     }
 
     /**
+     * Determine whether the current request must pass a captcha challenge. A request is exempt
+     * (no captcha required) if the user is logged in, the captcha feature flag is off, the client
+     * IP is in a bypass range, or the session has already been verified by captcha.
+     *
+     * @param request The current request object
+     * @return true if the request still needs to pass a captcha challenge
+     */
+    public static boolean isCaptchaRequired(HttpServletRequest request) {
+        if (isLoggedIn()) {
+            return false;
+        }
+        if (!FeatureFlags.isFlagEnabled(FeatureFlagEnum.ENABLE_CAPTCHA)) {
+            return false;
+        }
+        if (isClientIpBypassed(request)) {
+            return false;
+        }
+        if (isSuccessfulCaptchaToken(request)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * If captcha rules require a redirection to run through the captcha validation process,
      * this method will return the URL to redirect to. If it returns empty, then no redirect is needed.
      *
@@ -88,16 +112,7 @@ public class CaptchaService {
      * @return If empty, no redirect is needed. Otherwise, use the value as the destination for a 302 redirect
      */
     public static Optional<String> getRedirectUrlIfNeeded(HttpServletRequest request) {
-        if (isLoggedIn()) {
-            return Optional.empty();
-        }
-        if (!FeatureFlags.isFlagEnabled(FeatureFlagEnum.ENABLE_CAPTCHA)) {
-            return Optional.empty();
-        }
-        if (isClientIpBypassed(request)) {
-            return Optional.empty();
-        }
-        if (isSuccessfulCaptchaToken(request)) {
+        if (!isCaptchaRequired(request)) {
             return Optional.empty();
         }
         String currentUrl = request.getRequestURL().toString();

--- a/source/org/zfin/infrastructure/presentation/CaptchaController.java
+++ b/source/org/zfin/infrastructure/presentation/CaptchaController.java
@@ -9,12 +9,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.zfin.framework.featureflag.FeatureFlagEnum;
 import org.zfin.framework.featureflag.FeatureFlags;
 import org.zfin.infrastructure.captcha.CaptchaKeys;
 import org.zfin.infrastructure.captcha.CaptchaService;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.zfin.infrastructure.captcha.CaptchaService.setSuccessfulCaptchaToken;
@@ -23,6 +25,17 @@ import static org.zfin.infrastructure.captcha.CaptchaService.setSuccessfulCaptch
 @Controller
 @RequestMapping("/captcha")
 public class CaptchaController {
+
+    /**
+     * Lightweight JSON endpoint the frontend can call to decide whether to present a captcha
+     * (e.g. before opening the feedback form). Returns {"required": true|false} based on the
+     * same rules as {@link CaptchaService#getRedirectUrlIfNeeded}.
+     */
+    @GetMapping("/required")
+    @ResponseBody
+    public Map<String, Boolean> captchaRequired(HttpServletRequest request) {
+        return Map.of("required", CaptchaService.isCaptchaRequired(request));
+    }
 
     @GetMapping("/challenge")
     public String challenge(

--- a/source/org/zfin/infrastructure/presentation/UserCommentController.java
+++ b/source/org/zfin/infrastructure/presentation/UserCommentController.java
@@ -18,7 +18,7 @@ import org.zfin.properties.ZfinPropertiesEnum;
 
 import java.io.IOException;
 
-import static org.zfin.infrastructure.captcha.CaptchaService.isSuccessfulCaptchaToken;
+import static org.zfin.infrastructure.captcha.CaptchaService.isCaptchaRequired;
 import static org.zfin.infrastructure.captcha.CaptchaService.verifyCaptcha;
 
 
@@ -62,14 +62,21 @@ public class UserCommentController {
             return new ResponseEntity<>(new JSONStatusResponse("Error", "Invalid field"), HttpStatus.BAD_REQUEST);
         }
 
-        boolean isCaptchaValid = true; //default to true if exception occurs
-        try {
-            boolean alreadyCaptchaValidated = isSuccessfulCaptchaToken(request);
-            isCaptchaValid = (!StringUtils.isEmpty(altcha) && verifyCaptcha(altcha)) || alreadyCaptchaValidated;
-        } catch (IOException e) {}
-
-        if (!isCaptchaValid) {
-            return new ResponseEntity<>(new JSONStatusResponse("Error", "Invalid Captcha Response"), HttpStatus.BAD_REQUEST);
+        // Only enforce captcha when this request actually requires it. Logged-in users, bypassed
+        // IPs, and sessions that already passed captcha are exempt (see CaptchaService). If the
+        // session expired since the form was opened, captcha may have become required - in that
+        // case we return a CaptchaRequired status so the client can surface the widget and let the
+        // user resend without losing their comment.
+        if (isCaptchaRequired(request)) {
+            boolean isCaptchaValid = true; //default to true if verification errors, to avoid blocking legitimate input
+            try {
+                isCaptchaValid = !StringUtils.isEmpty(altcha) && verifyCaptcha(altcha);
+            } catch (IOException e) {
+                log.error("Error verifying captcha for user comment submission", e);
+            }
+            if (!isCaptchaValid) {
+                return new ResponseEntity<>(new JSONStatusResponse("CaptchaRequired", "Captcha verification required"), HttpStatus.BAD_REQUEST);
+            }
         }
 
         logSubmissionRequest(request, name, institution, email, subject);


### PR DESCRIPTION

The Your Input Welcome feedback form always showed an Altcha captcha. Omit it when a captcha is not actually required, reusing the rules in getRedirectUrlIfNeeded (logged in, flag off, bypassed IP, or already verified).

- CaptchaService: extract isCaptchaRequired(request); getRedirectUrlIfNeeded now delegates to it.
- CaptchaController: add GET /captcha/required returning {"required": bool} so the frontend can decide whether to present the widget.
- UserCommentController: only enforce captcha when isCaptchaRequired; return a distinct "CaptchaRequired" status (not a generic error) so the client can recover.
- your-input-welcome.js: consult the endpoint on open; hide the widget and enable submit when not required; on a CaptchaRequired submit response (e.g. session expired), reveal the widget and let the user resend without losing their comment.
- yourInputWelcome.tag: captcha hidden by default; JS reveals it only when needed; statechange handling moved into the JS file.