### PR TITLE
ZFIN-10306: attribute feature-gene attribution history to a real person

### DIFF
--- a/source/org/zfin/db/postGmakePostloaddb/1183/migrations/0020-ZFIN-9940-fix-guest-attribution-submitter.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1183/migrations/0020-ZFIN-9940-fix-guest-attribution-submitter.sql
@@ -1,0 +1,15 @@
+--liquibase formatted sql
+--changeset rtaylor:ZFIN-9940-fix-guest-attribution-submitter
+
+-- The CheckFeatureGeneAttributionTask was run with COMMIT_CHANGES=true during the
+-- release 1176 post-load (2025-12-16). Because the task runs without a logged-in user,
+-- every history row it wrote was attributed to the anonymous "Guest" fallback
+-- (submitter_id NULL, submitter_name 'Guest'). Re-attribute those ~8.4k rows to the
+-- developer who ran the task, Ryan Taylor (ZDB-PERS-210917-1), and note the ticket.
+UPDATE updates
+SET submitter_id   = 'ZDB-PERS-210917-1',
+    submitter_name = 'Taylor, Ryan',
+    comments       = comments || ' (See ZFIN-9940)'
+WHERE submitter_name = 'Guest'
+  AND field_name = 'record attribution'
+  AND comments = 'Added direct attribution to gene related to feature';

--- a/source/org/zfin/task/CheckFeatureGeneAttributionTask.java
+++ b/source/org/zfin/task/CheckFeatureGeneAttributionTask.java
@@ -10,6 +10,7 @@ import org.zfin.infrastructure.RecordAttribution;
 import org.zfin.infrastructure.repository.InfrastructureRepository;
 import org.zfin.marker.Marker;
 import org.zfin.ontology.datatransfer.AbstractScriptWrapper;
+import org.zfin.profile.Person;
 import org.zfin.publication.Publication;
 
 import java.io.BufferedWriter;
@@ -20,11 +21,18 @@ import java.util.*;
 
 import static org.zfin.publication.PublicationType.JOURNAL;
 import static org.zfin.repository.RepositoryFactory.*;
+import static org.zfin.util.ZfinSystemUtils.env;
 import static org.zfin.util.ZfinSystemUtils.envTrue;
 
 public class CheckFeatureGeneAttributionTask extends AbstractScriptWrapper {
 
+    // Person whose ZDB ID is supplied via SUBMITTER_PERSON_ID; the history records this task
+    // writes are attributed to this person. Required whenever COMMIT_CHANGES is set, so that
+    // committed changes are never logged against the anonymous "Guest" fallback (see ZFIN-9940).
+    private static final String SUBMITTER_PERSON_ID_ENV = "SUBMITTER_PERSON_ID";
+
     private boolean dryRun = true;
+    private Person submitter;
     private BufferedWriter csvWriter;
     private File outputFile;
 
@@ -53,11 +61,32 @@ public class CheckFeatureGeneAttributionTask extends AbstractScriptWrapper {
         if (envTrue("COMMIT_CHANGES")) {
             System.out.println("COMMIT_CHANGES is set, will commit changes to the database.");
             dryRun = false;
+            submitter = resolveSubmitter();
+            System.out.println("Attributing changes to " + submitter.getFullName() + " (" + submitter.getZdbID() + ")");
         } else {
             System.out.println("Dry run mode, will NOT commit changes to the database.");
             System.out.println("Set COMMIT_CHANGES environment variable to commit changes.");
             dryRun = true;
         }
+    }
+
+    /**
+     * Resolve the {@link Person} that committed changes will be attributed to, from the
+     * SUBMITTER_PERSON_ID environment variable. This task runs without a logged-in user, so
+     * without an explicit submitter the history would default to the "Guest" fallback. Fail
+     * fast (rather than silently logging "Guest") when committing.
+     */
+    private Person resolveSubmitter() {
+        String submitterId = env(SUBMITTER_PERSON_ID_ENV);
+        if (submitterId == null || submitterId.isBlank()) {
+            throw new IllegalStateException("COMMIT_CHANGES is set but " + SUBMITTER_PERSON_ID_ENV
+                + " is not provided. Set " + SUBMITTER_PERSON_ID_ENV + " to the ZDB person ID to attribute changes to.");
+        }
+        Person person = getProfileRepository().getPerson(submitterId.trim());
+        if (person == null) {
+            throw new IllegalStateException("No person found for " + SUBMITTER_PERSON_ID_ENV + "=" + submitterId);
+        }
+        return person;
     }
 
     private void checkFeature(Feature feature) {
@@ -83,7 +112,7 @@ public class CheckFeatureGeneAttributionTask extends AbstractScriptWrapper {
                 return;
             }
             infrastructureRepository.insertRecordAttribution(gene.zdbID, pub.getZdbID());
-            infrastructureRepository.insertUpdatesTable(gene.zdbID, "record attribution", pub.getZdbID(), "Added direct attribution to gene related to feature");
+            infrastructureRepository.insertUpdatesTable(gene.zdbID, submitter, "record attribution", null, pub.getZdbID(), "Added direct attribution to gene related to feature");
         }
     }
 


### PR DESCRIPTION
CheckFeatureGeneAttributionTask runs without a logged-in user, so when it was run with COMMIT_CHANGES=true during the release 1176 post-load (2025-12-16) every history row it wrote was attributed to the anonymous "Guest" fallback (submitter_id NULL, submitter_name 'Guest'), producing 8456 'record attribution' rows with submitter 'Guest'.

Require a SUBMITTER_PERSON_ID env var whenever COMMIT_CHANGES is set, resolve it to a Person, and write history via the Person overload so committed changes carry a real submitter. Fail fast (rather than silently logging 'Guest') when the var is missing/blank or names no person.

New invocation:
  COMMIT_CHANGES=true SUBMITTER_PERSON_ID=ZDB-PERS-210917-1 gradle checkFeatureGeneAttributionTask

Add a 1183 Liquibase migration to re-attribute the existing 8456 Guest rows to Ryan Taylor (ZDB-PERS-210917-1, who ran the task) and append " (See ZFIN-9940)" to their comments. Targets exactly those rows (submitter 'Guest' + 'record attribution' + exact comment) and is idempotent.