### PR TITLE
ZFIN-10316: trim whitespace in NumberTextBox coordinate fields

### DIFF
--- a/source/org/zfin/gwt/root/ui/NumberTextBox.java
+++ b/source/org/zfin/gwt/root/ui/NumberTextBox.java
@@ -7,9 +7,10 @@ public class NumberTextBox extends AbstractTextBox<Integer> {
     @Override
     public Integer getBoxValue() {
         String text = super.getText();
-        if (text.trim().length() == 0) {
+        if (text == null || text.trim().length() == 0) {
             return null;
         } else {
+            text = text.trim();
             if (StringUtils.isNumeric(text))
                 return Integer.parseInt(text);
             else
@@ -30,7 +31,7 @@ public class NumberTextBox extends AbstractTextBox<Integer> {
             return true;
         if (text.trim().length() == 0)
             return true;
-        return StringUtils.isNumeric(text);
+        return StringUtils.isNumeric(text.trim());
     }
 
     @Override
@@ -44,11 +45,12 @@ public class NumberTextBox extends AbstractTextBox<Integer> {
         if (text == null) {
             return false;
         }
-        if (!StringUtils.isNumeric(text))
-            return false;
-        if (text.trim().length() == 0) {
+        text = text.trim();
+        if (text.length() == 0) {
             return number.equals(0);
         }
+        if (!StringUtils.isNumeric(text))
+            return false;
         Integer textValue = Integer.parseInt(text);
         return textValue.equals(number);
     }


### PR DESCRIPTION
Pasting trailing/leading whitespace after a coordinate (e.g. "246810 ") caused StringUtils.isNumeric to return false, so getBoxValue returned null. That blocked reference-sequence auto-generation and produced a validation error when adding the line.

Trim the text before validating/parsing in getBoxValue, isValid, and isFieldEqual so surrounding whitespace is ignored across all numeric curation inputs.