### PR TITLE
Update command line utility to be able to load hibernate config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1501,22 +1501,14 @@ task copyClasspathTemplates(type: Copy) {
     into 'home/WEB-INF/classes'
 }
 compileJava.finalizedBy copyClasspathTemplates
-// compileTestJava reads from home/WEB-INF/classes (the same dir that
-// copyClasspathTemplates writes into), so Gradle needs the dependency
-// declared explicitly. Same applies to test runtime / processTestResources.
-compileTestJava.dependsOn copyClasspathTemplates
-processTestResources.dependsOn copyClasspathTemplates
-// Every JavaExec task uses sourceSets.main.runtimeClasspath, which includes
-// home/WEB-INF/classes (the dir copyClasspathTemplates writes into). Gradle 8.x
-// strict validation fails any such task without an explicit dependency edge, so
-// wire them all up here rather than per-task.
-tasks.withType(JavaExec).configureEach {
-    dependsOn copyClasspathTemplates
-}
-// jar packages the main sourceSet output, which includes home/WEB-INF/classes
-// (the dir copyClasspathTemplates writes into). Without this edge, installDist ->
-// jar fails the same Gradle 8.x strict validation (e.g. during installUtilities).
-jar.dependsOn copyClasspathTemplates
+// Register home/WEB-INF/classes as an output of the main source set, built by
+// copyClasspathTemplates. Because it is part of sourceSets.main.output, every task
+// that consumes that output -- jar, war, all JavaExec (via runtimeClasspath),
+// compileTestJava and the tests (via classpath) -- automatically gains a dependency
+// on copyClasspathTemplates. This replaces the per-task dependsOn edges that Gradle
+// 8.x strict validation otherwise demands (and that new tasks kept forgetting).
+// Custom tasks that copy this dir by hand (e.g. dirtycopy) still declare it explicitly.
+sourceSets.main.output.dir('home/WEB-INF/classes', builtBy: copyClasspathTemplates)
 
 // ============================================================================
 // GWT COMPILATION TASKS

--- a/build.gradle
+++ b/build.gradle
@@ -1513,6 +1513,10 @@ processTestResources.dependsOn copyClasspathTemplates
 tasks.withType(JavaExec).configureEach {
     dependsOn copyClasspathTemplates
 }
+// jar packages the main sourceSet output, which includes home/WEB-INF/classes
+// (the dir copyClasspathTemplates writes into). Without this edge, installDist ->
+// jar fails the same Gradle 8.x strict validation (e.g. during installUtilities).
+jar.dependsOn copyClasspathTemplates
 
 // ============================================================================
 // GWT COMPILATION TASKS

