### PR TITLE
ZFIN-10314: Figure link improvement

### DIFF
--- a/home/WEB-INF/jsp/figure/image-view.jsp
+++ b/home/WEB-INF/jsp/figure/image-view.jsp
@@ -53,22 +53,36 @@
                         <zfin2:toggledLinkList collection="${antibodyList}" maxNumber="5" commaDelimited="true"/>
                     </z:attributeListItem>
                 </c:if>
-                <z:attributeListItem label="Source">
-                    <c:if test="${!empty image.figure && fn:length(image.figure.publication.figures) > 1}">
-                        <c:set var="probeUrlPart" value=""/>
-                        <c:set var="probeDisplay" value=""/>
-                        <c:if test="${!empty probe}">
-                            <c:set var="probeUrlPart" value="?probeZdbID=${probe.zdbID}"/>
-                            <c:set var="probeDisplay" value="[${probe.abbreviation}]"/>
-                        </c:if>
 
-                        <c:if test="${image.figure.publication.type == CURATION}">
+
+                <z:attributeListItem label="Publication">
+                    <zfin:link entity="${image.figure.publication}" longVersion="true"/> -
+                    ${image.figure.publication.title}
+                </z:attributeListItem>
+
+
+
+
+
+
+                <z:attributeListItem label="All Figures">
+                    <c:if test="${!empty image.figure && fn:length(image.figure.publication.figures) > 1}">
+                        <c:if test="${!isLargeDataPublication}">
+                            <c:set var="probeUrlPart" value=""/>
+                            <c:set var="probeDisplay" value=""/>
                             <c:if test="${!empty probe}">
-                                <a class="additional-figures-link" href="/action/publication/${image.figure.publication.zdbID}/all-figures${probeUrlPart}">All Figures for ${image.figure.publication.shortAuthorList}</a>
+                                <c:set var="probeUrlPart" value="?probeZdbID=${probe.zdbID}"/>
+                                <c:set var="probeDisplay" value="[${probe.abbreviation}]"/>
                             </c:if>
-                        </c:if>
-                        <c:if test="${image.figure.publication.type != CURATION}">
-                            <a class="additional-figures-link" href="/action/publication/${image.figure.publication.zdbID}/all-figures${probeUrlPart}">Figures for ${image.figure.publication.shortAuthorList}${probeDisplay}</a>
+
+                            <c:if test="${image.figure.publication.type == CURATION}">
+                                <c:if test="${!empty probe}">
+                                    <a class="additional-figures-link" href="/action/publication/${image.figure.publication.zdbID}/all-figures${probeUrlPart}">All Figures for ${image.figure.publication.shortAuthorList}</a>
+                                </c:if>
+                            </c:if>
+                            <c:if test="${image.figure.publication.type != CURATION}">
+                                <a class="additional-figures-link" href="/action/publication/${image.figure.publication.zdbID}/all-figures${probeUrlPart}">Figures for ${image.figure.publication.shortAuthorList}${probeDisplay}</a>
+                            </c:if>
                         </c:if>
                     </c:if>
                 </z:attributeListItem>

--- a/home/WEB-INF/jsp/figure/image-view.jsp
+++ b/home/WEB-INF/jsp/figure/image-view.jsp
@@ -55,19 +55,21 @@
                 </c:if>
 
 
-                <z:attributeListItem label="Publication">
-                    <zfin:link entity="${image.figure.publication}" longVersion="true"/> -
-                    ${image.figure.publication.title}
-                </z:attributeListItem>
+                <c:if test="${!empty image.figure && !empty image.figure.publication}">
+                    <z:attributeListItem label="Publication">
+                        <zfin:link entity="${image.figure.publication}" longVersion="true"/> -
+                        ${image.figure.publication.title}
+                    </z:attributeListItem>
+                </c:if>
 
 
 
 
 
 
-                <z:attributeListItem label="All Figures">
-                    <c:if test="${!empty image.figure && fn:length(image.figure.publication.figures) > 1}">
-                        <c:if test="${!isLargeDataPublication}">
+                <c:if test="${!empty image.figure && fn:length(image.figure.publication.figures) > 1}">
+                    <c:if test="${!isLargeDataPublication}">
+                        <z:attributeListItem label="All Figures">
                             <c:set var="probeUrlPart" value=""/>
                             <c:set var="probeDisplay" value=""/>
                             <c:if test="${!empty probe}">
