### PR TITLE
ZFIN-10278 follow-up: novalidate the feedback form so hidden Altcha checkbox stops blocking submit

### DIFF
--- a/home/WEB-INF/tags/yourInputWelcome.tag
+++ b/home/WEB-INF/tags/yourInputWelcome.tag
@@ -8,7 +8,15 @@
             Your Input Welcome
         </div>
         <div class="popup-body" id="input-welcome-body">
-            <form id="input-welcome-form">
+            <%-- novalidate: the Altcha widget injects a hidden <input type="checkbox" required>
+                 inside #input-welcome-captcha. When the server tells us the visitor doesn't
+                 need a captcha (logged-in / already verified), we hide that container via
+                 display:none — but the required checkbox is still in the DOM, so the browser's
+                 native validation tries to focus an unfocusable element on submit and logs
+                 "An invalid form control with name='' is not focusable." The form's JS does
+                 its own field validation (see `validators` in your-input-welcome.js) and gates
+                 the submit button on captcha state, so we don't need the browser's pass. --%>
+            <form id="input-welcome-form" novalidate>
                 We welcome your input and comments. Please use this form to report issues or recommend updates to the information in ZFIN. We
                 appreciate as much detail as possible and references as appropriate. We will review your comments promptly.
                 <div id="input-welcome-form-controls">

--- a/source/org/zfin/infrastructure/presentation/UserCommentController.java
+++ b/source/org/zfin/infrastructure/presentation/UserCommentController.java
@@ -43,7 +43,13 @@ public class UserCommentController {
                                                             @RequestParam("yiw-email") String email,
                                                             @RequestParam("yiw-subject") String subject,
                                                             @RequestParam("yiw-comments") String comments,
-                                                            @RequestParam("altcha") String altcha,
+                                                            // altcha is empty/missing when this visitor doesn't need to solve a
+                                                            // captcha (logged-in, bypassed IP, or already verified). The
+                                                            // isCaptchaRequired branch below skips verification entirely in
+                                                            // that case; the StringUtils.isEmpty(altcha) guard catches the
+                                                            // session-expired path. Required-by-default would 400 the request
+                                                            // before either of those checks ran.
+                                                            @RequestParam(value = "altcha", required = false, defaultValue = "") String altcha,
                                                             @RequestParam("email") String hiddenEmail,
                                                             @RequestHeader(value = "referer", defaultValue = "<none>") String referer,
                                                             HttpServletRequest request


### PR DESCRIPTION


The Altcha widget injects a hidden <input type="checkbox" required>. When the server tells us the visitor doesn't need a captcha (logged-in or already verified), #input-welcome-captcha is hidden via display:none — but the required checkbox is still in the DOM, so the browser's native form validation fires on submit and logs "An invalid form control with name='' is not focusable."

The form's JS does its own field validation (see `validators` in your-input-welcome.js) and gates the submit button on captcha state, so we don't need the browser's pass. novalidate disables it cleanly and is robust to Altcha widget internals.