### PR TITLE
ZFIN-10314: carry probe through figure page links and show Probe

### DIFF
--- a/home/WEB-INF/jsp/figure/figure-view-summary.jsp
+++ b/home/WEB-INF/jsp/figure/figure-view-summary.jsp
@@ -12,13 +12,23 @@
         ${figure.publication.title}
     </z:attributeListItem>
 
+    <c:if test="${!empty probe}">
+        <z:attributeListItem label="Probe">
+            <zfin:link entity="${probe}"/>
+        </z:attributeListItem>
+    </c:if>
+
     <c:if test="${!isLargeDataPublication}">
         <z:attributeListItem label="Other Figures">
             <zfin2:toggledLinkList collection="${otherFigures}" maxNumber="5" commaDelimited="true"/>
         </z:attributeListItem>
 
+        <c:set var="probeUrlPart" value=""/>
+        <c:if test="${!empty probe}">
+            <c:set var="probeUrlPart" value="?probeZdbID=${probe.zdbID}"/>
+        </c:if>
         <z:attributeListItem label="All Figure Page">
-            <a href="/action/publication/${figure.publication.zdbID}/all-figures">Back to All Figure Page</a>
+            <a href="/action/publication/${figure.publication.zdbID}/all-figures${probeUrlPart}">Back to All Figure Page</a>
         </z:attributeListItem>
     </c:if>
 

--- a/source/org/zfin/figure/presentation/FigureViewController.java
+++ b/source/org/zfin/figure/presentation/FigureViewController.java
@@ -59,7 +59,7 @@ public class FigureViewController {
             model.addAttribute("probeSuppliers", suppliers);
         }
 
-        List<Figure> otherFigures = figureViewService.getOrderedFiguresForPublication(figure.getPublication());
+        List<Figure> otherFigures = figureViewService.getFiguresForPublicationAndProbe(figure.getPublication(), probe);
         model.addAttribute("otherFigures", otherFigures);
 
         List<PhenotypeWarehouse> warehouseList = getPhenotypeRepository().getPhenotypeWarehouse(figure.getZdbID());


### PR DESCRIPTION
For Thisse / direct-submission figures, the figure page is viewed in the context of a single probe. Restore probe-awareness that was lost in the figure page rewrite (#665):

- "Back to All Figure Page" link now passes ?probeZdbID so it lands on the probe-filtered all-figures page (< 50 figures) instead of the publication-figures-unavailable dead end.
- "Other Figures" list is now probe-limited via getFiguresForPublicationAndProbe rather than the full publication's figures.
- Add a "Probe" row to the figure summary linking to the clone.