### PR TITLE
ZFIN-10277: make disease/phenotype page ordering deterministic

### DIFF
--- a/source/org/zfin/ui/repository/HibernateDiseasePageRepository.java
+++ b/source/org/zfin/ui/repository/HibernateDiseasePageRepository.java
@@ -105,7 +105,8 @@ public class HibernateDiseasePageRepository implements DiseasePageRepository {
                 hql += "LOWER(" + entry.getKey() + ") like '%" + entry.getValue().toLowerCase() + "%' ";
             }
         }
-        hql += "order by fishStat.fish.order, fishStat.fish.nameOrder, fishStat.geneSymbolSearch";
+        hql += "order by fishStat.fish.order, fishStat.fish.nameOrder, fishStat.geneSymbolSearch, " +
+               "fishStat.fish.zdbID, fishStat.figure.zdbID, fishStat.publication.zdbID, fishStat.term.zdbID";
         Query<FishStatistics> query = HibernateUtil.currentSession().createQuery(hql, FishStatistics.class);
         if (includeChildren) {
             query.setParameterList("ids", matchingIds);
@@ -138,7 +139,8 @@ public class HibernateDiseasePageRepository implements DiseasePageRepository {
                 hql += "LOWER(" + entry.getKey() + ") like '%" + entry.getValue().toLowerCase() + "%' ";
             }
         }
-        hql += " order by fishModelDisplay.order, fishModelDisplay.fish.order, upper(fishModelDisplay.fish.displayName) ";
+        hql += " order by fishModelDisplay.order, fishModelDisplay.fish.order, upper(fishModelDisplay.fish.displayName), " +
+               "fishModelDisplay.fish.zdbID, fishModelDisplay.experiment.zdbID, fishModelDisplay.publication.zdbID, fishModelDisplay.disease.zdbID ";
         Query<FishModelDisplay> query = HibernateUtil.currentSession().createQuery(hql, FishModelDisplay.class);
         if (includeChildren) {
             query.setParameterList("ids", matchingIds);
@@ -165,7 +167,8 @@ public class HibernateDiseasePageRepository implements DiseasePageRepository {
             hql = "select chebiDisplay from ChebiFishModelDisplay as chebiDisplay " +
                   "where chebiDisplay.id in :ids ";
         }
-        hql += " order by chebiDisplay.fishModelDisplay.order, chebiDisplay.fishModelDisplay.fish.order, upper(chebiDisplay.fishModelDisplay.fish.displayName) ";
+        hql += " order by chebiDisplay.fishModelDisplay.order, chebiDisplay.fishModelDisplay.fish.order, upper(chebiDisplay.fishModelDisplay.fish.displayName), " +
+               "chebiDisplay.fishModelDisplay.fish.zdbID, chebiDisplay.fishModelDisplay.experiment.zdbID, chebiDisplay.fishModelDisplay.publication.zdbID, chebiDisplay.term.zdbID ";
         Query<ChebiFishModelDisplay> query = HibernateUtil.currentSession().createQuery(hql, ChebiFishModelDisplay.class);
         if (includeChildren) {
             query.setParameterList("ids", matchingIds);
@@ -224,7 +227,8 @@ public class HibernateDiseasePageRepository implements DiseasePageRepository {
                 hql += entry + " is not null ";
             }
         }
-        hql += "order by chebiPhenotype.fish.displayName";
+        hql += "order by chebiPhenotype.fish.displayName, " +
+               "chebiPhenotype.fish.zdbID, chebiPhenotype.figure.zdbID, chebiPhenotype.publication.zdbID, chebiPhenotype.experiment.zdbID, chebiPhenotype.term.zdbID";
         Query<ChebiPhenotypeDisplay> query = HibernateUtil.currentSession().createQuery(hql, ChebiPhenotypeDisplay.class);
         if (includeChildren) {
             query.setParameterList("ids", matchingIds);


### PR DESCRIPTION
The order-by clauses in HibernateDiseasePageRepository only sorted on non-unique display columns (fish order/name, gene symbol, display name). Rows tying on those columns had undefined relative order, so PostgreSQL could return them differently between executions, producing unstable ordering and inconsistent pagination across pages.

Append each row's natural key (persistent ZDB IDs, stable across table rebuilds) as a tie-breaker to establish a total order on all four queries: getPhenotype, getFishDiseaseModels, getFishDiseaseChebiModels, and getPhenotypeChebi. Display ordering is unchanged for non-tied rows.

Test endpoints (results should be identical across repeated requests and consistent page-to-page):

  getPhenotype (the reported case):
    /action/api/ontology/ZDB-TERM-100331-504/phenotype?directAnnotation=true&limit=25&page=1
    /action/api/ontology/ZDB-TERM-100331-504/phenotype?directAnnotation=false&limit=25&page=1

  getPhenotypeChebi:
    /action/api/ontology/ZDB-TERM-100331-504/phenotype-chebi?limit=25&page=1

  getFishDiseaseModels:
    /action/api/ontology/ZDB-TERM-100331-504/zebrafish-models?limit=25&page=1

  getFishDiseaseChebiModels:
    /action/api/ontology/ZDB-TERM-100331-504/chebi-zebrafish-models?limit=25&page=1