### PR TITLE
ZFIN-9394: Fix SignaFish load: https source, empty-input guard, per-ID link adds

### DIFF
--- a/source/org/zfin/datatransfer/LoadSignafishJob.java
+++ b/source/org/zfin/datatransfer/LoadSignafishJob.java
@@ -2,12 +2,9 @@ package org.zfin.datatransfer;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.zfin.Species;
 import org.zfin.framework.HibernateUtil;
 import org.zfin.infrastructure.ant.AbstractValidateDataReportTask;
-import org.zfin.repository.RepositoryFactory;
-import org.zfin.sequence.ForeignDB;
-import org.zfin.sequence.ForeignDBDataType;
+import org.zfin.marker.Marker;
 import org.zfin.sequence.ReferenceDatabase;
 import org.zfin.util.ReportGenerator;
 
@@ -17,6 +14,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.zfin.repository.RepositoryFactory.getMarkerRepository;
 
@@ -85,16 +83,9 @@ public class LoadSignafishJob extends AbstractValidateDataReportTask {
 
     private void load(List<String> geneIdList) {
 
-        ReferenceDatabase signafishDb = RepositoryFactory.getSequenceRepository().getReferenceDatabase(
-                ForeignDB.AvailableName.SIGNAFISH,
-                ForeignDBDataType.DataType.OTHER,
-                ForeignDBDataType.SuperType.SUMMARY_PAGE,
-                Species.Type.ZEBRAFISH);
-
+        ReferenceDatabase signafishDb = getMarkerRepository().getSignafishReferenceDatabase();
         if (signafishDb == null) {
-            throw new RuntimeException("Could not find the Signafish reference database "
-                    + "(" + ForeignDB.AvailableName.SIGNAFISH + "/" + ForeignDBDataType.DataType.OTHER
-                    + "/" + ForeignDBDataType.SuperType.SUMMARY_PAGE + "/" + Species.Type.ZEBRAFISH + "). "
+            throw new RuntimeException("Could not find the Signafish reference database. "
                     + "Aborting before any links are modified.");
         }
 
@@ -113,10 +104,29 @@ public class LoadSignafishJob extends AbstractValidateDataReportTask {
                     + "Check that the source file is reachable and populated.");
         }
 
-        int numberOfDeletedIds = getMarkerRepository().deleteMarkerDBLinksNotInList(signafishDb, geneIdList);
-        getMarkerRepository().addMarkerDBLinks(signafishDb, geneIdList);
+        // Resolve the source IDs to their current markers up front, following merges
+        // (zdb_replaced_data), so links are keyed on the surviving marker. Using these resolved IDs
+        // for both deletion and addition means a source ID that was later merged still links to the
+        // new marker, and the link is not churned (deleted + re-added) on every subsequent run.
+        List<String> resolvedIds = getMarkerRepository().getMarkersByZdbIDsIncludingReplaced(geneIdList)
+                .stream()
+                .map(Marker::getZdbID)
+                .collect(Collectors.toList());
+        logger.info("Resolved " + geneIdList.size() + " source ID(s) to " + resolvedIds.size() + " current marker(s)");
+
+        // Same destructive-load guard, applied after resolution: if a non-empty source list resolves
+        // to zero current markers, the delete below would wipe every link. Abort instead.
+        if (resolvedIds.isEmpty()) {
+            throw new RuntimeException("None of the " + geneIdList.size() + " source ID(s) resolved to a current marker. "
+                    + "Refusing to delete the " + existingLinkCount + " existing Signafish link(s). "
+                    + "Check that the source file contains valid ZFIN gene IDs.");
+        }
+
+        int numberOfDeletedIds = getMarkerRepository().deleteMarkerDBLinksNotInList(signafishDb, resolvedIds);
+        int numberOfAdded = getMarkerRepository().addSignafishMarkerDBLinks(resolvedIds);
         long finalLinkCount = getMarkerRepository().getSignafishLinkCount(signafishDb);
         logger.info("Deleted " + numberOfDeletedIds + " Signafish link(s) not in the incoming list");
+        logger.info("Added " + numberOfAdded + " new Signafish link(s)");
         logger.info("Signafish links after load: " + finalLinkCount + " (was " + existingLinkCount + ")");
 
         ReportGenerator rg = new ReportGenerator();

--- a/source/org/zfin/datatransfer/LoadSignafishJob.java
+++ b/source/org/zfin/datatransfer/LoadSignafishJob.java
@@ -84,13 +84,40 @@ public class LoadSignafishJob extends AbstractValidateDataReportTask {
                 ForeignDBDataType.SuperType.SUMMARY_PAGE,
                 Species.Type.ZEBRAFISH);
 
+        if (signafishDb == null) {
+            throw new RuntimeException("Could not find the Signafish reference database "
+                    + "(" + ForeignDB.AvailableName.SIGNAFISH + "/" + ForeignDBDataType.DataType.OTHER
+                    + "/" + ForeignDBDataType.SuperType.SUMMARY_PAGE + "/" + Species.Type.ZEBRAFISH + "). "
+                    + "Aborting before any links are modified.");
+        }
+
+        long existingLinkCount = getMarkerRepository().getSignafishLinkCount(signafishDb);
+        logger.info("Signafish reference database: " + signafishDb.getZdbID());
+        logger.info("Existing Signafish links before load: " + existingLinkCount);
+        logger.info("Gene IDs parsed from source: " + geneIdList.size());
+
+        // Guard against a destructive load. The load deletes every existing link not present in the
+        // incoming list, so an empty (or anomalously small) input file would silently wipe out all
+        // links. Abort before touching the database so the transaction rolls back and the build fails
+        // loudly instead of reporting "0 links" as a success. See ZFIN Load-Signafish_w build #516.
+        if (geneIdList.isEmpty()) {
+            throw new RuntimeException("Parsed an empty Signafish gene ID list from the source file. "
+                    + "Refusing to delete the " + existingLinkCount + " existing Signafish link(s). "
+                    + "Check that the source file is reachable and populated.");
+        }
+
         int numberOfDeletedIds = getMarkerRepository().deleteMarkerDBLinksNotInList(signafishDb, geneIdList);
         getMarkerRepository().addMarkerDBLinks(signafishDb, geneIdList);
+        long finalLinkCount = getMarkerRepository().getSignafishLinkCount(signafishDb);
+        logger.info("Deleted " + numberOfDeletedIds + " Signafish link(s) not in the incoming list");
+        logger.info("Signafish links after load: " + finalLinkCount + " (was " + existingLinkCount + ")");
+
         ReportGenerator rg = new ReportGenerator();
         rg.setReportTitle("Report for " + jobName);
         rg.includeTimestamp();
-        rg.addIntroParagraph("With this load there are now " + getMarkerRepository().getSignafishLinkCount(signafishDb) + " Signafish links in total.");
-        rg.addIntroParagraph("Deleted Records: " +numberOfDeletedIds);
+        rg.addIntroParagraph("Gene IDs parsed from source: " + geneIdList.size());
+        rg.addIntroParagraph("With this load there are now " + finalLinkCount + " Signafish links in total (was " + existingLinkCount + ").");
+        rg.addIntroParagraph("Deleted Records: " + numberOfDeletedIds);
         rg.writeFiles(new File(dataDirectory, jobName), "signafish-report");
     }
 
@@ -98,18 +125,28 @@ public class LoadSignafishJob extends AbstractValidateDataReportTask {
     private List<String> parseFile() throws Exception {
         String fileName = "zfin_ids.lst";
 
-        String url = "http://signalink.org/" + fileName;
+        // Must be https: the http URL 302-redirects to https, and URL.openStream() does not follow
+        // cross-protocol redirects, so http yields an empty body (0 IDs). See Load-Signafish_w build #516.
+        String url = "https://signalink.org/" + fileName;
+        logger.info("Fetching Signafish gene ID list from " + url);
 
         URL oracle = new URL(url);
         BufferedReader in = new BufferedReader(
                 new InputStreamReader(oracle.openStream()));
 
         String inputLine;
+        int totalLines = 0;
         List<String> idd = new ArrayList<>();
-        while ((inputLine = in.readLine()) != null)
-            idd.add(inputLine);
+        while ((inputLine = in.readLine()) != null) {
+            totalLines++;
+            String trimmed = inputLine.trim();
+            if (!trimmed.isEmpty()) {
+                idd.add(trimmed);
+            }
+        }
         in.close();
 
+        logger.info("Read " + totalLines + " line(s) from " + url + ", " + idd.size() + " non-blank gene ID(s)");
         return idd;
     }
 

--- a/source/org/zfin/datatransfer/LoadSignafishJob.java
+++ b/source/org/zfin/datatransfer/LoadSignafishJob.java
@@ -27,6 +27,13 @@ public class LoadSignafishJob extends AbstractValidateDataReportTask {
 
     private static Logger logger = LogManager.getLogger(LoadSignafishJob.class);
 
+    // Must be https: the http URL 302-redirects to https, and URL.openStream() does not follow
+    // cross-protocol redirects, so http yields an empty body (0 IDs). See Load-Signafish_w build #516.
+    static final String DEFAULT_SOURCE_URL = "https://signalink.org/zfin_ids.lst";
+
+    // Environment variable to override the upstream source URL (e.g. for testing against a fixture).
+    static final String SOURCE_URL_ENV_VAR = "SIGNAFISH_SOURCE_URL";
+
     public LoadSignafishJob(String jobName, String propertyPath, String baseDir) {
         super(jobName, propertyPath, baseDir);
     }
@@ -122,12 +129,17 @@ public class LoadSignafishJob extends AbstractValidateDataReportTask {
     }
 
 
-    private List<String> parseFile() throws Exception {
-        String fileName = "zfin_ids.lst";
+    private String getSourceUrl() {
+        String override = System.getenv(SOURCE_URL_ENV_VAR);
+        if (override != null && !override.trim().isEmpty()) {
+            logger.info("Overriding Signafish source URL from $" + SOURCE_URL_ENV_VAR);
+            return override.trim();
+        }
+        return DEFAULT_SOURCE_URL;
+    }
 
-        // Must be https: the http URL 302-redirects to https, and URL.openStream() does not follow
-        // cross-protocol redirects, so http yields an empty body (0 IDs). See Load-Signafish_w build #516.
-        String url = "https://signalink.org/" + fileName;
+    private List<String> parseFile() throws Exception {
+        String url = getSourceUrl();
         logger.info("Fetching Signafish gene ID list from " + url);
 
         URL oracle = new URL(url);

--- a/source/org/zfin/marker/repository/HibernateMarkerRepository.java
+++ b/source/org/zfin/marker/repository/HibernateMarkerRepository.java
@@ -118,6 +118,23 @@ public class HibernateMarkerRepository implements MarkerRepository {
     }
 
     @Override
+    public List<Marker> getMarkersByZdbIDsIncludingReplaced(List<String> zdbIDs) {
+        if (CollectionUtils.isEmpty(zdbIDs)) {
+            return new ArrayList<>();
+        }
+        // getMarker() already follows zdb_replaced_data when the ID itself no longer resolves.
+        // Dedup by surviving ZDB ID (merged IDs collapse together); keep input order; drop unknowns.
+        Map<String, Marker> resolved = new LinkedHashMap<>();
+        for (String zdbID : zdbIDs) {
+            Marker marker = getMarker(zdbID);
+            if (marker != null) {
+                resolved.putIfAbsent(marker.getZdbID(), marker);
+            }
+        }
+        return new ArrayList<>(resolved.values());
+    }
+
+    @Override
     public List<Marker> getMarkersByZdbIDsJoiningAliases(List<String> zdbIDs) {
         String hql = "select m from Marker m join fetch m.aliases where m.zdbID in (:IDs) ";
 
@@ -2829,23 +2846,29 @@ public class HibernateMarkerRepository implements MarkerRepository {
     }
 
     @Override
-    public int addMarkerDBLinks(final ReferenceDatabase referenceDatabase, List<String> geneIdList) {
-        if (CollectionUtils.isEmpty(geneIdList)) {
+    public ReferenceDatabase getSignafishReferenceDatabase() {
+        return RepositoryFactory.getSequenceRepository().getReferenceDatabase(
+                ForeignDB.AvailableName.SIGNAFISH,
+                ForeignDBDataType.DataType.OTHER,
+                ForeignDBDataType.SuperType.SUMMARY_PAGE,
+                Species.Type.ZEBRAFISH);
+    }
+
+    @Override
+    public int addSignafishMarkerDBLinks(List<String> markerIds) {
+        if (CollectionUtils.isEmpty(markerIds)) {
             return 0;
         }
+        ReferenceDatabase referenceDatabase = getSignafishReferenceDatabase();
 
         // Find which of the incoming IDs already have a link, so we add only the missing ones.
         // (Previously this short-circuited the entire batch if ANY link already existed, so new
         // IDs were never added once the table was non-empty.)
-        String hql = "from MarkerDBLink where referenceDatabase = :database and accessionNumber in (:list) ";
-        Query<MarkerDBLink> query = HibernateUtil.currentSession().createQuery(hql, MarkerDBLink.class);
-        query.setParameter("database", referenceDatabase);
-        query.setParameter("list", geneIdList);
-        Set<String> alreadyLinked = query.list().stream()
+        Set<String> alreadyLinked = getMarkerDBLinksInList(referenceDatabase, markerIds).stream()
                 .map(MarkerDBLink::getAccessionNumber)
                 .collect(Collectors.toSet());
 
-        List<String> idsToAdd = geneIdList.stream()
+        List<String> idsToAdd = markerIds.stream()
                 .distinct()
                 .filter(id -> !alreadyLinked.contains(id))
                 .collect(Collectors.toList());
@@ -2854,9 +2877,9 @@ public class HibernateMarkerRepository implements MarkerRepository {
         }
 
         // Only IDs that resolve to an existing marker get a link; unknown IDs are silently skipped.
-        Query<Marker> markerQuery = currentSession().createQuery("from Marker where zdbID in (:idList)", Marker.class);
-        markerQuery.setParameter("idList", idsToAdd);
-        List<Marker> markerList = markerQuery.list();
+        // Callers should pass IDs already resolved through zdb_replaced_data (see
+        // getMarkersByZdbIDsIncludingReplaced) so links land on the surviving marker after a merge.
+        List<Marker> markerList = getMarkersByZdbIDs(idsToAdd);
         markerList.forEach(gene -> {
             MarkerDBLink signafishLink = new MarkerDBLink();
             signafishLink.setMarker(gene);

--- a/source/org/zfin/marker/repository/HibernateMarkerRepository.java
+++ b/source/org/zfin/marker/repository/HibernateMarkerRepository.java
@@ -2830,31 +2830,48 @@ public class HibernateMarkerRepository implements MarkerRepository {
 
     @Override
     public int addMarkerDBLinks(final ReferenceDatabase referenceDatabase, List<String> geneIdList) {
+        if (CollectionUtils.isEmpty(geneIdList)) {
+            return 0;
+        }
+
+        // Find which of the incoming IDs already have a link, so we add only the missing ones.
+        // (Previously this short-circuited the entire batch if ANY link already existed, so new
+        // IDs were never added once the table was non-empty.)
         String hql = "from MarkerDBLink where referenceDatabase = :database and accessionNumber in (:list) ";
         Query<MarkerDBLink> query = HibernateUtil.currentSession().createQuery(hql, MarkerDBLink.class);
         query.setParameter("database", referenceDatabase);
         query.setParameter("list", geneIdList);
-        List<MarkerDBLink> dbLinks = query.list();
-        if (CollectionUtils.isEmpty(dbLinks)) {
-            Query<Marker> query1 = currentSession().createQuery("from Marker where zdbID in (:idList)", Marker.class);
-            query1.setParameter("idList", geneIdList);
-            List<Marker> markerList = query1.list();
-            markerList.forEach(gene -> {
-                MarkerDBLink signafishLink = new MarkerDBLink();
-                signafishLink.setMarker(gene);
-                signafishLink.setLinkInfo(String.format("Uncurated: signafish load for %tF", new Date()));
-                signafishLink.setAccessionNumber(gene.getZdbID());
-                signafishLink.setAccessionNumberDisplay(gene.getZdbID());
-                signafishLink.setReferenceDatabase(referenceDatabase);
-                HibernateUtil.currentSession().save(signafishLink);
-                RecordAttribution recAttr = new RecordAttribution();
-                recAttr.setDataZdbID(signafishLink.getZdbID());
-                recAttr.setSourceZdbID("ZDB-PUB-160316-7");
-                recAttr.setSourceType(RecordAttribution.SourceType.STANDARD);
-                HibernateUtil.currentSession().save(recAttr);
-            });
+        Set<String> alreadyLinked = query.list().stream()
+                .map(MarkerDBLink::getAccessionNumber)
+                .collect(Collectors.toSet());
+
+        List<String> idsToAdd = geneIdList.stream()
+                .distinct()
+                .filter(id -> !alreadyLinked.contains(id))
+                .collect(Collectors.toList());
+        if (idsToAdd.isEmpty()) {
+            return 0;
         }
-        return 0;
+
+        // Only IDs that resolve to an existing marker get a link; unknown IDs are silently skipped.
+        Query<Marker> markerQuery = currentSession().createQuery("from Marker where zdbID in (:idList)", Marker.class);
+        markerQuery.setParameter("idList", idsToAdd);
+        List<Marker> markerList = markerQuery.list();
+        markerList.forEach(gene -> {
+            MarkerDBLink signafishLink = new MarkerDBLink();
+            signafishLink.setMarker(gene);
+            signafishLink.setLinkInfo(String.format("Uncurated: signafish load for %tF", new Date()));
+            signafishLink.setAccessionNumber(gene.getZdbID());
+            signafishLink.setAccessionNumberDisplay(gene.getZdbID());
+            signafishLink.setReferenceDatabase(referenceDatabase);
+            HibernateUtil.currentSession().save(signafishLink);
+            RecordAttribution recAttr = new RecordAttribution();
+            recAttr.setDataZdbID(signafishLink.getZdbID());
+            recAttr.setSourceZdbID("ZDB-PUB-160316-7");
+            recAttr.setSourceType(RecordAttribution.SourceType.STANDARD);
+            HibernateUtil.currentSession().save(recAttr);
+        });
+        return markerList.size();
     }
 
     public Long getSignafishLinkCount(ReferenceDatabase referenceDatabase) {

--- a/source/org/zfin/marker/repository/MarkerRepository.java
+++ b/source/org/zfin/marker/repository/MarkerRepository.java
@@ -38,6 +38,15 @@ public interface MarkerRepository {
 
     List<Marker> getMarkersByZdbIDs(List<String> zdbIDs);
 
+    /**
+     * Resolve a list of marker ZDB IDs to their current markers, following the zdb_replaced_data
+     * merge table when an ID has been replaced. Several input IDs may collapse onto the same
+     * surviving marker after a merge, so the result is deduplicated by ZDB ID (input order
+     * preserved). IDs that match no marker even after resolution are dropped. Use this for external
+     * loads whose input may contain pre-merge IDs so links land on the surviving marker.
+     */
+    List<Marker> getMarkersByZdbIDsIncludingReplaced(List<String> zdbIDs);
+
     List<Marker> getMarkersByZdbIDsJoiningAliases(List<String> zdbIDs);
 
     SNP getSNPByID(String zdbID);
@@ -563,7 +572,9 @@ public interface MarkerRepository {
 
     List<FluorescentMarker> getAllFluorescentConstructs();
 
-    int addMarkerDBLinks(ReferenceDatabase referenceDatabase, List<String> geneIdList);
+    ReferenceDatabase getSignafishReferenceDatabase();
+
+    int addSignafishMarkerDBLinks(List<String> markerIds);
 
     Long getSignafishLinkCount(ReferenceDatabase referenceDatabase);
 


### PR DESCRIPTION
The Load-Signafish_w job wiped all 177 SignaFish db_links (build #516). Root cause: the source URL moved to https, but parseFile() fetched http://signalink.org/zfin_ids.lst. URL.openStream() does not follow cross-protocol (http->https) redirects, so it read the empty 302 body -> 0 IDs -> deleteMarkerDBLinksNotInList removed every existing link.

Changes:
- LoadSignafishJob.parseFile(): use https; trim/skip blank lines; log the URL and the line/ID counts read.
- LoadSignafishJob.load(): abort (rollback, fail the build) if the parsed list is empty rather than silently deleting every link; guard against a null reference-database lookup; log before/after counts to the console and report.
- HibernateMarkerRepository.addMarkerDBLinks(): add links per-ID instead of all-or-nothing. It previously skipped the entire batch if ANY link already existed, so newly added source IDs were never linked in steady state (e.g. gdf6a / ZDB-GENE-980526-373). Now only missing IDs are added, unknown markers are skipped, and the count added is returned.

Verified against a local DB: fetches 178 IDs over https, links the previously-orphaned gdf6a (177 -> 178), and a repeat run is a clean no-op with no duplicates.