--- a/server_apps/DB_maintenance/merge/README.md
+++ b/server_apps/DB_maintenance/merge/README.md
@@ -1,0 +1,214 @@
+# Marker-merge equivalence testing
+
+This directory holds the **differential equivalence harness** that proves the Java port
+(`org.zfin.marker.MergeMarkersCommandLine`, run as `zfin-util merge-markers`) produces the *same
+database effect* as the legacy Perl `cgi-bin/merge_markers.pl`, across many marker pairs of many
+types.
+
+- `compare_merge_markers.sh` — the host-side orchestrator (run this).
+- `derive_headless_merge_markers.sh` — turns the CGI Perl into a headless, batch-runnable form.
+
+It is a **characterization / golden-master test**: rather than asserting hand-written expectations,
+it runs *both* implementations against identical real data and asserts the resulting databases are
+identical. That is the only way to catch the kind of subtle porting bugs a generic
+foreign-key-graph merge is prone to (see "What it caught" at the bottom).
+
+```
+server_apps/DB_maintenance/merge/compare_merge_markers.sh 100      # 100 pairs across types
+COMPOSE=~/zfin/docker/docker-compose.yml OUT=/tmp/merge_cmp \
+  server_apps/DB_maintenance/merge/compare_merge_markers.sh 100    # with overrides
+```
+
+It is **destructive to throwaway clone databases only** (`merge_cmp_seed`, `merge_cmp_test`) and
+never touches `zfindb`. It runs on the host and drives the containers (`db` for psql/clone, `compile`
+for perl + `zfin-util`). Expect ~15–20 min for 100 pairs (the DB clones dominate). Drop the clones
+when done: `psql -U postgres -c 'drop database if exists merge_cmp_seed'` (and `merge_cmp_test`).
+
+---
+
+## The core idea: make the comparison deterministic
+
+Two separate runs of *anything* against a database differ in incidental ways — wall-clock
+timestamps, auto-generated ids, physical row order. The harness is built so the **only** legitimate
+difference between a Perl run and a Java run is wall-clock timestamps, which we then exclude:
+
+1. **Identical starting state.** Both implementations start from a byte-identical clone of the same
+   seed database. So every `get_id('DALIAS')`/`get_id('NOMEN')` call hands out the *same* new id on
+   both sides (the id sequence/regen table starts in the same state and is advanced the same number
+   of times by the same operations). Generated ZDB ids therefore **match**, not just "look similar".
+2. **Same pairs, same order.** Both runs process the identical list of pairs (`pairs.txt`) in the
+   same order, so cumulative state evolves identically.
+3. **Atomic per pair.** A pair that errors must be a clean no-op on *both* sides, or one partial
+   failure would desync everything after it. Java already gets this from `ToolBootstrap`'s
+   transaction; the headless Perl is derived with `RaiseError=1, AutoCommit=0` + an explicit commit
+   (see below). So a failed pair rolls back fully on both sides.
+4. **Exclude timestamps.** The remaining nondeterminism — `now()` in `mhist_date`, audit columns —
+   is removed by excluding all temporal column types from the fingerprint.
+
+With those four in place, "did the Perl and Java do the same thing?" reduces to "are the two
+databases identical (ignoring timestamp columns)?"
+
+---
+
+## Efficient DB cloning: `CREATE DATABASE ... TEMPLATE`
+
+`zfindb` is ~15 GB. A `pg_dump | psql` round-trip would take a long time and a lot of disk. Instead
+the harness uses PostgreSQL's template mechanism:
+
+```sql
+CREATE DATABASE merge_cmp_seed  TEMPLATE zfindb;          -- once, the frozen baseline
+CREATE DATABASE merge_cmp_test  TEMPLATE merge_cmp_seed;  -- reset before each implementation's batch
+```
+
+Why this is fast (~3 min for 15 GB here, disk-copy bound rather than logical):
+
+- `CREATE DATABASE ... TEMPLATE x` performs a **physical, file-level copy** of the template's data
+  directory. It does not parse, re-plan, re-index, or re-validate anything — it just copies the
+  files and registers a new database. That is dramatically cheaper than dump/restore, which
+  serializes every row to SQL/COPY text and rebuilds indexes/constraints on load.
+
+Operational requirements and gotchas (all handled by the script):
+
+- **No active connections to the template.** `CREATE DATABASE ... TEMPLATE x` requires that `x` has
+  zero other sessions (Postgres briefly treats the template as read-only). The script checks
+  `pg_stat_activity` for `zfindb` and aborts with a clear message if anything is connected — so run
+  it when the app/Tomcat is idle, or stop Tomcat first. (This is also why we clone `zfindb` into a
+  *frozen* `merge_cmp_seed` once, then re-template from the seed between runs: the seed has no
+  clients, so the per-implementation resets never contend with the live app.)
+- **Privilege.** Creating databases needs `CREATEDB`; we connect to the `db` container as the
+  `postgres` superuser over trust auth (`psql -h db -U postgres`).
+- **Disk.** Each clone is a full ~15 GB copy. The harness keeps at most the seed + one test clone
+  (~30 GB) and drops the test clone between phases.
+
+Reset between the two implementation runs is then just:
+
+```sql
+DROP DATABASE IF EXISTS merge_cmp_test;
+CREATE DATABASE merge_cmp_test TEMPLATE merge_cmp_seed;
+```
+
+Each implementation points at `merge_cmp_test`:
+- **Java:** a copy of `zfin.properties` with `DB_NAME=merge_cmp_test`, passed via
+  `ZFIN_PROPERTIES_PATH`.
+- **Perl:** the headless script's `<!--|DB_NAME|-->` placeholder is substituted to `merge_cmp_test`.
+
+---
+
+## Fingerprinting: order-independent, timestamp-free per-table content hashes
+
+After each implementation's batch, the harness computes a **content fingerprint per table** and
+compares the two sets of fingerprints. Comparing fingerprints (not full dumps) keeps it fast and
+makes a mismatch trivially localizable to a specific table.
+
+The fingerprint is computed entirely server-side by a temporary function:
+
+```sql
+create or replace function pg_temp.fp(tabs text[]) returns table(tbl text, fp text)
+language plpgsql as $f$
+declare r text; cols text; q text;
+begin
+  foreach r in array tabs loop
+    -- column list for this table, EXCLUDING temporal types (the only legit nondeterminism)
+    select string_agg(quote_ident(column_name), ',' order by ordinal_position) into cols
+      from information_schema.columns
+     where table_schema = 'public' and table_name = r
+       and data_type not in ('timestamp without time zone','timestamp with time zone',
+                             'date','time without time zone','time with time zone');
+    if cols is null then tbl := r; fp := '(missing-or-only-temporal-cols)'; return next; continue; end if;
+    -- per-row md5, then md5 of the row-hashes aggregated in SORTED order => order-independent
+    q := format(
+      'select coalesce(md5(string_agg(h, '''' order by h)), ''empty'')
+         from (select md5(row(%s)::text) h from public.%I) s', cols, r);
+    begin execute q into fp; exception when undefined_table then fp := '(missing)'; end;
+    tbl := r; return next;
+  end loop;
+end $f$;
+
+select tbl || '|' || fp from pg_temp.fp(string_to_array('<tables>', ',')) order by tbl;
+```
+
+Key properties:
+
+- **Order-independent.** Each row is hashed (`md5(row(...)::text)`), then the row-hashes are
+  aggregated `ORDER BY h` before hashing again. So two tables with identical rows in different
+  physical order (different clustering, vacuum, insertion order) fingerprint the same — we're
+  comparing *sets of rows*, not a byte dump.
+- **Timestamp-free.** Temporal columns (`timestamp`/`date`/`time`) are dropped from each table's
+  column list, discovered per-table from `information_schema.columns`. This is what lets two
+  independent runs match despite `mhist_date = now()` and audit timestamps. (It is a deliberate
+  blind spot: a real difference confined entirely to a timestamp column would not be flagged.
+  Acceptable here because timestamps are exactly the expected nondeterminism.)
+- **Whole-table.** It hashes all non-temporal columns of every row, so any data difference in any
+  compared table is caught.
+
+### Which tables get fingerprinted
+
+A merge touches an a-priori-unknown set of tables (that's the whole point of the generic FK walk),
+and fingerprinting all of a 15 GB database would be slow. So the harness derives the **merge
+footprint** automatically: it greps the Java tool's own SQL log for `update`/`delete`/`insert into
+<table>` and unions that with a small set of always-touched bookkeeping tables (`marker`,
+`marker_history`, `data_alias`, `zdb_active_data`, `zdb_replaced_data`, `record_attribution`,
+`db_link`). For the 100-pair multi-type run this was 32 tables.
+
+### Comparison and drill-down
+
+- Per-pair `OK`/`ERR` is compared (`results.diff`) — catches "succeeds on one, fails on the other".
+- Per-table fingerprints are compared (`fingerprint.diff`) — `IDENTICAL across N tables` is the pass
+  condition.
+- On a fingerprint mismatch the harness dumps the offending table(s) for inspection. To pinpoint
+  *why*, two finer tools were used during development:
+  - **Java `--dry-run`** logs every SQL statement it would execute and rolls back, so you can diff
+    the generated SQL without mutating anything.
+  - **Single-pair isolation:** clone once, run Java `--dry-run` (rolls back, leaving the clone
+    clean), then run Perl on the same clone, and diff just the suspect tables — far faster than
+    re-running the whole batch.
+
+---
+
+## Deriving a headless Perl (`derive_headless_merge_markers.sh`)
+
+The canonical `cgi-bin/merge_markers.pl` can't be run as-is in a batch: it's a CGI script with
+deploy-time placeholders. The derive step transforms it, changing **only** plumbing — never the
+merge logic:
+
+- fills the `<!--|DB_NAME|-->` / `<!--|PGHOST|-->` deploy placeholders;
+- swaps the two `CGI->param("OID"/"merge_oid")` reads for `$ARGV[0]`/`$ARGV[1]` and drops
+  `use CGI`/`CGI::Carp` (absent in the build container);
+- sets the DB user to `postgres` (trust auth) instead of the empty deploy default;
+- opens the DBI handle with `RaiseError => 1, AutoCommit => 0` and commits before disconnect, so each
+  invocation is **atomic** (matches Java's transaction; failed pairs roll back instead of leaving
+  partial state). Production runs the CGI under autocommit — making the *test* atomic is what keeps a
+  failed pair from desyncing the batch.
+- neutralizes the `regen_genox_marker(...)` call (see below).
+
+### Why `--skip-regen` / neutralizing regen
+
+`regen_genox_marker` is a denormalization recompute that rebuilds derived fast-search tables. It
+names a backup table with **minute granularity** (e.g. `mutant_fast_search_old_2606041640_...`), so
+when many merges run inside the same minute (the Perl is fast; Java's per-invocation JVM/Hibernate
+startup spreads them out) the second call collides with `relation ... already exists`. That is a
+batch-speed artifact, not a Perl-vs-Java logic difference, and the rebuilt tables are derived data
+that nightly jobs regenerate anyway. So both sides skip it: Java via the `--skip-regen` flag (a
+genuinely useful operational flag for bulk merges too), the Perl via the neutralized call. With
+regen skipped, the fast-search tables are only changed by the merge's direct FK reassignments, which
+are deterministic and identical on both sides.
+
+---
+
+## What it caught
+
+Running both implementations over 100 pairs surfaced four porting discrepancies that code review and
+unit tests would not have — see the memory note and `MergeMarkersCommandLine.java` comments:
+
+1. `mrkr_comments` `"\n\n"` quirk (Perl's loose `undef ne 'none'`).
+2. `operator does not exist: bigint = character varying` — `setString` types a param as `varchar`;
+   against a `bigint` key column reached during recursion Postgres refuses the comparison. The Perl
+   interpolates `unknown`-typed literals; the Java now does too.
+3. NULL collision keys — Perl concatenates `undef` as `""`; Java rendered `NULL` as `"null"`.
+4. The big one: the Perl's unique/primary-key conflict resolution is hand-unrolled for **exactly
+   2, 3, or 4 columns**; a generalized loop did conflict-resolution on wide keys (e.g.
+   `expression_experiment2`, 6–7 column unique constraints) that the Perl never performs. Capped to
+   `[2,4]`.
+
+Final result: identical per-pair `OK`/`ERR` and identical content fingerprints across 32 tables for
+100 pairs spanning genes, antibodies, morpholinos, CRISPRs, TALENs and pseudogenes.

--- a/server_apps/DB_maintenance/merge/TODO.md
+++ b/server_apps/DB_maintenance/merge/TODO.md
@@ -1,0 +1,60 @@
+# Pre-PR TODO — `command-line-utility` branch (merge-markers)
+
+**Do not open the PR until the items below are addressed or consciously deferred (with a filed
+ticket).** This branch ships `ToolBootstrap`, the `zfin-util` `requiresDatabase` wiring, the
+`copyClasspathTemplates` build fix, and `zfin-util merge-markers` (the Java port of
+`cgi-bin/merge_markers.pl`, verified equivalent — see `README.md`).
+
+Status legend: `[ ]` not started · `[~]` in progress · `[x]` done.
+
+---
+
+## Must decide before the PR
+
+- [ ] **Plan the Perl retirement (don't delete anything yet).** Find and list every caller of the
+      Perl so the cutover is deliberate:
+  - `cgi-bin/merge_markers.pl` — called by `merge-marker.jsp` (per its header comment). The JSP must
+    be repointed at `zfin-util merge-markers` (or a thin server-side action) before the Perl is
+    removed.
+  - `server_apps/DB_maintenance/merge/merge_markers_cmdline.pl` — check for cron/Jenkins/manual
+    callers.
+  - Decide: repoint callers **in this PR**, or land the Java tool now and repoint in a follow-up PR
+    (leaving the Perl in place until then). Either is fine — but the PR description must state which,
+    and **no Perl is deleted while a caller still points at it.**
+
+- [ ] **Confirm production regen behavior.** The tool runs `regen_genox_marker` by default;
+      `--skip-regen` is only for bulk/test use. Interactive single merges (the JSP path) should NOT
+      pass `--skip-regen`. Make sure whatever replaces the JSP call omits it. (The minute-granular
+      temp-table collision that `--skip-regen` avoids only occurs when many merges run within the
+      same minute — see README.)
+
+## Tickets to file (deliberate post-cutover improvements; the port faithfully replicates these)
+
+- [ ] **Wide-constraint conflict resolution.** The merge algorithm only resolves unique/primary-key
+      conflicts for keys of **2–4 columns** (faithfully ported from the Perl). Pairs that collide on
+      a wider constraint — e.g. `expression_experiment2` (6–7 col unique), `gene_description`,
+      `uq_sfclg_unique_location` — currently error and are skipped on **both** implementations (the
+      24/100 mutual ERRs in the equivalence run). File a ticket to decide whether to generalize
+      conflict handling in the Java going forward. Use the equivalence harness as the safety net for
+      any such change.
+
+- [ ] **`mrkr_comments` "\n\n" pollution.** The Java reproduces the Perl bug that writes `"\n\n"`
+      into the surviving marker's comment when the deleted marker has no note (loose
+      `undef ne 'none'`). File a ticket to fix it deliberately (in the Java) **and** clean up existing
+      polluted `mrkr_comments` values. Removing it now would (correctly) fail the equivalence test
+      against the Perl, so it must be a conscious post-cutover change.
+
+## Harness / housekeeping
+
+- [ ] **Auto-drop clones at end.** `compare_merge_markers.sh` leaves `merge_cmp_test` (and the
+      reusable `merge_cmp_seed`) behind — ~15 GB each. Add an end-of-run cleanup (or a `--keep` flag
+      to opt out), and document dropping them. (For now: `psql -U postgres -c 'drop database if
+      exists merge_cmp_test'` and likewise `merge_cmp_seed`.)
+
+## PR description should include
+
+- [ ] The equivalence evidence (100 pairs across 6 marker types; identical per-pair OK/ERR; identical
+      content fingerprints across 32 tables).
+- [ ] The four porting discrepancies the harness caught and how each was reconciled (see README +
+      commit `6926b445ec`).
+- [ ] The Perl-retirement decision (this PR vs follow-up) and links to the tickets filed above.

--- a/server_apps/DB_maintenance/merge/compare_merge_markers.sh
+++ b/server_apps/DB_maintenance/merge/compare_merge_markers.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# Differential equivalence test: prove the Java port (org.zfin.marker.MergeMarkersCommandLine,
+# i.e. `zfin-util merge-markers`) produces the same database effect as the legacy Perl
+# cgi-bin/merge_markers.pl, over many marker pairs.
+#
+# Strategy (runs on the host, orchestrates the containers):
+#   1. Clone the live `zfindb` once into a frozen seed DB (fast CREATE DATABASE ... TEMPLATE).
+#   2. Pick N gene pairs (each gene used once) from the seed.
+#   3. JAVA run:  reset a test DB from the seed; merge every pair with `zfin-util merge-markers`;
+#                 derive the set of touched tables from the tool's own SQL log; fingerprint them.
+#   4. PERL run:  reset the test DB from the seed; merge the same pairs (same order) with a headless
+#                 form of merge_markers.pl; fingerprint the same tables.
+#   5. Compare per-pair success/failure and per-table content fingerprints. Dump any mismatching
+#      table from both DBs for inspection.
+#
+# Because both runs start from the byte-identical seed and apply the same pairs in the same order,
+# get_id() hands out identical new IDs on both sides; the only expected nondeterminism is wall-clock
+# timestamps, so date/time columns are excluded from the fingerprint.
+#
+# Usage:   server_apps/DB_maintenance/merge/compare_merge_markers.sh [N_PAIRS]
+# Env:     COMPOSE=<path to docker-compose.yml>  OUT=<host output dir>  SEED=<seed db>  TEST=<test db>
+#
+# NOTE: destructive to the TEST/SEED databases (never to zfindb). Requires zfindb to have 0 active
+#       connections when the seed is first created (stop Tomcat or run when idle).
+set -euo pipefail
+
+N_PAIRS="${1:-20}"
+COMPOSE="${COMPOSE:-$HOME/zfin/docker/docker-compose.yml}"
+OUT="${OUT:-/tmp/merge_cmp}"
+SEED="${SEED:-merge_cmp_seed}"
+TEST="${TEST:-merge_cmp_test}"
+SRC_DB="${SRC_DB:-zfindb}"
+
+# Bookkeeping tables a merge always touches; always fingerprinted even if not seen in the log.
+CORE_TABLES="marker,marker_history,data_alias,zdb_active_data,zdb_replaced_data,record_attribution,db_link"
+
+mkdir -p "$OUT"
+log() { printf '\n=== %s ===\n' "$*"; }
+
+dc() { docker compose -f "$COMPOSE" "$@"; }
+# psql against an admin/maintenance connection (db container, trust auth as postgres).
+dbq() { dc exec -T db psql -U postgres -X -v ON_ERROR_STOP=1 "$@"; }
+
+# ---------------------------------------------------------------------------------------------------
+log "1. Ensure seed DB '$SEED' (clone of $SRC_DB)"
+if dbq -d postgres -tAc "select 1 from pg_database where datname='$SEED'" | grep -q 1; then
+    echo "seed already exists; reusing it"
+else
+    conns="$(dbq -d postgres -tAc "select count(*) from pg_stat_activity where datname='$SRC_DB'")"
+    if [ "$conns" -ne 0 ]; then
+        echo "ERROR: $SRC_DB has $conns active connection(s); CREATE DATABASE ... TEMPLATE needs 0." >&2
+        echo "       Stop Tomcat/other clients and retry." >&2
+        exit 1
+    fi
+    dbq -d postgres -c "create database $SEED template $SRC_DB"
+fi
+
+# ---------------------------------------------------------------------------------------------------
+log "2. Select up to $N_PAIRS pairs across marker types"
+# Marker types to cover (ZDB-ID infixes). The merge tool requires both markers to be the same type,
+# so we pair within each type. Rarer types take their quota first; GENE is listed LAST and absorbs
+# whatever the rarer types could not supply, so the run still reaches N_PAIRS total.
+TYPES="${TYPES:-ATB MRPHLNO CRISPR TALEN GENEP GENE}"
+ntypes="$(echo "$TYPES" | wc -w)"
+quota=$(((N_PAIRS + ntypes - 1) / ntypes))   # even-ish split; GENE tops up the remainder
+
+: > "$OUT/pairs.txt"
+remaining="$N_PAIRS"
+for pfx in $TYPES; do
+    [ "$remaining" -le 0 ] && break
+    want=$quota
+    [ "$pfx" = "GENE" ] && want="$remaining"   # let genes fill whatever rarer types can't
+    mapfile -t IDS < <(dbq -d "$SEED" -tAc "
+        select mrkr_zdb_id from marker
+         where mrkr_zdb_id like 'ZDB-$pfx-%' and mrkr_abbrev is not null
+           and mrkr_zdb_id not in (select zrepld_old_zdb_id from zdb_replaced_data)
+           and mrkr_zdb_id not in (select zrepld_new_zdb_id from zdb_replaced_data)
+         order by mrkr_zdb_id
+         limit $((want * 2))")
+    cnt=0
+    for ((i = 0; i + 1 < ${#IDS[@]} && remaining > 0; i += 2)); do
+        printf '%s %s\n' "${IDS[i]}" "${IDS[i + 1]}" >> "$OUT/pairs.txt"
+        remaining=$((remaining - 1))
+        cnt=$((cnt + 1))
+    done
+    printf '  %-9s %d pairs\n' "$pfx" "$cnt"
+done
+echo "wrote $(wc -l < "$OUT/pairs.txt") pairs to $OUT/pairs.txt"
+
+reset_test() {
+    dbq -d postgres -c "drop database if exists $TEST" >/dev/null
+    dbq -d postgres -c "create database $TEST template $SEED" >/dev/null
+}
+
+# ---------------------------------------------------------------------------------------------------
+log "3. JAVA run"
+reset_test
+dc run --rm -e TESTDB="$TEST" -e OUTDIR="$OUT" -v "$OUT:$OUT" compile bash -lc '
+    set -e
+    cp "$ZFIN_PROPERTIES_PATH" /tmp/test.properties
+    sed -i "s/^DB_NAME=.*/DB_NAME=$TESTDB/" /tmp/test.properties
+    : > "$OUTDIR/java_results.txt"; : > "$OUTDIR/java.log"
+    while read -r DEL INTO; do
+        if ZFIN_PROPERTIES_PATH=/tmp/test.properties \
+             "$TARGETROOT/utilities/bin/zfin-util" merge-markers "$DEL" "$INTO" --skip-regen >>"$OUTDIR/java.log" 2>&1; then
+            echo "OK $DEL $INTO"
+        else
+            echo "ERR $DEL $INTO"
+        fi
+    done < "$OUTDIR/pairs.txt" > "$OUTDIR/java_results.txt"
+'
+# Derive the touched-table set from the Java tool'\''s own SQL log.
+TOUCHED="$(grep -oiE '(update|delete from|insert into)[[:space:]]+(public\.)?[a-z_][a-z0-9_]*' "$OUT/java.log" \
+    | sed -E 's/.*[[:space:]](public\.)?//' | sort -u | paste -sd, -)"
+TABLES="$(printf '%s,%s' "$CORE_TABLES" "$TOUCHED" | tr ',' '\n' | grep . | sort -u | paste -sd, -)"
+echo "fingerprinting tables: $TABLES"
+fingerprint() { # $1 = output file. The `| grep '|'` drops psql command tags (e.g. CREATE FUNCTION).
+    dbq -d "$TEST" -tA <<SQL | grep '|' > "$1"
+create or replace function pg_temp.fp(tabs text[]) returns table(tbl text, fp text) language plpgsql as \$f\$
+declare r text; cols text; q text;
+begin
+  foreach r in array tabs loop
+    select string_agg(quote_ident(column_name), ',' order by ordinal_position) into cols
+      from information_schema.columns
+     where table_schema='public' and table_name=r
+       and data_type not in ('timestamp without time zone','timestamp with time zone','date',
+                              'time without time zone','time with time zone');
+    if cols is null then tbl:=r; fp:='(missing-or-only-temporal-cols)'; return next; continue; end if;
+    q := format('select coalesce(md5(string_agg(h, '''' order by h)), ''empty'') from (select md5(row(%s)::text) h from public.%I) s', cols, r);
+    begin execute q into fp; exception when undefined_table then fp:='(missing)'; end;
+    tbl := r; return next;
+  end loop;
+end \$f\$;
+select tbl || '|' || fp from pg_temp.fp(string_to_array('$TABLES', ',')) order by tbl;
+SQL
+}
+fingerprint "$OUT/java_fp.txt"
+
+# ---------------------------------------------------------------------------------------------------
+log "4. PERL run"
+reset_test
+dc run --rm -e TESTDB="$TEST" -e OUTDIR="$OUT" -v "$OUT:$OUT" compile bash -lc '
+    set -e
+    bash "$SOURCEROOT/server_apps/DB_maintenance/merge/derive_headless_merge_markers.sh" \
+        "$SOURCEROOT/cgi-bin/merge_markers.pl" "$TESTDB" db > /tmp/headless_merge.pl
+    : > "$OUTDIR/perl_results.txt"; : > "$OUTDIR/perl.log"
+    while read -r DEL INTO; do
+        if perl /tmp/headless_merge.pl "$DEL" "$INTO" >>"$OUTDIR/perl.log" 2>&1; then
+            echo "OK $DEL $INTO"
+        else
+            echo "ERR $DEL $INTO"
+        fi
+    done < "$OUTDIR/pairs.txt" > "$OUTDIR/perl_results.txt"
+'
+fingerprint "$OUT/perl_fp.txt"
+
+# ---------------------------------------------------------------------------------------------------
+log "5. Compare"
+status=0
+
+if diff -u "$OUT/perl_results.txt" "$OUT/java_results.txt" > "$OUT/results.diff"; then
+    echo "per-pair success/failure: IDENTICAL ($(wc -l < "$OUT/pairs.txt") pairs)"
+else
+    echo "per-pair success/failure: DIFFERS -> $OUT/results.diff"; status=1
+fi
+
+if diff -u "$OUT/perl_fp.txt" "$OUT/java_fp.txt" > "$OUT/fingerprint.diff"; then
+    echo "table fingerprints: IDENTICAL across $(wc -l < "$OUT/java_fp.txt") tables"
+else
+    echo "table fingerprints: DIFFER -> $OUT/fingerprint.diff"; status=1
+    # Dump each mismatching table from both DBs for inspection.
+    mismatch_tables="$(diff "$OUT/perl_fp.txt" "$OUT/java_fp.txt" | grep -oE '[<>] [a-z_][a-z0-9_]*\|' \
+        | sed -E 's/[<>] //; s/\|//' | sort -u)"
+    for t in $mismatch_tables; do
+        echo "  dumping mismatching table: $t"
+        dbq -d "$TEST" -c "\\copy (select * from public.$t order by 1) to '$OUT/java.$t.dump'" 2>/dev/null || true
+    done
+    echo "  (java-side dumps written to $OUT/*.dump; rerun the perl batch to capture its side if needed)"
+fi
+
+log "Done (exit $status). Artifacts in $OUT"
+exit $status

--- a/server_apps/DB_maintenance/merge/derive_headless_merge_markers.sh
+++ b/server_apps/DB_maintenance/merge/derive_headless_merge_markers.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Emit a headless (no-CGI) form of cgi-bin/merge_markers.pl to stdout.
+#
+# This is used only by compare_merge_markers.sh to run the canonical Perl merge in a batch/test
+# context. It changes ONLY the input plumbing and connection coordinates -- never the merge logic:
+#   - the deploy-time placeholders <!--|DB_NAME|--> / <!--|PGHOST|--> are filled in,
+#   - the two CGI->param() reads become $ARGV[0] / $ARGV[1],
+#   - `use CGI` / CGI::Carp (absent in the build container) are dropped,
+#   - the DB username is set to 'postgres' (trust auth) instead of the empty deploy default,
+#   - the DBI handle is opened with RaiseError=1, AutoCommit=0 and an explicit commit before
+#     disconnect, so each invocation is atomic. (Production runs the CGI script under autocommit;
+#     making the test run atomic matches the Java tool's all-or-nothing transaction, so a pair that
+#     errors is a clean no-op on both sides instead of leaving partial state that desyncs a batch.)
+#
+# Usage: derive_headless_merge_markers.sh <path-to-merge_markers.pl> <db-name> <db-host>
+set -euo pipefail
+
+src="$1"
+dbname="$2"
+dbhost="$3"
+
+DBNAME="$dbname" DBHOST="$dbhost" perl -0777 -pe '
+    my $db   = $ENV{DBNAME};
+    my $host = $ENV{DBHOST};
+    s/^\s*use\s+CGI;\s*$//mg;
+    s/^\s*use\s+CGI::Carp[^;]*;\s*$//mg;
+    s/my\s+\$data\s*=\s*new\s+CGI\(\);//g;
+    s/my\s+\$recordToBeDeleted\s*=\s*\$data->param\("OID"\);/my \$recordToBeDeleted = \$ARGV[0];/;
+    s/my\s+\$recordToBeMergedInto\s*=\s*\$data->param\("merge_oid"\);/my \$recordToBeMergedInto = \$ARGV[1];/;
+    s/<!--\|DB_NAME\|-->/$db/g;
+    s/<!--\|PGHOST\|-->/$host/g;
+    s/my\s+\$username\s*=\s*"";/my \$username = "postgres";/;
+    s/DBI->connect\s*\(\s*("DBI:Pg:[^"]*")\s*,\s*\$username\s*,\s*\$password\s*\)/DBI->connect($1, \$username, \$password, {RaiseError => 1, AutoCommit => 0})/;
+    s/\$dbh->disconnect\(\);/\$dbh->commit;\n\$dbh->disconnect();/;
+    s/\$curRegenGenox->execute\([^)]*\);/1; # regen_genox_marker skipped: matches Java --skip-regen (derived denorm recompute; its minute-granular temp table collides in a fast batch)/;
+' "$src"

--- a/source/org/zfin/framework/ToolBootstrap.java
+++ b/source/org/zfin/framework/ToolBootstrap.java
@@ -1,0 +1,164 @@
+package org.zfin.framework;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hibernate.Transaction;
+import org.zfin.properties.ZfinProperties;
+
+/**
+ * Headless entry point for ad-hoc Java jobs (reports, audits, one-off data fixes) that need to talk
+ * to the database without a full webapp deploy.
+ * <p>
+ * It removes the boilerplate every command-line job otherwise repeats: load {@link ZfinProperties},
+ * register a {@link org.hibernate.SessionFactory} with {@link HibernateUtil} via
+ * {@link HibernateSessionCreator}, run the work inside a single transaction, and always close the
+ * session. Once {@link #run} has set this up, jobs use the rest of the codebase normally &mdash;
+ * {@code RepositoryFactory.getXxxRepository()}, the static service classes, {@code ZfinPropertiesEnum},
+ * and {@code AbstractZfinMailSender.getInstance()} all work, because none of those depend on a Spring
+ * context (ZFIN's data layer is static-factory based, and it uses no {@code @Transactional}/Spring-AOP).
+ * <p>
+ * Typical usage from a {@code main()}:
+ * <pre>{@code
+ * public static void main(String[] args) {
+ *     ToolBootstrap.run("OrthoInconsistencyReport", args, () -> {
+ *         OrthologyRepository repo = RepositoryFactory.getOrthologyRepository();
+ *         // ...query, build the report, write the file...
+ *     });
+ * }
+ * }</pre>
+ *
+ * @see HibernateSessionCreator
+ * @see HibernateUtil
+ */
+public final class ToolBootstrap {
+
+    private static final Logger LOG = LogManager.getLogger(ToolBootstrap.class);
+
+    private ToolBootstrap() {
+    }
+
+    /**
+     * A unit of work to run against a bootstrapped ZFIN environment. May throw any checked exception;
+     * it will be caught, the transaction rolled back, and a {@link RuntimeException} rethrown.
+     */
+    @FunctionalInterface
+    public interface ToolJob {
+        void run() throws Exception;
+    }
+
+    /**
+     * Bootstrap the environment and run {@code job} inside a single managed transaction.
+     * <p>
+     * Lifecycle: {@link #initialize()} &rarr; begin transaction &rarr; {@code job.run()} &rarr; flush
+     * and commit on success / roll back on any exception &rarr; close the Hibernate session (always).
+     * If the job manages its own transactions (e.g. incremental commits via
+     * {@link HibernateUtil#flushAndCommitCurrentSession()}), the wrapper only commits when the
+     * transaction it opened is still active, so it will not double-commit.
+     *
+     * @param jobName label used in log lines
+     * @param job     the work to perform
+     * @throws RuntimeException wrapping any exception thrown by the job (after rollback)
+     */
+    public static void run(String jobName, ToolJob job) {
+        long start = System.currentTimeMillis();
+        LOG.info("Starting tool '{}'", jobName);
+        initialize();
+        Transaction tx = HibernateUtil.currentSession().beginTransaction();
+        try {
+            job.run();
+            if (tx.isActive()) {
+                HibernateUtil.currentSession().flush();
+                tx.commit();
+            }
+        } catch (Exception e) {
+            LOG.error("Tool '{}' failed; rolling back", jobName, e);
+            if (tx.isActive()) {
+                try {
+                    tx.rollback();
+                } catch (Exception rollbackError) {
+                    LOG.error("Rollback failed for tool '{}'", jobName, rollbackError);
+                }
+            }
+            throw new RuntimeException("Tool '" + jobName + "' failed: " + e.getMessage(), e);
+        } finally {
+            HibernateUtil.closeSession();
+            LOG.info("Tool '{}' finished in {} ms", jobName, System.currentTimeMillis() - start);
+        }
+    }
+
+    /**
+     * Convenience overload that logs the command-line arguments before delegating to
+     * {@link #run(String, ToolJob)}. The arguments are not passed into the job &mdash; the job's
+     * {@code main()} already has them and can close over whatever it needs.
+     */
+    public static void run(String jobName, String[] args, ToolJob job) {
+        LOG.info("Tool '{}' args: {}", jobName, (args == null ? "[]" : String.join(" ", args)));
+        run(jobName, job);
+    }
+
+    /**
+     * Load {@link ZfinProperties} and ensure a Hibernate {@link org.hibernate.SessionFactory} is
+     * registered with {@link HibernateUtil}. Idempotent: a second call is a no-op once the
+     * SessionFactory exists.
+     * <p>
+     * Exposed for jobs that want to manage their own transaction boundaries (e.g. long-running loads
+     * that commit in batches) rather than the single-transaction wrapper that {@link #run} provides.
+     */
+    public static void initialize() {
+        ZfinProperties.init();
+        if (!HibernateUtil.hasSessionFactoryDefined()) {
+            new HibernateSessionCreator();
+        }
+    }
+
+    // ------------------------------------------------------------------------------------------------
+    // Spring-context variant -- NOT YET IMPLEMENTED.
+    //
+    // The vast majority of ZFIN jobs do NOT need a Spring ApplicationContext: repositories come from
+    // RepositoryFactory, services are static, mail is AbstractZfinMailSender.getInstance(), and
+    // properties are ZfinPropertiesEnum. The codebase uses no @Transactional / @Cacheable / @Async /
+    // @Scheduled / method-security, so there is no Spring-AOP behavior to recover either.
+    //
+    // A context only earns its keep for the rare case of a bean wired ONLY through @Autowired with no
+    // static-factory accessor (the existing example is GafLoadJob, which boots its own
+    // FileSystemXmlApplicationContext to get an @Autowired DownloadService plus pluggable parser beans).
+    //
+    // Implementation notes for whoever picks this up (verified empirically 2026-06):
+    //   * Order matters: call initialize() FIRST (Hibernate up), THEN build the context. Beans whose
+    //     construction touches HibernateUtil.currentSession() fail otherwise.
+    //   * You CANNOT use ZfinConfiguration's plain @ComponentScan("org.zfin") headlessly: it sweeps in
+    //     web @Controllers (e.g. anatomyAjaxController) that @Autowired a request-scoped
+    //     HttpServletRequest, which does not exist outside a servlet container, and the refresh fails
+    //     with UnsatisfiedDependencyException.
+    //   * Define a dedicated headless @Configuration that excludes the web layer, e.g.:
+    //         @ComponentScan(value = "org.zfin", excludeFilters = @ComponentScan.Filter(
+    //             type = FilterType.ANNOTATION,
+    //             classes = {Controller.class, RestController.class, ControllerAdvice.class}))
+    //     then iterate the exclude set against whatever fails next (likely servlet-backed GWT RPC
+    //     @Services) until the context refreshes cleanly. Log every exclusion so coverage stays honest.
+    //   * Wrap the same transaction lifecycle as run(), and close() the context in a finally block.
+    //
+    // Intended shape:
+    //
+    //   @FunctionalInterface
+    //   public interface ToolJobWithContext {
+    //       void run(org.springframework.context.ApplicationContext ctx) throws Exception;
+    //   }
+    //
+    //   public static void runWithContext(String jobName, String[] args, ToolJobWithContext job) { ... }
+    // ------------------------------------------------------------------------------------------------
+
+    /**
+     * Placeholder for a future Spring-context-backed entry point. Not implemented &mdash; see the
+     * design notes in the source above this method. Use {@link #run(String, ToolJob)} instead unless
+     * you have a concrete bean that can only be obtained through {@code @Autowired} wiring.
+     *
+     * @throws UnsupportedOperationException always
+     */
+    public static void runWithContext(String jobName, String[] args, Object job) {
+        throw new UnsupportedOperationException(
+                "ToolBootstrap.runWithContext is not implemented. Almost all jobs only need run(...). "
+                        + "A Spring context is only required for @Autowired-only bean graphs; see the "
+                        + "design notes in ToolBootstrap.java before implementing.");
+    }
+}

--- a/source/org/zfin/marker/MergeMarkersCommandLine.java
+++ b/source/org/zfin/marker/MergeMarkersCommandLine.java
@@ -1,0 +1,933 @@
+package org.zfin.marker;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.zfin.framework.HibernateUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Command-line port of {@code cgi-bin/merge_markers.pl}: merges one marker (the "delete" record)
+ * into another (the "merge into" record), reassigning every foreign-key reference and applying the
+ * marker-specific business rules, then deleting the old record.
+ * <p>
+ * Like the Perl original, the heavy lifting is a <em>generic</em> recursive walk of PostgreSQL's
+ * {@code information_schema}: it discovers every table with a foreign key onto the record being
+ * deleted and generates {@code UPDATE}/{@code DELETE} statements (handling unique- and
+ * primary-key-constraint conflicts by deleting the losing row and recursing). On top of that it
+ * ports the explicit business rules: genotype/fish display-name renaming, antibody isotype/host
+ * merging, inference-group-member reassignment (FB&nbsp;11133), unspecified-allele renaming
+ * (FB&nbsp;10333), public-note concatenation (MRDL-121), STR fish/relationship de-duplication, GO
+ * root-term cleanup (FB&nbsp;11048), duplicate Alliance link removal (ZFIN-6073),
+ * {@code regen_genox_marker}, and the {@code data_alias} / {@code marker_history} /
+ * {@code zdb_replaced_data} bookkeeping.
+ * <p>
+ * Run via the headless command-line tool (registered as {@code merge-markers} with
+ * {@code requiresDatabase=true}), so it executes inside {@code ToolBootstrap.run}'s single managed
+ * transaction:
+ * <pre>{@code
+ *   zfin-util merge-markers <zdbIdToDelete> <zdbIdToMergeInto>            # execute (commit)
+ *   zfin-util merge-markers <zdbIdToDelete> <zdbIdToMergeInto> --dry-run # log SQL, roll back
+ * }</pre>
+ * In dry-run mode every statement is executed inside the transaction (so generated SQL reflects the
+ * real, consistent state) and then rolled back; the only non-transactional side effect avoided is
+ * the {@code regen_genox_marker} recompute, which is skipped. Sequence values consumed by
+ * {@code get_id(...)} are not reclaimed by the rollback.
+ */
+public class MergeMarkersCommandLine {
+
+    private static final Logger LOG = LogManager.getLogger(MergeMarkersCommandLine.class);
+
+    private static final Pattern ZDB_ID = Pattern.compile("^ZDB-([A-Z]+)-\\d{6}-\\d+$");
+
+    // GO ontology root terms (FB 11048).
+    private static final String ROOT_BIOLOGICAL_PROCESS = "ZDB-TERM-091209-6070";
+    private static final String ROOT_MOLECULAR_FUNCTION = "ZDB-TERM-091209-2432";
+    private static final String ROOT_CELLULAR_COMPONENT = "ZDB-TERM-091209-4029";
+
+    private static final String ALLIANCE_FDBCONT = "ZDB-FDBCONT-171018-1";
+
+    /** Sentinel the Perl uses for "no comment"; only a literal "none" suppresses the note update. */
+    private static final String NONE = "none";
+
+    private final String deleted;
+    private final String mergedInto;
+    private final boolean dryRun;
+    private final boolean skipRegen;
+
+    private String type1;
+    private String deletedAbbrev;
+    private String mergedAbbrev;
+    private String mergedName;
+    private String daliasId;
+    private String nomenId;
+
+    /** SQL string -> ordering value (FK-walk depth, or the record_attribution cleanup order). */
+    private final Map<String, Integer> mergeSQLs = new HashMap<>();
+    /** Guard so the recursive walk visits each (childTable, fkColumn) only once. */
+    private final Set<String> processed = new HashSet<>();
+    /** Every statement executed, for the dry-run / audit log. */
+    private final List<String> executedSql = new ArrayList<>();
+
+    public MergeMarkersCommandLine(String deleted, String mergedInto, boolean dryRun, boolean skipRegen) {
+        this.deleted = deleted;
+        this.mergedInto = mergedInto;
+        this.dryRun = dryRun;
+        this.skipRegen = skipRegen;
+    }
+
+    public static void main(String[] args) {
+        List<String> positional = new ArrayList<>();
+        boolean dryRun = false;
+        boolean skipRegen = false;
+        for (String arg : args) {
+            if ("--dry-run".equals(arg) || "-n".equals(arg)) {
+                dryRun = true;
+            } else if ("--skip-regen".equals(arg)) {
+                skipRegen = true;
+            } else {
+                positional.add(arg);
+            }
+        }
+        if (positional.size() != 2) {
+            throw new IllegalArgumentException(
+                    "Usage: merge-markers <zdbIdToDelete> <zdbIdToMergeInto> [--dry-run] [--skip-regen]");
+        }
+        new MergeMarkersCommandLine(positional.get(0), positional.get(1), dryRun, skipRegen).run();
+    }
+
+    public void run() {
+        type1 = validateZdbIdFormat(deleted, "record to be deleted");
+        String type2 = validateZdbIdFormat(mergedInto, "record to be merged into");
+        if (!type1.equals(type2)) {
+            throw new IllegalArgumentException(
+                    "Cannot merge markers of different types: " + deleted + " (" + type1 + ") vs "
+                            + mergedInto + " (" + type2 + ")");
+        }
+        if (deleted.equals(mergedInto)) {
+            throw new IllegalArgumentException("Cannot merge a marker into itself: " + deleted);
+        }
+
+        LOG.info("Merging {} into {}{}", deleted, mergedInto, dryRun ? " (DRY RUN)" : "");
+        try {
+            HibernateUtil.currentSession().doWork(this::doMerge);
+        } catch (RuntimeException e) {
+            // Let ToolBootstrap roll back and report; just make the message clear.
+            throw new RuntimeException("Merge of " + deleted + " into " + mergedInto + " failed: "
+                    + e.getMessage(), e);
+        }
+
+        if (dryRun) {
+            HibernateUtil.rollbackTransaction();
+            LOG.warn("DRY RUN complete: rolled back. {} statements would have executed:",
+                    executedSql.size());
+            for (String sql : executedSql) {
+                LOG.warn("  {}", sql);
+            }
+        } else {
+            LOG.info("Merge complete: executed {} statements.", executedSql.size());
+        }
+    }
+
+    private static String validateZdbIdFormat(String zdbId, String label) {
+        if (zdbId == null) {
+            throw new IllegalArgumentException("Missing ZDB ID for " + label);
+        }
+        Matcher m = ZDB_ID.matcher(zdbId);
+        if (!m.matches()) {
+            throw new IllegalArgumentException("Not a valid ZDB ID for the " + label + ": " + zdbId);
+        }
+        return m.group(1);
+    }
+
+    private void doMerge(Connection conn) throws SQLException {
+        assertExists(conn, deleted);
+        assertExists(conn, mergedInto);
+
+        // 1/2. Marker abbreviations + names, and the new DALIAS / NOMEN ids.
+        loadMarkerInfo(conn);
+
+        // 3. Genotype / fish display-name renaming (genes etc.; not antibodies).
+        if (!"ATB".equals(type1)) {
+            renameGenotypeDisplayNames(conn);
+            renameFishNames(conn);
+        }
+
+        // 4. Seed the "already processed" guard, matching the Perl.
+        processed.add("zdb_active_data" + "zactvd_zdb_id");
+        processed.add("updates" + "rec_id");
+        processed.add("zdb_replaced_data" + "zrepld_old_zdb_id");
+        processed.add("zdb_replaced_data" + "zrepld_new_zdb_id");
+        processed.add("record_attribution" + "recattrib_data_zdb_id");
+        processed.add("record_attribution" + "recattrib_source_zdb_id");
+
+        // 5. Pre-empt record_attribution unique-constraint conflicts (highest priority).
+        cleanupRecordAttributionTable(conn, 999);
+
+        // 6. Generic FK-graph walk: build all the UPDATE/DELETE statements.
+        recursivelyGetSQLs(conn, deleted, mergedInto, "zdb_active_data", "zactvd_zdb_id", 0);
+
+        // 7. Execute deepest-first; at equal depth DELETE sorts before UPDATE alphabetically.
+        List<Map.Entry<String, Integer>> sorted = new ArrayList<>(mergeSQLs.entrySet());
+        sorted.sort(Comparator
+                .comparingInt((Map.Entry<String, Integer> e) -> e.getValue()).reversed()
+                .thenComparing(Map.Entry::getKey));
+        for (Map.Entry<String, Integer> entry : sorted) {
+            exec(conn, entry.getKey());
+        }
+
+        // 8/9. Updating tables can trigger fresh record_attribution rows; clean up again (order 0).
+        cleanupRecordAttributionTable(conn, 0);
+        for (Map.Entry<String, Integer> entry : mergeSQLs.entrySet()) {
+            if (entry.getValue() == 0) {
+                exec(conn, entry.getKey());
+            }
+        }
+
+        // 10. Reassign remaining record_attribution rows.
+        execUpdate(conn,
+                "update record_attribution set recattrib_data_zdb_id = ? where recattrib_data_zdb_id = ?",
+                mergedInto, deleted);
+
+        // 11. data_alias: add the deleted marker's symbol as an alias of the surviving marker.
+        createAliasIfAbsent(conn);
+
+        // 12. marker_history: record the merge event.
+        createMarkerHistory(conn);
+
+        // 13/14. Type-specific business rules.
+        if ("ATB".equals(type1)) {
+            mergeAntibodyFields(conn);
+        } else {
+            mergeInferenceGroupMembers(conn);   // FB 11133
+            renameUnspecifiedAllele(conn);       // FB 10333
+        }
+
+        // 15. Public notes (MRDL-121).
+        mergePublicNotes(conn);
+
+        // 16. STR fish / marker_relationship de-duplication.
+        if (deleted.contains("MRPHLNO") || deleted.contains("CRISP") || deleted.contains("TALEN")) {
+            deleteConflictingStrUsages(conn);
+        }
+
+        // 17. GO root-term cleanup (FB 11048).
+        cleanupRedundantRootGoTerms(conn);
+
+        // 18. Duplicate Alliance link (ZFIN-6073).
+        execUpdate(conn,
+                "delete from zdb_active_data where exists("
+                        + "select 1 from db_link where dblink_zdb_id = zactvd_zdb_id "
+                        + "and dblink_linked_recid = ? and dblink_acc_num = ? "
+                        + "and dblink_fdbcont_zdb_id = ?)",
+                mergedInto, deleted, ALLIANCE_FDBCONT);
+
+        // 19. Regenerate genotype/expression denormalizations for the surviving marker.
+        // This recompute rebuilds derived fast-search tables; it is skipped for dry runs and when
+        // --skip-regen is given (e.g. bulk merges that regenerate once at the end, or the Perl-vs-Java
+        // equivalence harness, where regen_genox_marker's minute-granular temp-table name collides
+        // when many merges run within the same minute).
+        if (dryRun || skipRegen) {
+            LOG.info("skipping regen_genox_marker('{}'){}", mergedInto, dryRun ? " (dry run)" : " (--skip-regen)");
+        } else {
+            execUpdate(conn, "select regen_genox_marker(?)", mergedInto);
+        }
+
+        // 20-23. zdb_replaced_data bookkeeping + delete the old record.
+        execUpdate(conn, "delete from zdb_replaced_data where zrepld_old_zdb_id = ?", deleted);
+        execUpdate(conn, "update zdb_replaced_data set zrepld_new_zdb_id = ? where zrepld_new_zdb_id = ?",
+                mergedInto, deleted);
+        execUpdate(conn, "delete from zdb_active_data where zactvd_zdb_id = ?", deleted);
+        execUpdate(conn,
+                "insert into zdb_replaced_data (zrepld_old_zdb_id, zrepld_new_zdb_id) values (?, ?)",
+                deleted, mergedInto);
+    }
+
+    private void assertExists(Connection conn, String zdbId) throws SQLException {
+        if (countRows(conn, "zdb_active_data", "zactvd_zdb_id", zdbId) == 0) {
+            throw new IllegalArgumentException(zdbId + " is not found at ZFIN");
+        }
+    }
+
+    private void loadMarkerInfo(Connection conn) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select mrkr_abbrev, get_id('DALIAS') from marker where mrkr_zdb_id = ?")) {
+            ps.setString(1, deleted);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    deletedAbbrev = rs.getString(1);
+                    daliasId = rs.getString(2);
+                }
+            }
+        }
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select mrkr_abbrev, mrkr_name, get_id('NOMEN') from marker where mrkr_zdb_id = ?")) {
+            ps.setString(1, mergedInto);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    mergedAbbrev = rs.getString(1);
+                    mergedName = rs.getString(2);
+                    nomenId = rs.getString(3);
+                }
+            }
+        }
+        if (deletedAbbrev == null || mergedAbbrev == null) {
+            throw new IllegalArgumentException(
+                    "Both ZDB IDs must be markers (found in the marker table): " + deleted + ", " + mergedInto);
+        }
+    }
+
+    // ZFIN-6309: rename genotype display names that embed the deleted marker's symbol.
+    private void renameGenotypeDisplayNames(Connection conn) throws SQLException {
+        Map<String, String> genotypes = new HashMap<>();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select geno_zdb_id, geno_display_name from feature_marker_relationship, genotype_feature, genotype "
+                        + "where fmrel_mrkr_zdb_id = ? and fmrel_ftr_zdb_id = genofeat_feature_zdb_id "
+                        + "and genofeat_geno_zdb_id = geno_zdb_id")) {
+            ps.setString(1, deleted);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    genotypes.put(rs.getString(1), rs.getString(2));
+                }
+            }
+        }
+        for (Map.Entry<String, String> e : genotypes.entrySet()) {
+            String displayName = e.getValue();
+            if (displayName != null && displayName.contains(deletedAbbrev)) {
+                String newName = displayName.replace(deletedAbbrev, mergedAbbrev);
+                execUpdate(conn, "update genotype set geno_display_name = ? where geno_zdb_id = ?",
+                        newName, e.getKey());
+            }
+        }
+    }
+
+    private void renameFishNames(Connection conn) throws SQLException {
+        Map<String, String> fish = new HashMap<>();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select fish_zdb_id, fish_name from feature_marker_relationship, genotype_feature, fish "
+                        + "where fmrel_mrkr_zdb_id = ? and fmrel_ftr_zdb_id = genofeat_feature_zdb_id "
+                        + "and genofeat_geno_zdb_id = fish_genotype_zdb_id")) {
+            ps.setString(1, deleted);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    fish.put(rs.getString(1), rs.getString(2));
+                }
+            }
+        }
+        for (Map.Entry<String, String> e : fish.entrySet()) {
+            String fishName = e.getValue();
+            if (fishName != null && fishName.contains(deletedAbbrev)) {
+                String newName = fishName.replace(deletedAbbrev, mergedAbbrev);
+                execUpdate(conn, "update fish set fish_name = ? where fish_zdb_id = ?",
+                        newName, e.getKey());
+            }
+        }
+    }
+
+    /**
+     * Generic FK-graph walk (port of the Perl {@code recursivelyGetSQLs}). Discovers every child
+     * table referencing {@code parentTable.foreignKey} and records the UPDATE/DELETE needed to move
+     * references from {@code toBeDeleted} to {@code toBeMergedInto}, recursing into composite-key /
+     * unique-constraint conflicts so the losing rows are removed first.
+     */
+    private void recursivelyGetSQLs(Connection conn, String toBeDeleted, String toBeMergedInto,
+                                    String parentTable, String foreignKey, int depth) throws SQLException {
+        depth++;
+
+        List<String[]> children = new ArrayList<>(); // {childTable, fkColumn, childSchema}
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select distinct c.table_name, k1.column_name, k2.table_name, k2.column_name, "
+                        + "k1.table_schema, k2.table_schema "
+                        + "from information_schema.constraint_table_usage c, "
+                        + "information_schema.key_column_usage k1, information_schema.table_constraints tc1, "
+                        + "information_schema.key_column_usage k2, information_schema.table_constraints tc2 "
+                        + "where k1.column_name = ? and k1.table_name = ? "
+                        + "and tc1.table_name = k1.table_name and tc1.constraint_name = k1.constraint_name "
+                        + "and c.table_name = k1.table_name and c.constraint_name = k2.constraint_name "
+                        + "and c.table_name != k2.table_name "
+                        + "and tc2.table_name = k2.table_name and tc2.constraint_name = k2.constraint_name "
+                        + "and tc2.constraint_type = 'FOREIGN KEY' order by 1, 3, 4")) {
+            ps.setString(1, foreignKey);
+            ps.setString(2, parentTable);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    children.add(new String[]{rs.getString(3), rs.getString(4), rs.getString(6)});
+                }
+            }
+        }
+
+        for (String[] child : children) {
+            String childTable = child[0];
+            String fkColumn = child[1];
+            String childSchema = child[2];
+            if (processed.contains(childTable + fkColumn)) {
+                continue;
+            }
+            String schemaTable = childSchema + "." + childTable;
+
+            int rowsForDeleted = countRows(conn, schemaTable, fkColumn, toBeDeleted);
+            if (rowsForDeleted > 0 && !"record_attribution".equals(childTable)) {
+                // Non-FK columns of any UNIQUE constraint, and whether the FK is part of one.
+                List<String> uniqueCols = new ArrayList<>();
+                boolean fkInUnique = false;
+                int numUniqueCols = 0;
+                for (String col : constraintColumns(conn, childTable, "UNIQUE")) {
+                    if (col.equals(fkColumn)) {
+                        fkInUnique = true;
+                    } else {
+                        uniqueCols.add(col);
+                    }
+                    numUniqueCols++;
+                }
+
+                // Primary-key columns; track whether the FK is (part of) the PK.
+                List<String> pkCols = new ArrayList<>();
+                String soloPk = null;
+                String pkOfChild = null;
+                boolean fkInPk = false;
+                int numPkCols = 0;
+                for (String col : constraintColumns(conn, childTable, "PRIMARY KEY")) {
+                    if (col.equals(fkColumn)) {
+                        fkInPk = true;
+                        soloPk = col;
+                    } else {
+                        pkCols.add(col);
+                        pkOfChild = col;
+                    }
+                    numPkCols++;
+                }
+
+                // Scenario 1: FK is part of a multi-column UNIQUE constraint and the PK is a single
+                // (non-FK) column. Delete the conflicting "deleted" rows and recurse on the PK.
+                // The Perl only handles unique constraints of exactly 2, 3, or 4 columns (explicit
+                // if/elsif branches); for any other column count it does NO conflict resolution and
+                // just emits the plain UPDATE. We cap to [2,4] to match that behavior exactly --
+                // notably, wide unique constraints like expression_experiment2's (6-7 columns) get
+                // only the UPDATE, never conflict deletes.
+                if (fkInUnique && numUniqueCols >= 2 && numUniqueCols <= 4 && numPkCols == 1) {
+                    String selectList = String.join(", ", uniqueCols);
+                    Map<String, String> mergedCombos =
+                            comboToPk(conn, schemaTable, pkOfChild, selectList, fkColumn, toBeMergedInto);
+                    if (!mergedCombos.isEmpty()) {
+                        Map<String, String> deletedCombos =
+                                comboToPk(conn, schemaTable, pkOfChild, selectList, fkColumn, toBeDeleted);
+                        for (Map.Entry<String, String> e : deletedCombos.entrySet()) {
+                            if (mergedCombos.containsKey(e.getKey())) {
+                                String deletedPk = e.getValue();
+                                mergeSQLs.put("delete from " + schemaTable + " where " + pkOfChild
+                                        + " = '" + deletedPk + "'", depth);
+                                recursivelyGetSQLs(conn, deletedPk, mergedCombos.get(e.getKey()),
+                                        childTable, pkOfChild, depth);
+                            }
+                        }
+                    }
+                }
+
+                // Scenario 2: FK is part of a composite PRIMARY KEY. Delete the conflicting rows.
+                // As in scenario 1, the Perl only handles 2-, 3-, or 4-column primary keys; cap to
+                // [2,4] to match (other counts get no conflict deletes, only the UPDATE/recurse).
+                if (fkInPk && numPkCols >= 2 && numPkCols <= 4) {
+                    String selectListP = String.join(", ", pkCols);
+                    Set<String> mergedCombos =
+                            combos(conn, schemaTable, selectListP, fkColumn, toBeMergedInto);
+                    if (!mergedCombos.isEmpty()) {
+                        List<Map<String, String>> deletedRows =
+                                rowsByColumn(conn, schemaTable, selectListP, pkCols, fkColumn, toBeDeleted);
+                        for (Map<String, String> row : deletedRows) {
+                            StringBuilder combo = new StringBuilder();
+                            for (String col : pkCols) {
+                                combo.append(nz(row.get(col))); // NULL -> "" (Perl concatenates undef as "")
+                            }
+                            if (mergedCombos.contains(combo.toString())) {
+                                StringBuilder sql = new StringBuilder("delete from " + schemaTable
+                                        + " where " + fkColumn + " = '" + toBeDeleted + "'");
+                                for (String col : pkCols) {
+                                    sql.append(" and ").append(col).append(" = '").append(nz(row.get(col))).append("'");
+                                }
+                                mergeSQLs.put(sql.toString(), depth);
+                            }
+                        }
+                    }
+                }
+
+                if (fkInPk && numPkCols == 1) {
+                    // FK is the sole PK: recurse one level deeper without an UPDATE here.
+                    recursivelyGetSQLs(conn, toBeDeleted, toBeMergedInto, childTable, soloPk, depth);
+                } else {
+                    mergeSQLs.put("update " + schemaTable + " set " + fkColumn + " = '" + toBeMergedInto
+                            + "' where " + fkColumn + " = '" + toBeDeleted + "'", depth);
+                }
+            }
+
+            processed.add(childTable + fkColumn);
+        }
+    }
+
+    /**
+     * Build delete-from-record_attribution statements for rows whose (source, type) pair already
+     * exists for the surviving record (a unique-constraint conflict). Port of the Perl
+     * {@code cleanupRecordAttributionTable}; {@code order} is the value stored in {@link #mergeSQLs}.
+     */
+    private void cleanupRecordAttributionTable(Connection conn, int order) throws SQLException {
+        Set<String> mergedKeys = new HashSet<>();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select recattrib_source_zdb_id, recattrib_source_type from record_attribution "
+                        + "where recattrib_data_zdb_id = ?")) {
+            ps.setString(1, mergedInto);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    mergedKeys.add(rs.getString(1) + rs.getString(2));
+                }
+            }
+        }
+        if (mergedKeys.isEmpty()) {
+            return;
+        }
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select recattrib_pk_id, recattrib_source_zdb_id, recattrib_source_type "
+                        + "from record_attribution where recattrib_data_zdb_id = ?")) {
+            ps.setString(1, deleted);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    if (mergedKeys.contains(rs.getString(2) + rs.getString(3))) {
+                        mergeSQLs.put("delete from record_attribution where recattrib_pk_id = '"
+                                + rs.getString(1) + "'", order);
+                    }
+                }
+            }
+        }
+    }
+
+    private void createAliasIfAbsent(Connection conn) throws SQLException {
+        String existingAliasId = null;
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select dalias_zdb_id from data_alias where dalias_data_zdb_id = ? and dalias_alias = ? "
+                        + "and dalias_group_id = 1")) {
+            ps.setString(1, mergedInto);
+            ps.setString(2, deletedAbbrev);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    existingAliasId = rs.getString(1);
+                }
+            }
+        }
+        if (existingAliasId != null) {
+            daliasId = existingAliasId;
+            return;
+        }
+        execUpdate(conn, "insert into zdb_active_data values (?)", daliasId);
+        execUpdate(conn,
+                "insert into data_alias (dalias_zdb_id, dalias_data_zdb_id, dalias_alias, dalias_group_id) "
+                        + "values (?, ?, ?, '1')",
+                daliasId, mergedInto, deletedAbbrev);
+    }
+
+    private void createMarkerHistory(Connection conn) throws SQLException {
+        execUpdate(conn, "insert into zdb_active_data values (?)", nomenId);
+        execUpdate(conn,
+                "insert into marker_history (mhist_zdb_id, mhist_mrkr_zdb_id, mhist_event, mhist_reason, "
+                        + "mhist_date, mhist_mrkr_name_on_mhist_date, mhist_mrkr_abbrev_on_mhist_date, "
+                        + "mhist_comments, mhist_dalias_zdb_id) "
+                        + "values (?, ?, 'merged', 'same marker', now(), ?, ?, 'none', ?)",
+                nomenId, mergedInto, mergedName, mergedAbbrev, daliasId);
+    }
+
+    private void mergeAntibodyFields(Connection conn) throws SQLException {
+        for (String column : new String[]{"atb_type", "atb_hviso_name", "atb_ltiso_name",
+                "atb_host_organism", "atb_immun_organism"}) {
+            String fromValue = scalar(conn,
+                    "select " + column + " from antibody where atb_zdb_id = ?", deleted);
+            if (isPresent(fromValue)) {
+                String intoValue = scalar(conn,
+                        "select " + column + " from antibody where atb_zdb_id = ?", mergedInto);
+                if (!isPresent(intoValue)) {
+                    execUpdate(conn, "update antibody set " + column + " = ? where atb_zdb_id = ?",
+                            fromValue, mergedInto);
+                }
+            }
+        }
+    }
+
+    // FB 11133: move inference_group_member rows referencing the deleted gene, skipping duplicates.
+    private void mergeInferenceGroupMembers(Connection conn) throws SQLException {
+        String goaway = "ZFIN:" + deleted;
+        String into = "ZFIN:" + mergedInto;
+
+        Set<String> existing = new HashSet<>();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select distinct infgrmem_mrkrgoev_zdb_id, infgrmem_inferred_from "
+                        + "from inference_group_member where infgrmem_inferred_from = ?")) {
+            ps.setString(1, into);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    existing.add(rs.getString(1) + rs.getString(2));
+                }
+            }
+        }
+
+        List<String> mrkrgoevIds = new ArrayList<>();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select distinct infgrmem_mrkrgoev_zdb_id from inference_group_member "
+                        + "where infgrmem_inferred_from = ?")) {
+            ps.setString(1, goaway);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    mrkrgoevIds.add(rs.getString(1));
+                }
+            }
+        }
+
+        for (String mrkrgoevId : mrkrgoevIds) {
+            String key = mrkrgoevId + into;
+            if (!existing.contains(key)) {
+                execUpdate(conn,
+                        "update inference_group_member set infgrmem_inferred_from = ? "
+                                + "where infgrmem_mrkrgoev_zdb_id = ? and infgrmem_inferred_from = ?",
+                        into, mrkrgoevId, goaway);
+            }
+            existing.add(key);
+        }
+    }
+
+    // FB 10333: if only the deleted gene has an unspecified allele, rename it onto the surviving gene.
+    private void renameUnspecifiedAllele(Connection conn) throws SQLException {
+        List<String> deletedAlleles = unspecifiedAlleles(conn, deleted);
+        List<String> retainedAlleles = unspecifiedAlleles(conn, mergedInto);
+        if (!retainedAlleles.isEmpty() || deletedAlleles.isEmpty()) {
+            return;
+        }
+        // Match the Perl, which renames the last-fetched unspecified allele feature.
+        String featureId = deletedAlleles.get(deletedAlleles.size() - 1);
+        String newAlleleName = mergedAbbrev + "_unspecified";
+        execUpdate(conn,
+                "update feature set (feature_name, feature_abbrev) = (?, ?) where feature_zdb_id = ?",
+                newAlleleName, newAlleleName, featureId);
+
+        Map<String, String[]> genotypes = new HashMap<>(); // genoId -> {displayName, handle}
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select geno_zdb_id, geno_display_name, geno_handle from genotype, genotype_feature "
+                        + "where genofeat_feature_zdb_id = ? and genofeat_geno_zdb_id = geno_zdb_id")) {
+            ps.setString(1, featureId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    genotypes.put(rs.getString(1), new String[]{rs.getString(2), rs.getString(3)});
+                }
+            }
+        }
+        for (Map.Entry<String, String[]> e : genotypes.entrySet()) {
+            // The Perl uses s/// without /g here: first occurrence only.
+            String displayName = replaceFirstLiteral(e.getValue()[0], deletedAbbrev, mergedAbbrev);
+            String handle = replaceFirstLiteral(e.getValue()[1], deletedAbbrev, mergedAbbrev);
+            execUpdate(conn,
+                    "update genotype set (geno_display_name, geno_handle) = (?, ?) where geno_zdb_id = ?",
+                    displayName, handle, e.getKey());
+        }
+    }
+
+    private List<String> unspecifiedAlleles(Connection conn, String marker) throws SQLException {
+        List<String> ids = new ArrayList<>();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select fmrel_ftr_zdb_id from feature_marker_relationship, feature "
+                        + "where fmrel_ftr_zdb_id = feature_zdb_id and fmrel_mrkr_zdb_id = ? "
+                        + "and feature_unspecified = 't'")) {
+            ps.setString(1, marker);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    ids.add(rs.getString(1));
+                }
+            }
+        }
+        return ids;
+    }
+
+    // MRDL-121: concatenate public comments onto the surviving marker.
+    //
+    // Faithful to the Perl original, INCLUDING its quirk: the Perl uses loose `ne 'none'` checks, and
+    // in Perl `undef ne 'none'` is true, so a NULL comment on the deleted marker still "passes" and the
+    // surviving marker's comment gets set to second + "\n\n" + first (== "\n\n" when both are NULL).
+    // We replicate that exactly so the merge is behavior-identical to merge_markers.pl. The "\n\n"
+    // pollution is a known legacy bug to be fixed separately (see follow-up ticket); do not "clean it
+    // up" here or the equivalence test against the Perl will (correctly) fail.
+    private void mergePublicNotes(Connection conn) throws SQLException {
+        boolean[] found = new boolean[1];
+        String firstNote = fetchComment(conn, deleted, found);
+        if (!found[0] || NONE.equals(firstNote)) {
+            return;
+        }
+        String combined;
+        String secondNote = fetchComment(conn, mergedInto, found);
+        if (found[0] && !NONE.equals(secondNote)) {
+            combined = nz(secondNote) + "\n\n" + nz(firstNote);
+        } else {
+            combined = firstNote; // may be null -> stored as SQL NULL, matching the Perl
+        }
+        if (!NONE.equals(combined)) {
+            execUpdate(conn, "update marker set mrkr_comments = ? where mrkr_zdb_id = ?", combined, mergedInto);
+        }
+    }
+
+    /** Fetch mrkr_comments; sets found[0] to whether the marker row existed. Value may be null. */
+    private String fetchComment(Connection conn, String marker, boolean[] found) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select mrkr_comments from marker where mrkr_zdb_id = ?")) {
+            ps.setString(1, marker);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    found[0] = true;
+                    return rs.getString(1);
+                }
+                found[0] = false;
+                return NONE;
+            }
+        }
+    }
+
+    // For STRs, drop fish / marker_relationship rows that would collide on a unique constraint.
+    private void deleteConflictingStrUsages(Connection conn) throws SQLException {
+        List<String> fishIds = new ArrayList<>();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select distinct fstr1.fishstr_fish_zdb_id from fish_str fstr1 "
+                        + "where fstr1.fishstr_str_zdb_id = ? and exists("
+                        + "select 'x' from fish_str fstr2 where fstr2.fishstr_str_zdb_id = ? "
+                        + "and fstr2.fishstr_fish_zdb_id = fstr1.fishstr_fish_zdb_id)")) {
+            ps.setString(1, deleted);
+            ps.setString(2, mergedInto);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    fishIds.add(rs.getString(1));
+                }
+            }
+        }
+        List<String> relIds = new ArrayList<>();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select distinct mrkrrel1.mrel_zdb_id from marker_relationship mrkrrel1 "
+                        + "where mrkrrel1.mrel_mrkr_1_zdb_id = ? and exists("
+                        + "select 'x' from marker_relationship mrkrrel2 where mrkrrel2.mrel_mrkr_1_zdb_id = ? "
+                        + "and mrkrrel2.mrel_mrkr_2_zdb_id = mrkrrel1.mrel_mrkr_2_zdb_id "
+                        + "and mrkrrel2.mrel_type = mrkrrel1.mrel_type)")) {
+            ps.setString(1, deleted);
+            ps.setString(2, mergedInto);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    relIds.add(rs.getString(1));
+                }
+            }
+        }
+        for (String fishId : fishIds) {
+            execUpdate(conn, "delete from zdb_active_data where zactvd_zdb_id = ?", fishId);
+        }
+        for (String relId : relIds) {
+            execUpdate(conn, "delete from zdb_active_data where zactvd_zdb_id = ?", relId);
+        }
+    }
+
+    // FB 11048: when one marker has a real GO term and the other only the ontology root, drop the root.
+    private void cleanupRedundantRootGoTerms(Connection conn) throws SQLException {
+        for (String[] ontology : new String[][]{
+                {"biological_process", ROOT_BIOLOGICAL_PROCESS},
+                {"molecular_function", ROOT_MOLECULAR_FUNCTION},
+                {"cellular_component", ROOT_CELLULAR_COMPONENT}}) {
+            deleteRedundantRootGo(conn, deleted, mergedInto, ontology[1], ontology[0]);
+            deleteRedundantRootGo(conn, mergedInto, deleted, ontology[1], ontology[0]);
+        }
+    }
+
+    private void deleteRedundantRootGo(Connection conn, String markerWithNonRoot, String markerWithRoot,
+                                       String rootTermId, String ontology) throws SQLException {
+        boolean hasNonRoot;
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select 1 from marker_go_term_evidence, term where mrkrgoev_mrkr_zdb_id = ? "
+                        + "and mrkrgoev_term_zdb_id != ? and mrkrgoev_term_zdb_id = term_zdb_id "
+                        + "and term_ontology = ?")) {
+            ps.setString(1, markerWithNonRoot);
+            ps.setString(2, rootTermId);
+            ps.setString(3, ontology);
+            try (ResultSet rs = ps.executeQuery()) {
+                hasNonRoot = rs.next();
+            }
+        }
+        if (!hasNonRoot) {
+            return;
+        }
+        List<String> rootEvidenceIds = new ArrayList<>();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select mrkrgoev_zdb_id from marker_go_term_evidence "
+                        + "where mrkrgoev_mrkr_zdb_id = ? and mrkrgoev_term_zdb_id = ?")) {
+            ps.setString(1, markerWithRoot);
+            ps.setString(2, rootTermId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    rootEvidenceIds.add(rs.getString(1));
+                }
+            }
+        }
+        for (String evidenceId : rootEvidenceIds) {
+            execUpdate(conn, "delete from zdb_active_data where zactvd_zdb_id = ?", evidenceId);
+        }
+    }
+
+    // ---- low-level helpers -------------------------------------------------------------------
+
+    /** Column names participating in a constraint of the given type on the given table. */
+    private List<String> constraintColumns(Connection conn, String table, String constraintType)
+            throws SQLException {
+        List<String> cols = new ArrayList<>();
+        try (PreparedStatement ps = conn.prepareStatement(
+                "select kc.column_name from information_schema.key_column_usage kc, "
+                        + "information_schema.table_constraints tc where kc.table_name = ? "
+                        + "and tc.table_name = kc.table_name and tc.constraint_name = kc.constraint_name "
+                        + "and tc.constraint_type = ?")) {
+            ps.setString(1, table);
+            ps.setString(2, constraintType);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    cols.add(rs.getString(1));
+                }
+            }
+        }
+        return cols;
+    }
+
+    /** Map of concatenated unique-column values -> primary-key value, for rows where FK = id. */
+    private Map<String, String> comboToPk(Connection conn, String schemaTable, String pkColumn,
+                                          String selectList, String fkColumn, String id) throws SQLException {
+        Map<String, String> result = new HashMap<>();
+        String sql = "select " + pkColumn + ", " + selectList + " from " + schemaTable
+                + " where " + fkColumn + " = " + lit(id);
+        try (Statement st = conn.createStatement(); ResultSet rs = st.executeQuery(sql)) {
+            int colCount = rs.getMetaData().getColumnCount();
+            while (rs.next()) {
+                StringBuilder combo = new StringBuilder();
+                for (int i = 2; i <= colCount; i++) {
+                    combo.append(nz(rs.getString(i))); // NULL -> "" (Perl concatenates undef as "")
+                }
+                result.put(combo.toString(), rs.getString(1));
+            }
+        }
+        return result;
+    }
+
+    /** Set of concatenated column values from {@code selectList} for rows where FK = id. */
+    private Set<String> combos(Connection conn, String schemaTable, String selectList,
+                               String fkColumn, String id) throws SQLException {
+        Set<String> result = new HashSet<>();
+        String sql = "select " + selectList + " from " + schemaTable + " where " + fkColumn + " = " + lit(id);
+        try (Statement st = conn.createStatement(); ResultSet rs = st.executeQuery(sql)) {
+            int colCount = rs.getMetaData().getColumnCount();
+            while (rs.next()) {
+                StringBuilder combo = new StringBuilder();
+                for (int i = 1; i <= colCount; i++) {
+                    combo.append(nz(rs.getString(i))); // NULL -> "" (Perl concatenates undef as "")
+                }
+                result.add(combo.toString());
+            }
+        }
+        return result;
+    }
+
+    /** Rows as column->value maps (only the columns named in {@code columns}), for rows where FK = id. */
+    private List<Map<String, String>> rowsByColumn(Connection conn, String schemaTable, String selectList,
+                                                    List<String> columns, String fkColumn, String id)
+            throws SQLException {
+        List<Map<String, String>> rows = new ArrayList<>();
+        String sql = "select " + selectList + " from " + schemaTable + " where " + fkColumn + " = " + lit(id);
+        try (Statement st = conn.createStatement(); ResultSet rs = st.executeQuery(sql)) {
+            ResultSetMetaData md = rs.getMetaData();
+            while (rs.next()) {
+                Map<String, String> row = new HashMap<>();
+                for (int i = 1; i <= md.getColumnCount(); i++) {
+                    row.put(columns.get(i - 1), rs.getString(i));
+                }
+                rows.add(row);
+            }
+        }
+        return rows;
+    }
+
+    private int countRows(Connection conn, String schemaTable, String column, String id) throws SQLException {
+        try (Statement st = conn.createStatement();
+             ResultSet rs = st.executeQuery(
+                     "select count(*) from " + schemaTable + " where " + column + " = " + lit(id))) {
+            return rs.next() ? rs.getInt(1) : 0;
+        }
+    }
+
+    private String scalar(Connection conn, String sql, String param) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, param);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? rs.getString(1) : null;
+            }
+        }
+    }
+
+    /** Execute a statement built from trusted identifiers and validated ids (no bind parameters). */
+    private void exec(Connection conn, String sql) throws SQLException {
+        executedSql.add(sql);
+        LOG.info("SQL: {}", sql);
+        try (Statement st = conn.createStatement()) {
+            st.execute(sql);
+        }
+    }
+
+    /** Execute a parameterized statement (used whenever fetched string values are embedded). */
+    private void execUpdate(Connection conn, String sql, String... params) throws SQLException {
+        StringBuilder rendered = new StringBuilder();
+        for (int i = 0; i < params.length; i++) {
+            if (i > 0) {
+                rendered.append(", ");
+            }
+            rendered.append(params[i]); // StringBuilder renders null as "null" (null-safe logging)
+        }
+        executedSql.add(sql + "  -- params: " + rendered);
+        LOG.info("SQL: {} | params: {}", sql, rendered);
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            for (int i = 0; i < params.length; i++) {
+                ps.setString(i + 1, params[i]);
+            }
+            ps.execute();
+        }
+    }
+
+    private static boolean isPresent(String value) {
+        return value != null && !value.isEmpty() && !"none".equals(value);
+    }
+
+    /** Null-coalesce to empty string, mirroring Perl's undef-to-"" coercion in string concatenation. */
+    private static String nz(String value) {
+        return value == null ? "" : value;
+    }
+
+    /**
+     * Render a value as a quoted SQL literal, the way the Perl interpolates ids/keys into its
+     * queries. Crucial for the generic FK walk: a literal is "unknown"-typed and Postgres coerces it
+     * to the column's type, so it works against numeric (bigint) key columns reached during recursion.
+     * Binding the same value with setString would type it as varchar and fail with
+     * "operator does not exist: bigint = character varying".
+     */
+    private static String lit(String value) {
+        return value == null ? "NULL" : "'" + value.replace("'", "''") + "'";
+    }
+
+    private static String replaceFirstLiteral(String input, String target, String replacement) {
+        if (input == null) {
+            return null;
+        }
+        int idx = input.indexOf(target);
+        return idx < 0 ? input : input.substring(0, idx) + replacement + input.substring(idx + target.length());
+    }
+}

--- a/source/org/zfin/util/commandline/CommandLineUtilityRegistry.java
+++ b/source/org/zfin/util/commandline/CommandLineUtilityRegistry.java
@@ -1,5 +1,8 @@
 package org.zfin.util.commandline;
 
+import org.zfin.framework.ToolBootstrap;
+
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
 
@@ -12,7 +15,14 @@ public class CommandLineUtilityRegistry {
     private static final Map<String, UtilityInfo> UTILITIES = new LinkedHashMap<>();
 
     static {
-        // Register available utilities here
+        // Register available utilities here.
+        //
+        // Use the 4-arg register(...) for utilities that do NOT need the database (pure file/IO tools);
+        // their main() is invoked directly. Use the 5-arg register(..., requiresDatabase=true) for
+        // data tools (reports, audits, loads): they run inside ToolBootstrap.run(...), which loads
+        // ZfinProperties, brings up Hibernate, and wraps the run in a single managed transaction
+        // (commit on success, rollback on failure). Such tools should let main() return normally
+        // rather than calling System.exit(), so the transaction commits and the session closes.
         register("csv2xlsx",
                 "org.zfin.datatransfer.util.CSVToXLSXConverter",
                 "Convert CSV file to XLSX format",
@@ -24,7 +34,12 @@ public class CommandLineUtilityRegistry {
                 "Manage token storage operations",
                 "token-storage <operation> [options] \n eg. token-storage read NCBI_API_TOKEN\n     token-storage write NCBI_API_TOKEN 'your_token_value'");
 
-        // Add more utilities as they are discovered/created
+        // Add more utilities as they are discovered/created. Example of a database-backed tool:
+        // register("ortho-inconsistency-report",
+        //         "org.zfin.orthology.OrthoInconsistencyReportJob",
+        //         "Report orthology inconsistencies",
+        //         "ortho-inconsistency-report [<output.csv>]",
+        //         true);
     }
 
     /**
@@ -36,7 +51,18 @@ public class CommandLineUtilityRegistry {
      * @param usage       Usage example (without the 'zfin-util' prefix)
      */
     private static void register(String name, String mainClass, String description, String usage) {
-        UTILITIES.put(name.toLowerCase(), new UtilityInfo(name, mainClass, description, usage));
+        register(name, mainClass, description, usage, false);
+    }
+
+    /**
+     * Register a utility, specifying whether it needs the database.
+     *
+     * @param requiresDatabase if true, the utility runs inside {@link ToolBootstrap#run}, which loads
+     *                         properties, brings up Hibernate, and manages a single transaction; if
+     *                         false, its main() is invoked directly with no environment setup.
+     */
+    private static void register(String name, String mainClass, String description, String usage, boolean requiresDatabase) {
+        UTILITIES.put(name.toLowerCase(), new UtilityInfo(name, mainClass, description, usage, requiresDatabase));
     }
 
     /**
@@ -94,7 +120,32 @@ public class CommandLineUtilityRegistry {
         // Load the main class and invoke its main method
         Class<?> mainClass = Class.forName(util.mainClass);
         Method mainMethod = mainClass.getMethod("main", String[].class);
-        mainMethod.invoke(null, (Object) args);
+
+        if (util.requiresDatabase) {
+            // Run inside the ToolBootstrap environment: properties + Hibernate + a managed transaction.
+            ToolBootstrap.run(util.name, args, () -> invokeMain(mainMethod, args));
+        } else {
+            invokeMain(mainMethod, args);
+        }
+    }
+
+    /**
+     * Invoke a utility's static main(String[]), unwrapping the reflection wrapper so the utility's
+     * own exception propagates (and, for database-backed tools, reaches ToolBootstrap's rollback).
+     */
+    private static void invokeMain(Method mainMethod, String[] args) throws Exception {
+        try {
+            mainMethod.invoke(null, (Object) args);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception ex) {
+                throw ex;
+            }
+            if (cause instanceof Error err) {
+                throw err;
+            }
+            throw e;
+        }
     }
 
     /**
@@ -105,12 +156,14 @@ public class CommandLineUtilityRegistry {
         final String mainClass;
         final String description;
         final String usage;
+        final boolean requiresDatabase;
 
-        UtilityInfo(String name, String mainClass, String description, String usage) {
+        UtilityInfo(String name, String mainClass, String description, String usage, boolean requiresDatabase) {
             this.name = name;
             this.mainClass = mainClass;
             this.description = description;
             this.usage = usage;
+            this.requiresDatabase = requiresDatabase;
         }
     }
 }

--- a/source/org/zfin/util/commandline/CommandLineUtilityRegistry.java
+++ b/source/org/zfin/util/commandline/CommandLineUtilityRegistry.java
@@ -34,12 +34,15 @@ public class CommandLineUtilityRegistry {
                 "Manage token storage operations",
                 "token-storage <operation> [options] \n eg. token-storage read NCBI_API_TOKEN\n     token-storage write NCBI_API_TOKEN 'your_token_value'");
 
-        // Add more utilities as they are discovered/created. Example of a database-backed tool:
-        // register("ortho-inconsistency-report",
-        //         "org.zfin.orthology.OrthoInconsistencyReportJob",
-        //         "Report orthology inconsistencies",
-        //         "ortho-inconsistency-report [<output.csv>]",
-        //         true);
+        // Merge one marker into another (port of cgi-bin/merge_markers.pl). Database-backed, so it
+        // runs inside ToolBootstrap.run's managed transaction.
+        register("merge-markers",
+                "org.zfin.marker.MergeMarkersCommandLine",
+                "Merge one marker into another (reassign references, then delete the old record)",
+                "merge-markers <zdbIdToDelete> <zdbIdToMergeInto> [--dry-run] [--skip-regen]",
+                true);
+
+        // Add more utilities as they are discovered/created.
     }
 
     /**


### PR DESCRIPTION
This pull request introduces a new utility class, `ToolBootstrap`, to simplify running command-line jobs that require database access, and refactors the command-line utility registry to support tools that need a managed Hibernate environment. Now, database-backed utilities can be registered and executed with automatic property loading, Hibernate session management, and transaction handling, reducing boilerplate and risk of resource leaks.
