### PR TITLE
HTML Report improvement: compress internal data

### DIFF
--- a/home/uniprot/reportmaker/build.groovy
+++ b/home/uniprot/reportmaker/build.groovy
@@ -58,11 +58,16 @@ if (startIdx < 0 || endIdx < 0) {
     System.exit(3)
 }
 
-// Escape "</" → "<\/" so any string in the data can't break out of the
-// surrounding <script> block (e.g. an error blob containing "</script>")
-// and can't reproduce our PLACEHOLDER_END sentinel. "<\/" is JSON-legal.
-def json    = JsonOutput.prettyPrint(JsonOutput.toJson(data)).replace('</', '<\\/')
-def payload = "${START}\n        window.REPORT_DATA = ${json};\n        "
+// Gzip + Base64-encode the JSON so this matches what the Java ReportWriter
+// emits (window.REPORT_DATA_GZ); the viewer inflates it with the browser's
+// native DecompressionStream. Base64 is <script>-safe by construction — its
+// alphabet can't contain "</" to break out of the tag or reproduce the
+// PLACEHOLDER_END sentinel — so no escaping is needed.
+def json = JsonOutput.toJson(data)
+def bos  = new ByteArrayOutputStream()
+new java.util.zip.GZIPOutputStream(bos).withCloseable { it.write(json.getBytes('UTF-8')) }
+def b64  = bos.toByteArray().encodeBase64().toString()
+def payload = "${START}\n        window.REPORT_DATA_GZ = \"${b64}\";\n        "
 def out     = template.substring(0, startIdx) + payload + template.substring(endIdx)
 
 if (opts.output) {

--- a/source/org/zfin/report/ReportWriter.java
+++ b/source/org/zfin/report/ReportWriter.java
@@ -2,11 +2,14 @@ package org.zfin.report;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Base64;
+import java.util.zip.GZIPOutputStream;
 
 /**
  * Serializes a {@link Report} to JSON and inlines it into the report HTML
@@ -56,14 +59,23 @@ public class ReportWriter {
             throw new IOException("Template missing " + PLACEHOLDER_START + " / "
                 + PLACEHOLDER_END + " markers (or end precedes start).");
         }
-        // Escape "</" → "<\/" so user-controlled strings can't break out of the
-        // surrounding <script> block (e.g. an error blob containing "</script>")
-        // and so the inlined JSON can't accidentally reproduce our PLACEHOLDER_END
-        // sentinel. "<\/" is a JSON-legal escape that decodes back to "</".
-        String json = mapper.writeValueAsString(report).replace("</", "<\\/");
+        // Gzip then Base64-encode the JSON: report payloads are highly
+        // repetitive and compress ~5-15x, and the viewer inflates them with the
+        // browser's native DecompressionStream. Base64 is also <script>-safe by
+        // construction — its alphabet can't contain "</" to break out of the tag
+        // or reproduce our PLACEHOLDER_END sentinel — so no escaping is needed.
+        String b64 = gzipBase64(mapper.writeValueAsBytes(report));
         String payload = PLACEHOLDER_START
-            + "\n        window.REPORT_DATA = " + json + ";\n        ";
+            + "\n        window.REPORT_DATA_GZ = \"" + b64 + "\";\n        ";
         return template.substring(0, start) + payload + template.substring(end);
+    }
+
+    private static String gzipBase64(byte[] data) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gz = new GZIPOutputStream(bos)) {
+            gz.write(data);
+        }
+        return Base64.getEncoder().encodeToString(bos.toByteArray());
     }
 
     private String loadDefaultTemplate() throws IOException {

--- a/source/org/zfin/report/ReportWriter.java
+++ b/source/org/zfin/report/ReportWriter.java
@@ -1,7 +1,6 @@
 package org.zfin.report;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,8 +27,10 @@ public class ReportWriter {
     private static final String PLACEHOLDER_START = "//PLACEHOLDER_START";
     private static final String PLACEHOLDER_END   = "//PLACEHOLDER_END";
 
-    private final ObjectMapper mapper = new ObjectMapper()
-        .enable(SerializationFeature.INDENT_OUTPUT);
+    // Compact (non-indented) JSON: the payload is machine-read by the report
+    // viewer, never hand-edited, so indentation is pure byte bloat in a file
+    // that can grow large.
+    private final ObjectMapper mapper = new ObjectMapper();
 
     /** Render using the bundled classpath template. */
     public String render(Report report) throws IOException {

--- a/source/org/zfin/report/report-template.html
+++ b/source/org/zfin/report/report-template.html
@@ -13,7 +13,7 @@
 
     <script>
         //PLACEHOLDER_START
-        window.REPORT_DATA = JSON_GOES_HERE;
+        window.REPORT_DATA_GZ = "BASE64_GZIP_GOES_HERE";
         //PLACEHOLDER_END
     </script>
 
@@ -818,10 +818,41 @@
         `;
     }
 
-    document.addEventListener('DOMContentLoaded', () => {
+    async function loadReportData() {
+        // Newer reports inline a gzipped + Base64-encoded payload
+        // (REPORT_DATA_GZ); older reports inline the raw JSON object
+        // (REPORT_DATA). Support both so previously generated reports keep
+        // rendering.
+        if (typeof window.REPORT_DATA_GZ === 'string') {
+            if (typeof DecompressionStream !== 'function') {
+                throw new Error('This report is compressed, but your browser does not support ' +
+                    'DecompressionStream. Please open it in a current version of Chrome, Edge, Firefox, or Safari.');
+            }
+            const bytes = Uint8Array.from(atob(window.REPORT_DATA_GZ), c => c.charCodeAt(0));
+            const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream('gzip'));
+            return JSON.parse(await new Response(stream).text());
+        }
+        return window.REPORT_DATA;
+    }
+
+    document.addEventListener('DOMContentLoaded', async () => {
         const root = document.getElementById('root');
-        root.innerHTML = '';
-        render(html`<${App} data=${window.REPORT_DATA} />`, root);
+        try {
+            const data = await loadReportData();
+            root.innerHTML = '';
+            render(html`<${App} data=${data} />`, root);
+        } catch (e) {
+            root.innerHTML = '';
+            const div = document.createElement('div');
+            div.className = 'error';
+            const h = document.createElement('h2');
+            h.textContent = 'Error Loading Report';
+            const p = document.createElement('p');
+            p.textContent = (e && e.message) ? e.message : String(e);
+            div.appendChild(h);
+            div.appendChild(p);
+            root.appendChild(div);
+        }
     });
 })();
 </script>

--- a/test/org/zfin/orthology/jobs/OrthoUpdateReportJobTest.java
+++ b/test/org/zfin/orthology/jobs/OrthoUpdateReportJobTest.java
@@ -167,9 +167,24 @@ public class OrthoUpdateReportJobTest {
         children.forEach(c -> assertNotNull("nav count for " + c.getTitle(), c.getCount()));
 
         String html = new org.zfin.report.ReportWriter().render(report);
-        assertTrue(html.contains("window.REPORT_DATA"));
-        assertTrue(html.contains("Inconsistent ZF gene names"));
+        assertTrue(html.contains("window.REPORT_DATA_GZ"));
+        // The payload is gzipped + Base64-encoded, so assert against the
+        // inflated JSON rather than the (now opaque) HTML.
+        String json = inflateReportData(html);
+        assertTrue(json.contains("Inconsistent ZF gene names"));
         // Diff highlighting reached the output (OrthoNameDiff wraps changes in <u>).
-        assertTrue(html.contains("<u>") || html.contains("<\\/u>"));
+        assertTrue(json.contains("<u>"));
+    }
+
+    /** Extract and gunzip the {@code window.REPORT_DATA_GZ} payload from rendered report HTML. */
+    private static String inflateReportData(String html) throws Exception {
+        var matcher = java.util.regex.Pattern
+            .compile("window\\.REPORT_DATA_GZ = \"([^\"]*)\"")
+            .matcher(html);
+        assertTrue("REPORT_DATA_GZ payload present", matcher.find());
+        byte[] gz = java.util.Base64.getDecoder().decode(matcher.group(1));
+        try (var in = new java.util.zip.GZIPInputStream(new java.io.ByteArrayInputStream(gz))) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
     }
 }


### PR DESCRIPTION
Our HTML reports get pretty large sometimes. We can compress them as zip files but that can be annoying to go through the trouble of downloading and unzipping each time. This uses gzip (supported by Java and Javascript natively) to compress the JSON and encode it as base64 inside the html--making the files much smaller.