### PR TITLE
Deploy script: Improve usability

### DIFF
--- a/docker/release-prompts.sh
+++ b/docker/release-prompts.sh
@@ -13,7 +13,53 @@ cmprun() {
 SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 LOG_DIR=/research/zusers/informix/release-logs
 
-if [ -z "$RELEASE_PROMPTS_INPUTS" ]; then
+# One-time splash on the very first invocation. The screen/script re-execs
+# each set one of these markers (STY / RELEASE_PROMPTS_RECORDING), so this
+# block is skipped on those re-runs and the banner shows exactly once.
+if [ -z "$STY" ] && [ -z "$RELEASE_PROMPTS_RECORDING" ]; then
+    clear
+    cat <<'BANNER'
+================================================================
+            ZFIN Release Deployment Driver
+================================================================
+
+Steps through the release deployment one action at a time. At
+each step you choose:
+
+  Y / Enter   run it        S   skip it
+  B           go back       F   forward without running
+  Q           quit
+
+The run auto-wraps in a `screen` session (detach: Ctrl-A d) and
+is recorded with `script` under:
+  /research/zusers/informix/release-logs/
+
+Environment knobs (all optional):
+
+  RELEASE=<num>       release number    -- skips the prompt
+  DEPLOY_DIR=<path>   deploy directory  -- skips the prompt
+  BEGIN_STEP=<n>      jump straight to step <n>
+  NO_SCREEN=1         don't wrap in screen
+  NO_SCRIPT=1         don't record with script
+
+Example (no prompts, start at step 8):
+
+  RELEASE=1234 \
+  DEPLOY_DIR=/opt/zfin/source_roots/test/zfin/docker \
+  BEGIN_STEP=8 \
+  ./release-prompts.sh
+
+================================================================
+
+BANNER
+    read -rp "Press Enter to begin (Ctrl-C to abort)... " _
+fi
+
+# Prompt only for whichever inputs weren't already supplied. Invoking with
+# both RELEASE and DEPLOY_DIR set and non-empty skips the reads entirely.
+# They're exported below so the screen/script re-execs (and docker compose)
+# inherit them whether they came from the environment or the prompts.
+if [ -z "$RELEASE" ] || [ -z "$DEPLOY_DIR" ]; then
     read -rp "Release number (e.g. 1234): " RELEASE
     read -rp "Deploy dir (e.g. /opt/zfin/source_roots/test/zfin/docker): " DEPLOY_DIR
 
@@ -21,10 +67,9 @@ if [ -z "$RELEASE_PROMPTS_INPUTS" ]; then
         echo "Both release number and deploy dir are required."
         exit 1
     fi
-
-    export RELEASE DEPLOY_DIR
-    export RELEASE_PROMPTS_INPUTS=1
 fi
+
+export RELEASE DEPLOY_DIR
 
 if [ -z "$STY" ] && [ -z "$NO_SCREEN" ]; then
     if ! command -v screen >/dev/null; then
@@ -59,7 +104,7 @@ labels=(
     "cmprun 'gradle make'"
     "cmprun 'gradle liquibasePostBuild'"
     "cmprun 'ant deploy-catalina-base'"
-    "cmprun 'ant deploy'"
+    "cmprun 'ant deploy-without-tests'"
     "cmprun 'ant deploy-jobs'"
     "cmprun 'ant deploy-plugins'"
     "cmprun 'ant create-views'"
@@ -72,6 +117,7 @@ labels=(
     "docker compose up -d tomcat"
     "docker compose down solr"
     "docker compose up -d solr"
+    "cmprun 'ant test' (deferred DB tests + smoke; rolls back, slow)"
 )
 
 commands=(
@@ -87,7 +133,7 @@ commands=(
     "cmprun 'gradle make'"
     "cmprun 'gradle liquibasePostBuild'"
     "cmprun 'ant deploy-catalina-base'"
-    "cmprun 'ant deploy'"
+    "cmprun 'ant deploy-without-tests'"
     "cmprun 'ant deploy-jobs'"
     "cmprun 'ant deploy-plugins'"
     "cmprun 'ant create-views'"
@@ -100,10 +146,23 @@ commands=(
     "docker compose up -d tomcat"
     "docker compose down solr"
     "docker compose up -d solr"
+    "cmprun 'ant test'"
 )
 
 total=${#labels[@]}
+
+# BEGIN_STEP (1-indexed, matching the "[Step N/total]" display) jumps the
+# loop straight to that step instead of starting at the top. Inherited across
+# the screen/script re-execs from the initial environment.
 i=0
+if [ -n "$BEGIN_STEP" ]; then
+    if ! [[ "$BEGIN_STEP" =~ ^[0-9]+$ ]] || [ "$BEGIN_STEP" -lt 1 ] || [ "$BEGIN_STEP" -gt "$total" ]; then
+        echo "BEGIN_STEP must be a whole number between 1 and $total (got '$BEGIN_STEP')." >&2
+        exit 1
+    fi
+    i=$((BEGIN_STEP - 1))
+    echo "Starting at step $BEGIN_STEP/$total."
+fi
 
 while [ "$i" -lt "$total" ]; do
     echo


### PR DESCRIPTION
This pull request improves the user experience and flexibility of the `docker/release-prompts.sh` release deployment script. The main enhancements include displaying a user-friendly banner at startup and adding support for jumping directly to a specific deployment step via an environment variable.

User experience improvements:

* Added a one-time splash banner on the first invocation of the script, providing clear instructions and environment variable options to the user. The banner is shown only once per run, not on re-executions in `screen` or `script` sessions.

Deployment process flexibility:

* Introduced support for the `BEGIN_STEP` environment variable, allowing users to start the deployment process at a specific step. The script validates the value and provides feedback if it is out of range or invalid.