@@ -83,9 +85,9 @@
                             <c:if test="${image.figure.publication.type != CURATION}">
                                 <a class="additional-figures-link" href="/action/publication/${image.figure.publication.zdbID}/all-figures${probeUrlPart}">Figures for ${image.figure.publication.shortAuthorList}${probeDisplay}</a>
                             </c:if>
-                        </c:if>
+                        </z:attributeListItem>
                     </c:if>
-                </z:attributeListItem>
+                </c:if>
             </z:attributeList>
         </div>
 

--- a/source/org/zfin/figure/service/FigureViewService.java
+++ b/source/org/zfin/figure/service/FigureViewService.java
@@ -436,6 +436,9 @@ public class FigureViewService {
     }
 
     public Clone getProbeForFigure(Figure figure) {
+        if (figure == null) {
+            return null;
+        }
         Clone probe = null;
         if (!CollectionUtils.isEmpty(figure.getExpressionFigureStage())) {
             ExpressionFigureStage figureStage = figure.getExpressionFigureStage().iterator().next();

--- a/source/org/zfin/publication/presentation/ImageViewController.java
+++ b/source/org/zfin/publication/presentation/ImageViewController.java
@@ -64,9 +64,11 @@ public class ImageViewController {
             }
         }
 
-
         model.addAttribute("image", image);
         Figure figure = image.getFigure();
+        Clone probe = figureViewService.getProbeForFigure(figure);
+        model.addAttribute("probe", probe);
+
         if (figure!=null) {
             model.addAttribute(LookupStrings.DYNAMIC_TITLE, "Image: " + figureViewService.getFullFigureLabel(image.getFigure()));
             model.addAttribute("expressionGeneList", figureViewService.getExpressionGenes(image.getFigure()));
@@ -79,8 +81,6 @@ public class ImageViewController {
 
             model.addAttribute("expressionSummaryMap", expressionSummaryMap);
             model.addAttribute("phenotypeSummaryMap", phenotypeSummaryMap);
-            Clone probe = figureViewService.getProbeForFigure(figure);
-            model.addAttribute("probe", probe);
         }
 
         model.addAttribute("directLink", true);
@@ -95,6 +95,7 @@ public class ImageViewController {
         ImageNavigationMenu navigationMenu = new ImageNavigationMenu();
         navigationMenu.setModel(model);
         model.addAttribute("navigationMenu", navigationMenu);
+        model.addAttribute("isLargeDataPublication", figureViewService.isLargeDataPublication(figure.getPublication(), probe));
 
         return "figure/image-view";
     }

--- a/source/org/zfin/publication/presentation/ImageViewController.java
+++ b/source/org/zfin/publication/presentation/ImageViewController.java
@@ -85,17 +85,19 @@ public class ImageViewController {
 
         model.addAttribute("directLink", true);
 
+        boolean isLargeDataPublication = false;
         if (image.getFigure() != null && image.getFigure().getPublication() != null ) {
             Publication publication = image.getFigure().getPublication();
             model.addAttribute("publication", publication);
             model.addAttribute("showElsevierMessage", figureViewService.showElsevierMessage(publication));
             model.addAttribute("hasAcknowledgment", figureViewService.hasAcknowledgment(publication));
+            isLargeDataPublication = figureViewService.isLargeDataPublication(publication, probe);
         }
 
         ImageNavigationMenu navigationMenu = new ImageNavigationMenu();
         navigationMenu.setModel(model);
         model.addAttribute("navigationMenu", navigationMenu);
-        model.addAttribute("isLargeDataPublication", figureViewService.isLargeDataPublication(figure.getPublication(), probe));
+        model.addAttribute("isLargeDataPublication", isLargeDataPublication);
 
         return "figure/image-view";
     }


### PR DESCRIPTION
The image page should handle large data publications in the same way as the figure page:

Hide "all figures" link for pubs with a lot of figures, but show the link if the pub has probe information and limit the results to only the probe figures.