### PR TITLE
ZFIN-8948 follow-up: add GOA load impact tables to report

### DIFF
--- a/server_apps/DB_maintenance/build.gradle
+++ b/server_apps/DB_maintenance/build.gradle
@@ -40,6 +40,7 @@ task validateBlastDatabases(type: JavaExec) {
 }
 
 task loadGafGoa(type: JavaExec) {
+    dependsOn ":copyClasspathTemplates"
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'org.zfin.datatransfer.go.service.GafLoadJob'
     args = [

--- a/source/org/zfin/datatransfer/go/service/GafLoadJob.java
+++ b/source/org/zfin/datatransfer/go/service/GafLoadJob.java
@@ -168,6 +168,13 @@ public class GafLoadJob extends AbstractValidateDataReportTask {
             gafService.generateRemovedEntries(gafJobData, gafOrganization);
             List<GafJobEntry> optional = Optional.ofNullable(gafJobData.getRemovedEntries()).orElse(new ArrayList<>());
             System.out.println("Removed entries: " + optional.size());
+
+            // Snapshot DB counts attributed to this organization just before any
+            // mutation, then again after add/update/remove, for the report's
+            // "Load impact" section. GOA-only because that's where the user-
+            // requested before/after comparison applies.
+            GoaLoadSnapshot beforeSnapshot = captureSnapshotIfGoa(gafOrganization);
+
             logger.info("Before adding new one");
             addAnnotations(gafJobData);
             logger.info("Before updating");
@@ -175,6 +182,8 @@ public class GafLoadJob extends AbstractValidateDataReportTask {
 
             logger.info("Before removing");
             removeAnnotations(gafJobData);
+
+            GoaLoadSnapshot afterSnapshot = captureSnapshotIfGoa(gafOrganization);
             FileWriter summary = new FileWriter(new File(new File(dataDirectory, jobName), jobName + "_summary.txt"));
             FileWriter details = new FileWriter(new File(new File(dataDirectory, jobName), jobName + "_details.txt"));
 
@@ -230,7 +239,7 @@ public class GafLoadJob extends AbstractValidateDataReportTask {
                 logger.warn("Failed to generate error summary", ex);
             }
 
-            writeHtmlReport(gafJobData, errorSummary);
+            writeHtmlReport(gafJobData, errorSummary, beforeSnapshot, afterSnapshot);
 
             //throw an exception if parser encountered an error
             //do this at the end so the load works for records that are valid
@@ -328,19 +337,36 @@ public class GafLoadJob extends AbstractValidateDataReportTask {
     }
 
     /** Generate the HTML report viewer alongside the .txt artifacts. */
-    private void writeHtmlReport(GafJobData gafJobData, GafErrorSummary errorSummary) {
+    private void writeHtmlReport(GafJobData gafJobData, GafErrorSummary errorSummary,
+                                 GoaLoadSnapshot beforeSnapshot, GoaLoadSnapshot afterSnapshot) {
         try {
             File htmlReport = new File(new File(dataDirectory, jobName), jobName + ".html");
             List<String> sources = organization.equals("GOA")
                 ? List.of(downloadUrl, downloadUrl2, downloadUrl3)
                 : List.of(downloadUrl);
             Report report = new GafReportBuilder()
-                .build(jobName, organization, sources, gafJobData, errorSummary);
+                .build(jobName, organization, sources, gafJobData, errorSummary,
+                       beforeSnapshot, afterSnapshot);
             new ReportWriter().write(report, htmlReport);
             logger.info("HTML report written to: {}", htmlReport.getAbsolutePath());
             System.out.println("HTML report written to: " + htmlReport.getAbsolutePath());
         } catch (Exception ex) {
             logger.warn("Failed to generate HTML report", ex);
+        }
+    }
+
+    /**
+     * Capture a DB snapshot of GOA-attributed annotations, or return null for
+     * non-GOA loads or if the query fails. Snapshot failures are reported but
+     * never fail the load — the report just won't include the impact section.
+     */
+    private GoaLoadSnapshot captureSnapshotIfGoa(GafOrganization gafOrganization) {
+        if (!"GOA".equals(organization)) return null;
+        try {
+            return GoaLoadSnapshot.capture(gafOrganization);
+        } catch (Exception ex) {
+            logger.warn("Failed to capture GOA load snapshot", ex);
+            return null;
         }
     }
 

--- a/source/org/zfin/datatransfer/go/service/GafReportBuilder.java
+++ b/source/org/zfin/datatransfer/go/service/GafReportBuilder.java
@@ -11,8 +11,10 @@ import org.zfin.report.ReportTable;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -53,6 +55,16 @@ public class GafReportBuilder {
                         List<String> sourceUrls,
                         GafJobData data,
                         GafErrorSummary errorSummary) {
+        return build(jobName, organization, sourceUrls, data, errorSummary, null, null);
+    }
+
+    public Report build(String jobName,
+                        String organization,
+                        List<String> sourceUrls,
+                        GafJobData data,
+                        GafErrorSummary errorSummary,
+                        GoaLoadSnapshot before,
+                        GoaLoadSnapshot after) {
 
         // No subtitle: the renderer already formats createdAt locale-aware
         // in the footer, so a server-locale Date.toString() above would be
@@ -72,7 +84,7 @@ public class GafReportBuilder {
                 "Use the navigation tree on the left to drill into added, updated, removed, " +
                 "and errored annotations. Counts and a categorized error breakdown are below."));
 
-        addSummaryTables(root, data, errorSummary, sourceUrls);
+        addSummaryTables(root, data, errorSummary, sourceUrls, organization, before, after);
         report.root(root);
 
         root.addChild(buildAdded(data));
@@ -144,7 +156,8 @@ public class GafReportBuilder {
     // -------- summary tables (root) --------
 
     private void addSummaryTables(ReportNode root, GafJobData data, GafErrorSummary errorSummary,
-                                  List<String> sourceUrls) {
+                                  List<String> sourceUrls, String organization,
+                                  GoaLoadSnapshot before, GoaLoadSnapshot after) {
         ReportTable counts = new ReportTable()
             .schemaRef(SCHEMA_COUNT)
             .title("Action breakdown")
@@ -174,6 +187,8 @@ public class GafReportBuilder {
                 .forEach(e -> t.addRow("label", e.getKey(), "count", e.getValue()));
             root.addTable(t);
         }
+
+        appendLoadImpactTables(root, organization, before, after);
 
         if (sourceUrls != null && !sourceUrls.isEmpty()) {
             for (String url : sourceUrls) {
@@ -428,6 +443,99 @@ public class GafReportBuilder {
                 "type", GafErrorSummary.idType(e.getKey()),
                 "count", e.getValue()));
         node.addTable(idTable);
+    }
+
+    /**
+     * Append the three "Load impact" tables (overall / per evidence code /
+     * per source pub) inline on the given node — typically the root summary —
+     * showing MGOE counts attributed to the organization, measured immediately
+     * before and after the load. No-op for non-GOA loads or when either
+     * snapshot is missing (e.g. a snapshot query failed mid-load).
+     */
+    private void appendLoadImpactTables(ReportNode node, String organization,
+                                        GoaLoadSnapshot before, GoaLoadSnapshot after) {
+        if (before == null || after == null) return;
+        node.addTable(buildOverallImpactTable(before, after));
+        node.addTable(buildEvidenceCodeImpactTable(before, after));
+        node.addTable(buildSourceImpactTable(before, after));
+    }
+
+    private ReportTable buildOverallImpactTable(GoaLoadSnapshot before, GoaLoadSnapshot after) {
+        ReportTable table = newImpactTable("Totals", "label", "Metric");
+        addImpactRow(table, "Total annotations",
+            before.getTotalAnnotations(), after.getTotalAnnotations());
+        addImpactRow(table, "Distinct GO terms used",
+            before.getDistinctGoTerms(), after.getDistinctGoTerms());
+        addImpactRow(table, "Markers with annotation",
+            before.getDistinctMarkers(), after.getDistinctMarkers());
+        return table;
+    }
+
+    private ReportTable buildEvidenceCodeImpactTable(GoaLoadSnapshot before, GoaLoadSnapshot after) {
+        ReportTable table = newImpactTable(
+            "Annotations per evidence code",
+            "label", "Evidence code");
+        for (String code : unionKeys(before.getCountsByEvidenceCode(), after.getCountsByEvidenceCode())) {
+            addImpactRow(table, code,
+                before.getCountsByEvidenceCode().getOrDefault(code, 0L),
+                after.getCountsByEvidenceCode().getOrDefault(code, 0L));
+        }
+        return table;
+    }
+
+    private ReportTable buildSourceImpactTable(GoaLoadSnapshot before, GoaLoadSnapshot after) {
+        // Source is a publication ZDB ID — render it as a ZFIN link via the
+        // shared "publication" field def so curators can click through. Rows
+        // whose net change is zero are dropped: most source pubs don't move
+        // each load and the unchanged rows drown out the interesting ones.
+        ReportTable table = new ReportTable()
+            .title("Annotations per source publication (excluding unchanged)")
+            .description("Before/after counts grouped by source publication; unchanged rows omitted.")
+            .addColumn(ReportTable.Column.of("label",   "Publication", "publication"))
+            .addColumn(ReportTable.Column.of("before",  "# Before",    "count"))
+            .addColumn(ReportTable.Column.of("after",   "# After",     "count"))
+            .addColumn(ReportTable.Column.of("change",  "Net change",  "count"))
+            .addColumn(ReportTable.Column.of("percent", "% change"));
+        for (String src : unionKeys(before.getCountsBySource(), after.getCountsBySource())) {
+            long b = before.getCountsBySource().getOrDefault(src, 0L);
+            long a = after.getCountsBySource().getOrDefault(src, 0L);
+            if (a == b) continue;
+            addImpactRow(table, src, b, a);
+        }
+        return table;
+    }
+
+    private ReportTable newImpactTable(String title, String labelKey, String labelHeader) {
+        return new ReportTable()
+            .title(title)
+            .addColumn(ReportTable.Column.of(labelKey, labelHeader))
+            .addColumn(ReportTable.Column.of("before",  "# Before",   "count"))
+            .addColumn(ReportTable.Column.of("after",   "# After",    "count"))
+            .addColumn(ReportTable.Column.of("change",  "Net change", "count"))
+            .addColumn(ReportTable.Column.of("percent", "% change"));
+    }
+
+    private static void addImpactRow(ReportTable table, String label, long before, long after) {
+        long change = after - before;
+        // Skip rows that are zero on both sides — usually means the category
+        // didn't exist in either snapshot and adds no signal.
+        if (before == 0 && after == 0) return;
+        String percent = before == 0
+            ? (after == 0 ? "" : "—")
+            : String.format("%+.2f%%", (change * 100.0) / before);
+        table.addRow(
+            "label",   label,
+            "before",  before,
+            "after",   after,
+            "change",  change,
+            "percent", percent);
+    }
+
+    /** Ordered union of keys: present-in-both first by descending after-count, then before-only. */
+    private static Set<String> unionKeys(Map<String, Long> before, Map<String, Long> after) {
+        Set<String> keys = new LinkedHashSet<>(after.keySet());
+        keys.addAll(before.keySet());
+        return keys;
     }
 
     private ReportNode buildExisting(GafJobData data) {

--- a/source/org/zfin/datatransfer/go/service/GoaLoadSnapshot.java
+++ b/source/org/zfin/datatransfer/go/service/GoaLoadSnapshot.java
@@ -1,0 +1,107 @@
+package org.zfin.datatransfer.go.service;
+
+import org.zfin.datatransfer.go.GafOrganization;
+import org.zfin.framework.HibernateUtil;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Point-in-time snapshot of {@code marker_go_term_evidence} rows attributed to
+ * a given {@link GafOrganization}. Captured once before the GAF/GOA load and
+ * once after, the pair drives the "Load impact" tables in the report.
+ *
+ * <p>Filtering is done through the {@code gafOrganization} association (FK to
+ * {@code marker_go_term_evidence_annotation_organization}), matching how
+ * {@code GafService.findOutdatedEntries} identifies the load's existing rows.
+ */
+public class GoaLoadSnapshot {
+
+    private final Map<String, Long> countsByEvidenceCode;
+    private final long distinctGoTerms;
+    private final long distinctMarkers;
+    private final Map<String, Long> countsBySource;
+
+    private GoaLoadSnapshot(Map<String, Long> countsByEvidenceCode,
+                            long distinctGoTerms,
+                            long distinctMarkers,
+                            Map<String, Long> countsBySource) {
+        this.countsByEvidenceCode = countsByEvidenceCode;
+        this.distinctGoTerms = distinctGoTerms;
+        this.distinctMarkers = distinctMarkers;
+        this.countsBySource = countsBySource;
+    }
+
+    public Map<String, Long> getCountsByEvidenceCode() { return countsByEvidenceCode; }
+    public long getDistinctGoTerms()                   { return distinctGoTerms; }
+    public long getDistinctMarkers()                   { return distinctMarkers; }
+    public Map<String, Long> getCountsBySource()       { return countsBySource; }
+
+    public long getTotalAnnotations() {
+        return countsByEvidenceCode.values().stream().mapToLong(Long::longValue).sum();
+    }
+
+    public static GoaLoadSnapshot capture(GafOrganization gafOrganization) {
+        return new GoaLoadSnapshot(
+            countByEvidenceCode(gafOrganization),
+            distinctGoTerms(gafOrganization),
+            distinctMarkers(gafOrganization),
+            countBySource(gafOrganization));
+    }
+
+    private static Map<String, Long> countByEvidenceCode(GafOrganization org) {
+        String hql = "select ev.evidenceCode.code, count(ev) " +
+                     "  from MarkerGoTermEvidence ev " +
+                     " where ev.gafOrganization = :org " +
+                     " group by ev.evidenceCode.code";
+        List<Object[]> rows = HibernateUtil.currentSession()
+            .createQuery(hql, Object[].class)
+            .setParameter("org", org)
+            .list();
+        return toSortedMap(rows);
+    }
+
+    private static long distinctGoTerms(GafOrganization org) {
+        String hql = "select count(distinct ev.goTerm) " +
+                     "  from MarkerGoTermEvidence ev " +
+                     " where ev.gafOrganization = :org";
+        return scalar(hql, org);
+    }
+
+    private static long distinctMarkers(GafOrganization org) {
+        String hql = "select count(distinct ev.marker) " +
+                     "  from MarkerGoTermEvidence ev " +
+                     " where ev.gafOrganization = :org";
+        return scalar(hql, org);
+    }
+
+    private static Map<String, Long> countBySource(GafOrganization org) {
+        String hql = "select ev.source.zdbID, count(ev) " +
+                     "  from MarkerGoTermEvidence ev " +
+                     " where ev.gafOrganization = :org " +
+                     " group by ev.source.zdbID";
+        List<Object[]> rows = HibernateUtil.currentSession()
+            .createQuery(hql, Object[].class)
+            .setParameter("org", org)
+            .list();
+        return toSortedMap(rows);
+    }
+
+    private static long scalar(String hql, GafOrganization org) {
+        Long count = HibernateUtil.currentSession()
+            .createQuery(hql, Long.class)
+            .setParameter("org", org)
+            .uniqueResult();
+        return count == null ? 0L : count;
+    }
+
+    /** Sort by count descending so the most-used codes/sources land at the top. */
+    private static Map<String, Long> toSortedMap(List<Object[]> rows) {
+        Map<String, Long> out = new LinkedHashMap<>();
+        rows.stream()
+            .sorted((a, b) -> Long.compare((Long) b[1], (Long) a[1]))
+            .forEach(r -> out.put((String) r[0], (Long) r[1]));
+        return out;
+    }
+}


### PR DESCRIPTION
GoaLoadSnapshot captures four HQL counts of marker_go_term_evidence rows attributed to a GAF organization: per evidence code, distinct GO terms, distinct markers, and per source publication. GafLoadJob snapshots the DB once just before the first batch mutation and once after the last; non-GOA loads and snapshot failures are no-ops. GafReportBuilder appends three new tables (Totals, per evidence code, per source pub) inline on the root node just above the Source links, with Before / After / Net change / % change columns. Per-source rows with zero net change are dropped.

Also: declare an explicit dependsOn copyClasspathTemplates on the loadGafGoa gradle task — Gradle 8.14 strict validation flags the task otherwise, since the global wire in root build.gradle only covers root-project JavaExec tasks.