### PR TITLE
Zfin-10350: phenotype mart lock fix

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+# Before merging this PR
+
+These are planning/scratch artifacts that should not land on `main`:
+
+- Delete `reference/phenotype-mart-refresh-options.md`
+- Delete this `TODO.md` file

--- a/reference/phenotype-mart-refresh-options.md
+++ b/reference/phenotype-mart-refresh-options.md
@@ -1,0 +1,172 @@
+# Phenotype mart refresh: incident, fix, and redesign options
+
+## Context
+
+The phenotype mart is three derived tables, fully recomputed nightly from the
+expression/phenotype source tables by
+`server_apps/DB_maintenance/warehouse/phenotypeMart/`:
+
+| table | PK | natural key | populated by |
+|---|---|---|---|
+| `phenotype_source_generated` (psg) | `pg_id` (serial) | `(pg_genox_zdb_id, pg_fig_zdb_id, pg_start_stg_zdb_id, pg_end_stg_zdb_id)` | `SELECT DISTINCT` |
+| `phenotype_observation_generated` (pog) | `psg_id` (serial) | `psg_pg_id` + identifying attribute tuple | `SELECT` (no DISTINCT) |
+| `phenotype_generated_curated_mapping` (pgcm) | — | `pgcm_pg_id` + source | `SELECT DISTINCT` |
+
+Pipeline: `regenPhenotypeMart.sh` → `runPhenotypeMart.sh` (builds `_temp`
+tables via `populateTables.sql`, then runs `refreshPhenotypeMart.sql` to swap
+`_temp` into the live tables) → `gradle runPhenotypeIndexer` (Solr).
+
+Consumers: Hibernate entities (`PhenotypeSourceGenerated`,
+`PhenotypeStatementWarehouse`, `PhenotypeWarehouse`), the Solr DIH
+(`server_apps/solr/site_index/conf/db-data-config.xml`, joining pog + psg +
+`mutant_fast_search` + `term`), and data downloads. The tables are **leaf**
+tables — nothing outside the mart references them except the internal
+`pog → psg` FK.
+
+## The incident (Index-Faceted-Search-Step-1, prod, 2026-06-11)
+
+`refreshPhenotypeMart.sql`'s table swap could not acquire the
+`AccessExclusiveLock` on `phenotype_observation_generated`: the `ALTER TABLE …
+RENAME` blocked ~7 min behind ~100 live web-app `AccessShareLock` readers and
+head-of-line-blocked ~99 more, then was cancelled, rolling the whole
+transaction back. `ON_ERROR_STOP=1` + the wrapper's `set -e` aborted before the
+diagnostic echo, so the Jenkins console only showed the generic
+`PROBLEM ENCOUNTERED` trap; the real Postgres error went to
+`regenPhenotypeMartReportPostgres.txt` (via the `&>` redirect).
+
+Root cause: the slow `CREATE new-live + INSERT … SELECT FROM _temp` ran *after*
+the rename had already taken the exclusive lock, so the lock was held across
+the whole rebuild+copy, and acquisition had no `lock_timeout`.
+
+## Phase 0 — shipped fix (branch `ZFIN-phenotype-mart-lock-fix`)
+
+Two commits, validated on PG 18 against `zfindb`:
+
+1. **Two-phase split.** Do all slow work (back up to `_bkup`, build
+   fully-populated/indexed/FK'd `*_new` tables the app never reads) *before*
+   any rename; the exclusive-lock window is reduced to the metadata-only
+   renames (`live → *_old_<ts>`, `*_new → live`) just before commit. `*_new`
+   child FKs reference the `*_new` parent so they point at the new live parent
+   after the swap (FKs track by OID).
+
+2. **`lock_timeout` + bounded retry.** Split into two transactions (generator
+   `runPhenotypeMart.sh` no longer wraps the file in begin/commit):
+   - TXN 1 (build) commits — releasing the `SHARE ROW EXCLUSIVE` locks the
+     FK-adds hold on the parent tables (fish_experiment, figure, stage, marker,
+     term), so they are not held across the retry back-off.
+   - TXN 2 (swap) does the renames under `SET LOCAL lock_timeout='10s'` in a
+     sub-transaction retry loop (5 attempts, 20s back-off). On
+     `lock_not_available`/`deadlock_detected` the sub-transaction rolls back
+     (releasing that attempt's locks) and sleeps, so back-off holds nothing on
+     the live or parent tables — readers run freely between attempts. After the
+     budget is exhausted it raises a clear error, leaving the live tables
+     unchanged and the `*_new` tables for a later/next-run swap.
+
+Validated: happy path reproduces the baseline structure exactly; a held
+`AccessShareLock` forces a timeout then the swap recovers on the next attempt;
+a lock held through the whole budget fails cleanly with live tables unchanged
+and `*_new` retained, and the next run cleans up (`DROP TABLE IF EXISTS`) and
+succeeds.
+
+Phase 0 fixes the prod failure but does **not** bound the lock *acquisition*
+contention away — it makes it safe (fail fast, retry, never starve), not
+absent. Removing the swap entirely is the goal of the later phases.
+
+## The keystone constraint: surrogate keys churn
+
+`pg_id`/`psg_id` are `nextval(...)` serials assigned fresh each rebuild, so the
+same logical row gets a **different id every run**. This is what blocks the two
+"nice" redesigns:
+
+- **Materialized view + `REFRESH … CONCURRENTLY`** would see every row as
+  changed (the unique-index diff is keyed on the churning id) → full rewrite,
+  slower than now. Also: matviews can't carry FKs, can't be a serial-PK target,
+  and the ~15 sequential enrichment `UPDATE`s would have to collapse into one
+  defining `SELECT`.
+- **Incremental `MERGE`** has no stable key to match "same logical row" across
+  runs.
+
+So **stable identity is the prerequisite** for both. A natural key exists for
+psg (the 4 fields). For pog it requires first resolving duplicates (below).
+
+### Options weighed
+
+- **A. Blue-green via a view** — *skip.* Repointing a view still needs
+  `AccessExclusiveLock` on the view, which waits behind the same readers — same
+  contention as the rename, so it still needs lock_timeout+retry. Only upside is
+  dropping the `_old`/`_new`/index-name juggling, at the cost of permanent view
+  indirection. Marginal.
+- **B. Materialized view + `REFRESH CONCURRENTLY`** — the "right" Postgres tool
+  for derived-data blue-green, but here a large/risky rewrite (see constraints
+  above). Viable only after identity is stabilized.
+- **C. Incremental `MERGE` by natural key** — best steady-state lock profile
+  (row locks only, no swap, no DDL, no `_old` cleanup), and naturally enables
+  incremental Solr indexing. Highest implementation/correctness risk; needs
+  stable identity and careful handling of denormalized name changes + deletes;
+  keep a periodic full reconcile against drift. **Recommended end state.**
+
+### Single-column hash key vs composite key
+
+A deterministic hash key (`pg_id = md5(concat_ws('|', natkey...))::uuid`) is a
+standard pattern (dbt/Data Vault) and here is *less* disruptive than a composite
+PK: it keeps the single-column join/FK shape (composite would widen `pog → psg`,
+`pgcm → psg`, and the Solr DIH joins to 4 columns). Trade-offs: an
+`integer → uuid`/`text` type change ripples to the Hibernate entities, Solr DIH,
+and downloads; hash inputs for pog must be the identifying `*_zdb_id`s +
+tag/relations only (NOT the denormalized name columns, so a term/marker rename
+is an in-place UPDATE, not a new identity); NULLs must be normalized in the hash
+input; don't truncate into bigint (collision risk) — use full md5 as uuid/text.
+
+Alternative that keeps `integer`: **preserve-by-lookup** (reuse the existing
+`pg_id` for a matched natural key, new serial only for new keys) — no type
+change, but an upsert/lookup against live during build. Both approaches hit the
+same pog-uniqueness wall.
+
+### pog duplicate finding (gates the identity work)
+
+`pog` has 659 rows that are **identical on every column** (642 groups, max
+multiplicity 4), concentrated in the expression path. Cause: the three pog
+inserts use plain `SELECT` (psg and pgcm use `SELECT DISTINCT`); the
+expression/labeling/part-of joins fan out and project identical tuples. The
+paths are mutually exclusive on `psg_mrkr_relation`, so a per-insert `DISTINCT`
+removes them with no information loss. These are a benign artifact + a latent
+~0.24% over-count, not meaningful data.
+
+## Plan
+
+Dependencies: `0 → (1 → 2 → 3) → 4`. Phases 0 and 1 are independently
+shippable; 2 gates 3; 3 supersedes the Phase-0 swap machinery (which stays
+correct in the meantime).
+
+- **Phase 0 — ship the prod fix.** Branch `ZFIN-phenotype-mart-lock-fix` (PR
+  open). Deploy `refreshPhenotypeMart.sql` + `runPhenotypeMart.sh` to
+  `TARGETROOT`. Resolves the incident.
+- **Phase 1 — dedup pog.** Add `DISTINCT` to the three pog inserts in
+  `populateTables.sql`. Verify the row count drops by exactly the known dups and
+  that Solr facet counts / downloads are unaffected. Independent; also fixes the
+  over-count. Makes pog's natural key unique.
+- **Phase 2 — stable identity (keystone).** Make `pg_id`/`psg_id` deterministic.
+  Decision: hash (`uuid`, accepts type-change ripple) vs preserve-by-lookup
+  (keeps `integer`). Prereq: Phase 1.
+- **Phase 3 — remove the swap.** Replace rebuild+rename with incremental `MERGE`
+  (recompute to `_temp`, `MERGE … ON id` into live): row locks only, no
+  `AccessExclusiveLock`, no swap, no `_old` cleanup. Keep a periodic full
+  reconcile. (Materialized view + `REFRESH CONCURRENTLY` is the fallback.)
+- **Phase 4 — optional.** Drive incremental Solr phenotype indexing from the
+  same delta instead of the full reindex that runs after.
+
+### Open decisions
+
+- (a) OK to dedup pog in Phase 1 (≈0.24% fewer rows)?
+- (b) Phase 2 identity: accept the `uuid`/`text` type change, or keep `integer`
+  via preserve-by-lookup?
+- (c) Phase 3: incremental `MERGE` (recommended) vs materialized view?
+
+## Testing notes
+
+All phases verified on the local PG 18.4 `zfindb` via `zrun` (compile container
+login shell → `psql` to the `db` container): capture a baseline of counts /
+indexes / FK constraints, run the change, diff against baseline, and run twice
+to confirm cross-run idempotency. Concurrency/lock behavior tested by holding an
+`AccessShareLock` from a second session (`docker compose exec db psql … BEGIN;
+SELECT …; pg_sleep(N); COMMIT;`) while running the swap.

--- a/server_apps/DB_maintenance/warehouse/phenotypeMart/refreshPhenotypeMart.sql
+++ b/server_apps/DB_maintenance/warehouse/phenotypeMart/refreshPhenotypeMart.sql
@@ -1,34 +1,44 @@
 -- Refresh phenotype mart tables by swapping in data from *_temp tables.
 --
--- Two-phase design to minimise the AccessExclusiveLock window on the live
--- tables. ALL the slow work — backing up current data and building the
--- fully-populated / indexed / FK'd replacement tables — happens first under
--- *_new staging names that the application never reads, so production queries
--- against the live phenotype_* tables are NOT blocked while it runs. Only the
--- final metadata-only renames (live -> *_old_<ts>, *_new -> live) need the
--- exclusive lock, so that window is just the renames + commit instead of the
--- whole rebuild-and-copy (which previously held the lock for minutes and was
--- starved out by concurrent readers).
+-- Run as TWO separate transactions to keep the AccessExclusiveLock window on
+-- the live tables tiny AND bounded. runPhenotypeMart.sh deliberately does NOT
+-- wrap this file in begin/commit -- the transaction boundaries below are load
+-- bearing.
 --
--- Old tables are renamed with a timestamp suffix and left for later cleanup
--- by regen_cleanup_renamed_tables().
+--   TRANSACTION 1 (build) -- no conflicting lock on the live tables.
+--     Back up current data to *_bkup (AccessShare only) and build the
+--     fully-populated / indexed / FK'd *_new replacement tables that the
+--     application never reads. Committing here releases the SHARE ROW
+--     EXCLUSIVE locks the FK-adds hold on the referenced parent tables
+--     (fish_experiment, figure, stage, marker, term) and makes *_new durable.
+--
+--   TRANSACTION 2 (swap) -- the only AccessExclusiveLock window on the live
+--     tables. Metadata-only renames (live -> *_old_<ts>, *_new -> live),
+--     guarded by a short lock_timeout and a bounded retry loop. Because this
+--     transaction touches ONLY the live phenotype_* tables (no *_bkup copy, no
+--     FK-adds), it holds nothing during the back-off sleeps -- production reads
+--     are fully unblocked between attempts, so the swap lands in the next gap
+--     between long-running readers instead of starving (which is what made the
+--     old single-transaction rebuild-under-lock hang ~7 min and roll back).
+--
+-- Old tables are renamed with a timestamp suffix and left for later cleanup by
+-- regen_cleanup_renamed_tables().
+
+-- =========================================================================
+-- TRANSACTION 1 -- build the replacement tables (slow; no lock on live).
+-- =========================================================================
+BEGIN;
 
 DO $$
-DECLARE
-    psg_old_name text;
-    pog_old_name text;
-    pgcm_old_name text;
-    ts text := to_char(now(), 'YYMMDDHH24MI') || '_' || substring(md5(random()::text), 1, 4);
 BEGIN
 
--- =========================================================================
--- PHASE A -- slow work, NO conflicting lock on the live tables.
--- Production reads of the live phenotype_* tables continue uninterrupted:
--- the *_bkup copy only takes AccessShareLock on the live tables, and the
--- *_new tables built below are invisible to the application.
--- =========================================================================
+-- Flag the (slow) rebuild as in progress; cleared once the *_new tables are
+-- built, just before the swap.
+update zdb_flag
+  set (zflag_is_on,zflag_last_modified) = ('t',now())
+ where zflag_name = 'regen_phenotypemart';
 
--- Back up current data into *_bkup tables.
+-- Back up current data into *_bkup tables (reads live = AccessShareLock only).
 truncate phenotype_generated_curated_mapping_bkup;
 truncate phenotype_source_generated_bkup;
 truncate phenotype_observation_generated_bkup;
@@ -70,13 +80,7 @@ select psg_id, psg_pg_id,psg_mrkr_zdb_id, psg_mrkr_abbrev,psg_mrkr_relation,psg_
 insert into phenotype_generated_curated_mapping_bkup (pgcm_pg_id, pgcm_source_id, pgcm_id_type)
  select pgcm_pg_id, pgcm_source_id, pgcm_id_type from phenotype_generated_curated_mapping;
 
-
-update zdb_flag
-  set (zflag_is_on,zflag_last_modified) = ('t',now())
- where zflag_name = 'regen_phenotypemart';
-
--- Drop any *_new tables left behind by a previously failed run (a failed run
--- rolls back atomically, so these only appear if someone left them manually).
+-- Drop any *_new tables left behind by a previously failed/interrupted run.
 -- Drop the child (FK) table before its parent.
 DROP TABLE IF EXISTS phenotype_observation_generated_new;
 DROP TABLE IF EXISTS phenotype_source_generated_new;
@@ -165,92 +169,134 @@ CREATE TABLE phenotype_generated_curated_mapping_new (LIKE phenotype_generated_c
 insert into phenotype_generated_curated_mapping_new (pgcm_pg_id, pgcm_source_id, pgcm_id_type)
  select pgcm_pg_id, pgcm_source_id, pgcm_id_type from phenotype_generated_curated_mapping_temp;
 
--- =========================================================================
--- PHASE B -- fast metadata swap. This is the ONLY part that takes an
--- AccessExclusiveLock on the live tables; every statement below is a
--- metadata-only rename, so the lock is held just until the commit that
--- immediately follows.
--- =========================================================================
-
--- 1. Rename the current live tables OUT to *_old_<ts>, freeing the canonical
---    table / index / constraint names. Left for regen_cleanup_renamed_tables().
-
--- phenotype_generated_curated_mapping (no FKs pointing to it, simplest)
-IF EXISTS (SELECT 1 FROM information_schema.tables
-           WHERE table_name = 'phenotype_generated_curated_mapping' AND table_schema = 'public') THEN
-    pgcm_old_name := 'phenotype_generated_curated_mapping_old_' || ts;
-    RAISE NOTICE 'Renaming phenotype_generated_curated_mapping to %', pgcm_old_name;
-    EXECUTE 'ALTER TABLE phenotype_generated_curated_mapping RENAME TO ' || pgcm_old_name;
-END IF;
-
--- phenotype_observation_generated (child of phenotype_source_generated)
-IF EXISTS (SELECT 1 FROM information_schema.tables
-           WHERE table_name = 'phenotype_observation_generated' AND table_schema = 'public') THEN
-    pog_old_name := 'phenotype_observation_generated_old_' || ts;
-    RAISE NOTICE 'Renaming phenotype_observation_generated to %', pog_old_name;
-    EXECUTE 'ALTER TABLE phenotype_observation_generated RENAME TO ' || pog_old_name;
-
-    -- Free the canonical index/constraint names for the incoming table.
-    EXECUTE 'ALTER INDEX IF EXISTS phenotype_observation_generated_pkey RENAME TO ' || pog_old_name || '_pkey';
-    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT phenotype_warehouse_foreign_key TO ' || pog_old_name || '_wh_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT marker_foreign_key TO ' || pog_old_name || '_mrkr_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e1a_foreign_key TO ' || pog_old_name || '_e1a_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e1b_foreign_key TO ' || pog_old_name || '_e1b_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e2a_foreign_key TO ' || pog_old_name || '_e2a_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e2b_foreign_key TO ' || pog_old_name || '_e2b_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT quality_foreign_key TO ' || pog_old_name || '_q_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
-END IF;
-
--- phenotype_source_generated (parent)
-IF EXISTS (SELECT 1 FROM information_schema.tables
-           WHERE table_name = 'phenotype_source_generated' AND table_schema = 'public') THEN
-    psg_old_name := 'phenotype_source_generated_old_' || ts;
-    RAISE NOTICE 'Renaming phenotype_source_generated to %', psg_old_name;
-    EXECUTE 'ALTER TABLE phenotype_source_generated RENAME TO ' || psg_old_name;
-
-    EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_pkey RENAME TO ' || psg_old_name || '_pkey';
-    EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_genox RENAME TO ' || psg_old_name || '_genox';
-    EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_fig RENAME TO ' || psg_old_name || '_fig';
-    EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_start RENAME TO ' || psg_old_name || '_start';
-    EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_end RENAME TO ' || psg_old_name || '_end';
-    BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk1 TO ' || psg_old_name || '_fk1'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk2 TO ' || psg_old_name || '_fk2'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk3 TO ' || psg_old_name || '_fk3'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk4 TO ' || psg_old_name || '_fk4'; EXCEPTION WHEN undefined_object THEN NULL; END;
-END IF;
-
--- 2. Rename the *_new tables IN to the canonical live names, restoring the
---    canonical index/constraint names so the next run's rename-out matches.
-
-ALTER TABLE phenotype_source_generated_new RENAME TO phenotype_source_generated;
-ALTER INDEX phenotype_source_generated_new_pkey RENAME TO phenotype_source_generated_pkey;
-ALTER INDEX phenotype_source_generated_new_genox RENAME TO phenotype_source_generated_genox;
-ALTER INDEX phenotype_source_generated_new_fig RENAME TO phenotype_source_generated_fig;
-ALTER INDEX phenotype_source_generated_new_start RENAME TO phenotype_source_generated_start;
-ALTER INDEX phenotype_source_generated_new_end RENAME TO phenotype_source_generated_end;
-ALTER TABLE phenotype_source_generated RENAME CONSTRAINT phenotype_source_generated_new_fk1 TO constraint_fk1;
-ALTER TABLE phenotype_source_generated RENAME CONSTRAINT phenotype_source_generated_new_fk2 TO constraint_fk2;
-ALTER TABLE phenotype_source_generated RENAME CONSTRAINT phenotype_source_generated_new_fk3 TO constraint_fk3;
-ALTER TABLE phenotype_source_generated RENAME CONSTRAINT phenotype_source_generated_new_fk4 TO constraint_fk4;
-
-ALTER TABLE phenotype_observation_generated_new RENAME TO phenotype_observation_generated;
-ALTER INDEX phenotype_observation_generated_new_pkey RENAME TO phenotype_observation_generated_pkey;
-ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_wh_fk TO phenotype_warehouse_foreign_key;
-ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_mrkr_fk TO marker_foreign_key;
-ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_e1a_fk TO e1a_foreign_key;
-ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_e1b_fk TO e1b_foreign_key;
-ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_e2a_fk TO e2a_foreign_key;
-ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_e2b_fk TO e2b_foreign_key;
-ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_q_fk TO quality_foreign_key;
-
-ALTER TABLE phenotype_generated_curated_mapping_new RENAME TO phenotype_generated_curated_mapping;
-
+-- *_new tables are built and durable; clear the rebuild-in-progress flag.
 update zdb_flag
   set (zflag_is_on,zflag_last_modified) = ('f',now())
- where zflag_name = 'regen_phenotypemart' ;
-
-update warehouse_run_tracking
- set wrt_last_loaded_date = now()
- where wrt_mart_name = 'phenotype mart';
+ where zflag_name = 'regen_phenotypemart';
 
 END $$;
+
+COMMIT;
+
+-- =========================================================================
+-- TRANSACTION 2 -- fast metadata swap, lock_timeout + bounded retry.
+-- The ONLY AccessExclusiveLock window on the live tables. Holds nothing on
+-- the live or parent tables during back-off sleeps.
+-- =========================================================================
+BEGIN;
+
+DO $$
+DECLARE
+    psg_old_name text;
+    pog_old_name text;
+    pgcm_old_name text;
+    ts text := to_char(now(), 'YYMMDDHH24MI') || '_' || substring(md5(random()::text), 1, 4);
+    swap_attempts constant int := 5;   -- max tries before giving up
+    swap_wait     constant text := '10s';   -- per-attempt lock_timeout
+    swap_backoff  constant int  := 20;   -- seconds to wait between attempts
+    swap_attempt int := 0;
+BEGIN
+    LOOP
+        swap_attempt := swap_attempt + 1;
+        BEGIN
+            -- Bound how long any single rename will wait for the exclusive
+            -- lock; if a live reader is mid-query we fail fast rather than
+            -- block (and head-of-line-block) the whole site. Transaction-local,
+            -- re-applied each attempt (a sub-transaction rollback reverts it).
+            PERFORM set_config('lock_timeout', swap_wait, true);
+
+            -- 1. Rename the current live tables OUT to *_old_<ts>, freeing the
+            --    canonical table / index / constraint names. Left for
+            --    regen_cleanup_renamed_tables().
+
+            -- phenotype_generated_curated_mapping (no FKs pointing to it)
+            IF EXISTS (SELECT 1 FROM information_schema.tables
+                       WHERE table_name = 'phenotype_generated_curated_mapping' AND table_schema = 'public') THEN
+                pgcm_old_name := 'phenotype_generated_curated_mapping_old_' || ts;
+                RAISE NOTICE 'Renaming phenotype_generated_curated_mapping to %', pgcm_old_name;
+                EXECUTE 'ALTER TABLE phenotype_generated_curated_mapping RENAME TO ' || pgcm_old_name;
+            END IF;
+
+            -- phenotype_observation_generated (child of phenotype_source_generated)
+            IF EXISTS (SELECT 1 FROM information_schema.tables
+                       WHERE table_name = 'phenotype_observation_generated' AND table_schema = 'public') THEN
+                pog_old_name := 'phenotype_observation_generated_old_' || ts;
+                RAISE NOTICE 'Renaming phenotype_observation_generated to %', pog_old_name;
+                EXECUTE 'ALTER TABLE phenotype_observation_generated RENAME TO ' || pog_old_name;
+
+                EXECUTE 'ALTER INDEX IF EXISTS phenotype_observation_generated_pkey RENAME TO ' || pog_old_name || '_pkey';
+                BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT phenotype_warehouse_foreign_key TO ' || pog_old_name || '_wh_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
+                BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT marker_foreign_key TO ' || pog_old_name || '_mrkr_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
+                BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e1a_foreign_key TO ' || pog_old_name || '_e1a_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
+                BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e1b_foreign_key TO ' || pog_old_name || '_e1b_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
+                BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e2a_foreign_key TO ' || pog_old_name || '_e2a_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
+                BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e2b_foreign_key TO ' || pog_old_name || '_e2b_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
+                BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT quality_foreign_key TO ' || pog_old_name || '_q_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
+            END IF;
+
+            -- phenotype_source_generated (parent)
+            IF EXISTS (SELECT 1 FROM information_schema.tables
+                       WHERE table_name = 'phenotype_source_generated' AND table_schema = 'public') THEN
+                psg_old_name := 'phenotype_source_generated_old_' || ts;
+                RAISE NOTICE 'Renaming phenotype_source_generated to %', psg_old_name;
+                EXECUTE 'ALTER TABLE phenotype_source_generated RENAME TO ' || psg_old_name;
+
+                EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_pkey RENAME TO ' || psg_old_name || '_pkey';
+                EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_genox RENAME TO ' || psg_old_name || '_genox';
+                EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_fig RENAME TO ' || psg_old_name || '_fig';
+                EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_start RENAME TO ' || psg_old_name || '_start';
+                EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_end RENAME TO ' || psg_old_name || '_end';
+                BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk1 TO ' || psg_old_name || '_fk1'; EXCEPTION WHEN undefined_object THEN NULL; END;
+                BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk2 TO ' || psg_old_name || '_fk2'; EXCEPTION WHEN undefined_object THEN NULL; END;
+                BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk3 TO ' || psg_old_name || '_fk3'; EXCEPTION WHEN undefined_object THEN NULL; END;
+                BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk4 TO ' || psg_old_name || '_fk4'; EXCEPTION WHEN undefined_object THEN NULL; END;
+            END IF;
+
+            -- 2. Rename the *_new tables IN to the canonical live names,
+            --    restoring the canonical index/constraint names so the next
+            --    run's rename-out matches.
+            ALTER TABLE phenotype_source_generated_new RENAME TO phenotype_source_generated;
+            ALTER INDEX phenotype_source_generated_new_pkey RENAME TO phenotype_source_generated_pkey;
+            ALTER INDEX phenotype_source_generated_new_genox RENAME TO phenotype_source_generated_genox;
+            ALTER INDEX phenotype_source_generated_new_fig RENAME TO phenotype_source_generated_fig;
+            ALTER INDEX phenotype_source_generated_new_start RENAME TO phenotype_source_generated_start;
+            ALTER INDEX phenotype_source_generated_new_end RENAME TO phenotype_source_generated_end;
+            ALTER TABLE phenotype_source_generated RENAME CONSTRAINT phenotype_source_generated_new_fk1 TO constraint_fk1;
+            ALTER TABLE phenotype_source_generated RENAME CONSTRAINT phenotype_source_generated_new_fk2 TO constraint_fk2;
+            ALTER TABLE phenotype_source_generated RENAME CONSTRAINT phenotype_source_generated_new_fk3 TO constraint_fk3;
+            ALTER TABLE phenotype_source_generated RENAME CONSTRAINT phenotype_source_generated_new_fk4 TO constraint_fk4;
+
+            ALTER TABLE phenotype_observation_generated_new RENAME TO phenotype_observation_generated;
+            ALTER INDEX phenotype_observation_generated_new_pkey RENAME TO phenotype_observation_generated_pkey;
+            ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_wh_fk TO phenotype_warehouse_foreign_key;
+            ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_mrkr_fk TO marker_foreign_key;
+            ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_e1a_fk TO e1a_foreign_key;
+            ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_e1b_fk TO e1b_foreign_key;
+            ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_e2a_fk TO e2a_foreign_key;
+            ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_e2b_fk TO e2b_foreign_key;
+            ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_q_fk TO quality_foreign_key;
+
+            ALTER TABLE phenotype_generated_curated_mapping_new RENAME TO phenotype_generated_curated_mapping;
+
+            EXIT;  -- swap succeeded
+
+        EXCEPTION
+            WHEN lock_not_available OR deadlock_detected THEN
+                -- The sub-transaction rolled back: every rename in this attempt
+                -- is undone and the exclusive locks released, so the back-off
+                -- sleep below holds nothing on the live tables.
+                IF swap_attempt >= swap_attempts THEN
+                    RAISE EXCEPTION 'phenotype mart swap could not acquire the AccessExclusiveLock on the live tables after % attempts (lock_timeout %); aborting. The live tables are unchanged; the *_new tables remain for a manual swap or the next run.', swap_attempts, swap_wait;
+                END IF;
+                RAISE NOTICE 'phenotype mart swap: attempt %/% timed out waiting for the exclusive lock; backing off %s before retry', swap_attempt, swap_attempts, swap_backoff;
+                PERFORM pg_sleep(swap_backoff);
+        END;
+    END LOOP;
+
+    update warehouse_run_tracking
+     set wrt_last_loaded_date = now()
+     where wrt_mart_name = 'phenotype mart';
+
+END $$;
+
+COMMIT;

--- a/server_apps/DB_maintenance/warehouse/phenotypeMart/refreshPhenotypeMart.sql
+++ b/server_apps/DB_maintenance/warehouse/phenotypeMart/refreshPhenotypeMart.sql
@@ -1,6 +1,17 @@
 -- Refresh phenotype mart tables by swapping in data from *_temp tables.
--- Uses rename-instead-of-truncate to avoid deadlocks with the indexer.
--- Old tables are renamed with a timestamp suffix for later cleanup.
+--
+-- Two-phase design to minimise the AccessExclusiveLock window on the live
+-- tables. ALL the slow work — backing up current data and building the
+-- fully-populated / indexed / FK'd replacement tables — happens first under
+-- *_new staging names that the application never reads, so production queries
+-- against the live phenotype_* tables are NOT blocked while it runs. Only the
+-- final metadata-only renames (live -> *_old_<ts>, *_new -> live) need the
+-- exclusive lock, so that window is just the renames + commit instead of the
+-- whole rebuild-and-copy (which previously held the lock for minutes and was
+-- starved out by concurrent readers).
+--
+-- Old tables are renamed with a timestamp suffix and left for later cleanup
+-- by regen_cleanup_renamed_tables().
 
 DO $$
 DECLARE
@@ -10,8 +21,14 @@ DECLARE
     ts text := to_char(now(), 'YYMMDDHH24MI') || '_' || substring(md5(random()::text), 1, 4);
 BEGIN
 
--- Back up current data into *_bkup tables
+-- =========================================================================
+-- PHASE A -- slow work, NO conflicting lock on the live tables.
+-- Production reads of the live phenotype_* tables continue uninterrupted:
+-- the *_bkup copy only takes AccessShareLock on the live tables, and the
+-- *_new tables built below are invisible to the application.
+-- =========================================================================
 
+-- Back up current data into *_bkup tables.
 truncate phenotype_generated_curated_mapping_bkup;
 truncate phenotype_source_generated_bkup;
 truncate phenotype_observation_generated_bkup;
@@ -26,16 +43,16 @@ select pg_id, pg_genox_zdb_id, pg_fig_zdb_id, pg_start_stg_zdb_id, pg_end_stg_zd
 
 insert into phenotype_observation_generated_bkup (psg_id,
        	     				   psg_pg_id,
-       	     				   psg_mrkr_zdb_id,	
+       	     				   psg_mrkr_zdb_id,
 					   psg_mrkr_abbrev,
 					   psg_mrkr_relation,
 					   psg_e1a_zdb_id,
 					   psg_e1a_name,
-					   psg_e1_relation_name,	
+					   psg_e1_relation_name,
 					   psg_e1b_zdb_id,
 					   psg_e1b_name,
 					   psg_e2a_zdb_id,
-					   psg_e2a_name,	
+					   psg_e2a_name,
 					   psg_e2_relation_name,
 					   psg_e2b_zdb_id,
 					   psg_e2b_name,
@@ -58,14 +75,17 @@ update zdb_flag
   set (zflag_is_on,zflag_last_modified) = ('t',now())
  where zflag_name = 'regen_phenotypemart';
 
--- -------------------------------------------------------------------------
--- Swap: rename old tables out with timestamp suffix to avoid deadlocks.
--- The exclusive lock window is just these fast DDL renames, not a full
--- truncate cascade which would block on FK checks.
--- Old tables are left for later cleanup by regen_cleanup_renamed_tables().
--- -------------------------------------------------------------------------
+-- =========================================================================
+-- PHASE B -- fast metadata swap. This is the ONLY part that takes an
+-- AccessExclusiveLock on the live tables; every statement below is a
+-- metadata-only rename, so the lock is held just until the commit that
+-- immediately follows.
+-- =========================================================================
 
--- 1. phenotype_generated_curated_mapping (no FKs pointing to it, simplest)
+-- 1. Rename the current live tables OUT to *_old_<ts>, freeing the canonical
+--    table / index / constraint names. Left for regen_cleanup_renamed_tables().
+
+-- phenotype_generated_curated_mapping (no FKs pointing to it, simplest)
 IF EXISTS (SELECT 1 FROM information_schema.tables
            WHERE table_name = 'phenotype_generated_curated_mapping' AND table_schema = 'public') THEN
     pgcm_old_name := 'phenotype_generated_curated_mapping_old_' || ts;
@@ -73,16 +93,15 @@ IF EXISTS (SELECT 1 FROM information_schema.tables
     EXECUTE 'ALTER TABLE phenotype_generated_curated_mapping RENAME TO ' || pgcm_old_name;
 END IF;
 
--- 2. phenotype_observation_generated (has FK to phenotype_source_generated, rename first)
+-- phenotype_observation_generated (child of phenotype_source_generated)
 IF EXISTS (SELECT 1 FROM information_schema.tables
            WHERE table_name = 'phenotype_observation_generated' AND table_schema = 'public') THEN
     pog_old_name := 'phenotype_observation_generated_old_' || ts;
     RAISE NOTICE 'Renaming phenotype_observation_generated to %', pog_old_name;
     EXECUTE 'ALTER TABLE phenotype_observation_generated RENAME TO ' || pog_old_name;
 
-    -- Rename indexes to avoid collisions
+    -- Free the canonical index/constraint names for the incoming table.
     EXECUTE 'ALTER INDEX IF EXISTS phenotype_observation_generated_pkey RENAME TO ' || pog_old_name || '_pkey';
-    -- Rename constraints
     BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT phenotype_warehouse_foreign_key TO ' || pog_old_name || '_wh_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
     BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT marker_foreign_key TO ' || pog_old_name || '_mrkr_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
     BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e1a_foreign_key TO ' || pog_old_name || '_e1a_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
@@ -92,50 +111,53 @@ IF EXISTS (SELECT 1 FROM information_schema.tables
     BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT quality_foreign_key TO ' || pog_old_name || '_q_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
 END IF;
 
--- 3. phenotype_source_generated (parent table, rename after child is gone)
+-- phenotype_source_generated (parent)
 IF EXISTS (SELECT 1 FROM information_schema.tables
            WHERE table_name = 'phenotype_source_generated' AND table_schema = 'public') THEN
     psg_old_name := 'phenotype_source_generated_old_' || ts;
     RAISE NOTICE 'Renaming phenotype_source_generated to %', psg_old_name;
     EXECUTE 'ALTER TABLE phenotype_source_generated RENAME TO ' || psg_old_name;
 
-    -- Rename indexes
     EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_pkey RENAME TO ' || psg_old_name || '_pkey';
     EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_genox RENAME TO ' || psg_old_name || '_genox';
     EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_fig RENAME TO ' || psg_old_name || '_fig';
     EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_start RENAME TO ' || psg_old_name || '_start';
     EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_end RENAME TO ' || psg_old_name || '_end';
-    -- Rename constraints
     BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk1 TO ' || psg_old_name || '_fk1'; EXCEPTION WHEN undefined_object THEN NULL; END;
     BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk2 TO ' || psg_old_name || '_fk2'; EXCEPTION WHEN undefined_object THEN NULL; END;
     BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk3 TO ' || psg_old_name || '_fk3'; EXCEPTION WHEN undefined_object THEN NULL; END;
     BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk4 TO ' || psg_old_name || '_fk4'; EXCEPTION WHEN undefined_object THEN NULL; END;
 END IF;
 
--- -------------------------------------------------------------------------
--- Recreate empty live tables (with correct structure) and populate from temp
--- -------------------------------------------------------------------------
+-- Drop any *_new tables left behind by a previously failed run (a failed run
+-- rolls back atomically, so these only appear if someone left them manually).
+-- Drop the child (FK) table before its parent.
+DROP TABLE IF EXISTS phenotype_observation_generated_new;
+DROP TABLE IF EXISTS phenotype_source_generated_new;
+DROP TABLE IF EXISTS phenotype_generated_curated_mapping_new;
 
--- Recreate phenotype_source_generated
-CREATE TABLE phenotype_source_generated (LIKE phenotype_source_generated_temp INCLUDING ALL);
-ALTER TABLE phenotype_source_generated ADD PRIMARY KEY (pg_id);
+-- -------------------------------------------------------------------------
+-- Build phenotype_source_generated_new (parent table)
+-- -------------------------------------------------------------------------
+CREATE TABLE phenotype_source_generated_new (LIKE phenotype_source_generated_temp INCLUDING ALL);
+ALTER TABLE phenotype_source_generated_new ADD CONSTRAINT phenotype_source_generated_new_pkey PRIMARY KEY (pg_id);
 -- Detach the sequence so cleanup's DROP of the renamed _old_ table can't
 -- cascade-drop it. OWNED BY NONE avoids PG's role-ownership-must-match
 -- check that re-linking OWNED BY <col> would impose.
-IF pg_get_serial_sequence('phenotype_source_generated', 'pg_id') IS NOT NULL THEN
-    EXECUTE 'ALTER SEQUENCE ' || pg_get_serial_sequence('phenotype_source_generated', 'pg_id')
+IF pg_get_serial_sequence('phenotype_source_generated_new', 'pg_id') IS NOT NULL THEN
+    EXECUTE 'ALTER SEQUENCE ' || pg_get_serial_sequence('phenotype_source_generated_new', 'pg_id')
         || ' OWNED BY NONE';
 END IF;
-CREATE INDEX phenotype_source_generated_genox ON phenotype_source_generated (pg_genox_zdb_id);
-CREATE INDEX phenotype_source_generated_fig ON phenotype_source_generated (pg_fig_zdb_id);
-CREATE INDEX phenotype_source_generated_start ON phenotype_source_generated (pg_start_stg_zdb_id);
-CREATE INDEX phenotype_source_generated_end ON phenotype_source_generated (pg_end_stg_zdb_id);
-ALTER TABLE phenotype_source_generated ADD CONSTRAINT constraint_fk1 FOREIGN KEY (pg_genox_zdb_id) REFERENCES fish_experiment (genox_zdb_id);
-ALTER TABLE phenotype_source_generated ADD CONSTRAINT constraint_fk2 FOREIGN KEY (pg_fig_zdb_id) REFERENCES figure (fig_zdb_id);
-ALTER TABLE phenotype_source_generated ADD CONSTRAINT constraint_fk3 FOREIGN KEY (pg_start_stg_zdb_id) REFERENCES stage (stg_zdb_id);
-ALTER TABLE phenotype_source_generated ADD CONSTRAINT constraint_fk4 FOREIGN KEY (pg_end_stg_zdb_id) REFERENCES stage (stg_zdb_id);
+CREATE INDEX phenotype_source_generated_new_genox ON phenotype_source_generated_new (pg_genox_zdb_id);
+CREATE INDEX phenotype_source_generated_new_fig ON phenotype_source_generated_new (pg_fig_zdb_id);
+CREATE INDEX phenotype_source_generated_new_start ON phenotype_source_generated_new (pg_start_stg_zdb_id);
+CREATE INDEX phenotype_source_generated_new_end ON phenotype_source_generated_new (pg_end_stg_zdb_id);
+ALTER TABLE phenotype_source_generated_new ADD CONSTRAINT phenotype_source_generated_new_fk1 FOREIGN KEY (pg_genox_zdb_id) REFERENCES fish_experiment (genox_zdb_id);
+ALTER TABLE phenotype_source_generated_new ADD CONSTRAINT phenotype_source_generated_new_fk2 FOREIGN KEY (pg_fig_zdb_id) REFERENCES figure (fig_zdb_id);
+ALTER TABLE phenotype_source_generated_new ADD CONSTRAINT phenotype_source_generated_new_fk3 FOREIGN KEY (pg_start_stg_zdb_id) REFERENCES stage (stg_zdb_id);
+ALTER TABLE phenotype_source_generated_new ADD CONSTRAINT phenotype_source_generated_new_fk4 FOREIGN KEY (pg_end_stg_zdb_id) REFERENCES stage (stg_zdb_id);
 
-insert into phenotype_source_generated (pg_id,
+insert into phenotype_source_generated_new (pg_id,
        	     			 pg_genox_zdb_id,
 				 pg_fig_zdb_id,
 				 pg_start_stg_zdb_id,
@@ -143,34 +165,38 @@ insert into phenotype_source_generated (pg_id,
 select pg_id, pg_genox_zdb_id, pg_fig_zdb_id, pg_start_stg_zdb_id, pg_end_stg_zdb_id
   from phenotype_source_generated_temp;
 
--- Recreate phenotype_observation_generated
-CREATE TABLE phenotype_observation_generated (LIKE phenotype_observation_generated_temp INCLUDING ALL);
-ALTER TABLE phenotype_observation_generated ADD PRIMARY KEY (psg_id);
+-- -------------------------------------------------------------------------
+-- Build phenotype_observation_generated_new (child table). Its FK points at
+-- phenotype_source_generated_new so that, after the swap, it references the
+-- new live parent table (FKs track by OID, surviving the rename).
+-- -------------------------------------------------------------------------
+CREATE TABLE phenotype_observation_generated_new (LIKE phenotype_observation_generated_temp INCLUDING ALL);
+ALTER TABLE phenotype_observation_generated_new ADD CONSTRAINT phenotype_observation_generated_new_pkey PRIMARY KEY (psg_id);
 -- Detach the sequence (see note above).
-IF pg_get_serial_sequence('phenotype_observation_generated', 'psg_id') IS NOT NULL THEN
-    EXECUTE 'ALTER SEQUENCE ' || pg_get_serial_sequence('phenotype_observation_generated', 'psg_id')
+IF pg_get_serial_sequence('phenotype_observation_generated_new', 'psg_id') IS NOT NULL THEN
+    EXECUTE 'ALTER SEQUENCE ' || pg_get_serial_sequence('phenotype_observation_generated_new', 'psg_id')
         || ' OWNED BY NONE';
 END IF;
-ALTER TABLE phenotype_observation_generated ADD CONSTRAINT phenotype_warehouse_foreign_key FOREIGN KEY (psg_pg_id) REFERENCES phenotype_source_generated (pg_id);
-ALTER TABLE phenotype_observation_generated ADD CONSTRAINT marker_foreign_key FOREIGN KEY (psg_mrkr_zdb_id) REFERENCES marker (mrkr_zdb_id);
-ALTER TABLE phenotype_observation_generated ADD CONSTRAINT e1a_foreign_key FOREIGN KEY (psg_e1a_zdb_id) REFERENCES term (term_zdb_id);
-ALTER TABLE phenotype_observation_generated ADD CONSTRAINT e1b_foreign_key FOREIGN KEY (psg_e1b_zdb_id) REFERENCES term (term_zdb_id);
-ALTER TABLE phenotype_observation_generated ADD CONSTRAINT e2a_foreign_key FOREIGN KEY (psg_e2a_zdb_id) REFERENCES term (term_zdb_id);
-ALTER TABLE phenotype_observation_generated ADD CONSTRAINT e2b_foreign_key FOREIGN KEY (psg_e2b_zdb_id) REFERENCES term (term_zdb_id);
-ALTER TABLE phenotype_observation_generated ADD CONSTRAINT quality_foreign_key FOREIGN KEY (psg_quality_zdb_id) REFERENCES term (term_zdb_id);
+ALTER TABLE phenotype_observation_generated_new ADD CONSTRAINT pog_new_wh_fk FOREIGN KEY (psg_pg_id) REFERENCES phenotype_source_generated_new (pg_id);
+ALTER TABLE phenotype_observation_generated_new ADD CONSTRAINT pog_new_mrkr_fk FOREIGN KEY (psg_mrkr_zdb_id) REFERENCES marker (mrkr_zdb_id);
+ALTER TABLE phenotype_observation_generated_new ADD CONSTRAINT pog_new_e1a_fk FOREIGN KEY (psg_e1a_zdb_id) REFERENCES term (term_zdb_id);
+ALTER TABLE phenotype_observation_generated_new ADD CONSTRAINT pog_new_e1b_fk FOREIGN KEY (psg_e1b_zdb_id) REFERENCES term (term_zdb_id);
+ALTER TABLE phenotype_observation_generated_new ADD CONSTRAINT pog_new_e2a_fk FOREIGN KEY (psg_e2a_zdb_id) REFERENCES term (term_zdb_id);
+ALTER TABLE phenotype_observation_generated_new ADD CONSTRAINT pog_new_e2b_fk FOREIGN KEY (psg_e2b_zdb_id) REFERENCES term (term_zdb_id);
+ALTER TABLE phenotype_observation_generated_new ADD CONSTRAINT pog_new_q_fk FOREIGN KEY (psg_quality_zdb_id) REFERENCES term (term_zdb_id);
 
-insert into phenotype_observation_generated (psg_id,
+insert into phenotype_observation_generated_new (psg_id,
        	     				   psg_pg_id,
-       	     				   psg_mrkr_zdb_id,	
+       	     				   psg_mrkr_zdb_id,
 					   psg_mrkr_abbrev,
 					   psg_mrkr_relation,
 					   psg_e1a_zdb_id,
 					   psg_e1a_name,
-					   psg_e1_relation_name,	
+					   psg_e1_relation_name,
 					   psg_e1b_zdb_id,
 					   psg_e1b_name,
 					   psg_e2a_zdb_id,
-					   psg_e2a_name,	
+					   psg_e2a_name,
 					   psg_e2_relation_name,
 					   psg_e2b_zdb_id,
 					   psg_e2b_name,
@@ -185,11 +211,39 @@ select psg_id, psg_pg_id,psg_mrkr_zdb_id, psg_mrkr_abbrev,psg_mrkr_relation,psg_
 	psg_e2b_name,psg_tag,psg_quality_zdb_id, psg_quality_name, psg_short_name, psg_pre_eap_phenotype
   from phenotype_observation_generated_temp;
 
--- Recreate phenotype_generated_curated_mapping
-CREATE TABLE phenotype_generated_curated_mapping (LIKE phenotype_generated_curated_mapping_temp INCLUDING ALL);
+-- -------------------------------------------------------------------------
+-- Build phenotype_generated_curated_mapping_new
+-- -------------------------------------------------------------------------
+CREATE TABLE phenotype_generated_curated_mapping_new (LIKE phenotype_generated_curated_mapping_temp INCLUDING ALL);
 
-insert into phenotype_generated_curated_mapping (pgcm_pg_id, pgcm_source_id, pgcm_id_type)
+insert into phenotype_generated_curated_mapping_new (pgcm_pg_id, pgcm_source_id, pgcm_id_type)
  select pgcm_pg_id, pgcm_source_id, pgcm_id_type from phenotype_generated_curated_mapping_temp;
+
+-- 2. Rename the *_new tables IN to the canonical live names, restoring the
+--    canonical index/constraint names so the next run's rename-out matches.
+
+ALTER TABLE phenotype_source_generated_new RENAME TO phenotype_source_generated;
+ALTER INDEX phenotype_source_generated_new_pkey RENAME TO phenotype_source_generated_pkey;
+ALTER INDEX phenotype_source_generated_new_genox RENAME TO phenotype_source_generated_genox;
+ALTER INDEX phenotype_source_generated_new_fig RENAME TO phenotype_source_generated_fig;
+ALTER INDEX phenotype_source_generated_new_start RENAME TO phenotype_source_generated_start;
+ALTER INDEX phenotype_source_generated_new_end RENAME TO phenotype_source_generated_end;
+ALTER TABLE phenotype_source_generated RENAME CONSTRAINT phenotype_source_generated_new_fk1 TO constraint_fk1;
+ALTER TABLE phenotype_source_generated RENAME CONSTRAINT phenotype_source_generated_new_fk2 TO constraint_fk2;
+ALTER TABLE phenotype_source_generated RENAME CONSTRAINT phenotype_source_generated_new_fk3 TO constraint_fk3;
+ALTER TABLE phenotype_source_generated RENAME CONSTRAINT phenotype_source_generated_new_fk4 TO constraint_fk4;
+
+ALTER TABLE phenotype_observation_generated_new RENAME TO phenotype_observation_generated;
+ALTER INDEX phenotype_observation_generated_new_pkey RENAME TO phenotype_observation_generated_pkey;
+ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_wh_fk TO phenotype_warehouse_foreign_key;
+ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_mrkr_fk TO marker_foreign_key;
+ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_e1a_fk TO e1a_foreign_key;
+ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_e1b_fk TO e1b_foreign_key;
+ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_e2a_fk TO e2a_foreign_key;
+ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_e2b_fk TO e2b_foreign_key;
+ALTER TABLE phenotype_observation_generated RENAME CONSTRAINT pog_new_q_fk TO quality_foreign_key;
+
+ALTER TABLE phenotype_generated_curated_mapping_new RENAME TO phenotype_generated_curated_mapping;
 
 update zdb_flag
   set (zflag_is_on,zflag_last_modified) = ('f',now())

--- a/server_apps/DB_maintenance/warehouse/phenotypeMart/refreshPhenotypeMart.sql
+++ b/server_apps/DB_maintenance/warehouse/phenotypeMart/refreshPhenotypeMart.sql
@@ -75,60 +75,6 @@ update zdb_flag
   set (zflag_is_on,zflag_last_modified) = ('t',now())
  where zflag_name = 'regen_phenotypemart';
 
--- =========================================================================
--- PHASE B -- fast metadata swap. This is the ONLY part that takes an
--- AccessExclusiveLock on the live tables; every statement below is a
--- metadata-only rename, so the lock is held just until the commit that
--- immediately follows.
--- =========================================================================
-
--- 1. Rename the current live tables OUT to *_old_<ts>, freeing the canonical
---    table / index / constraint names. Left for regen_cleanup_renamed_tables().
-
--- phenotype_generated_curated_mapping (no FKs pointing to it, simplest)
-IF EXISTS (SELECT 1 FROM information_schema.tables
-           WHERE table_name = 'phenotype_generated_curated_mapping' AND table_schema = 'public') THEN
-    pgcm_old_name := 'phenotype_generated_curated_mapping_old_' || ts;
-    RAISE NOTICE 'Renaming phenotype_generated_curated_mapping to %', pgcm_old_name;
-    EXECUTE 'ALTER TABLE phenotype_generated_curated_mapping RENAME TO ' || pgcm_old_name;
-END IF;
-
--- phenotype_observation_generated (child of phenotype_source_generated)
-IF EXISTS (SELECT 1 FROM information_schema.tables
-           WHERE table_name = 'phenotype_observation_generated' AND table_schema = 'public') THEN
-    pog_old_name := 'phenotype_observation_generated_old_' || ts;
-    RAISE NOTICE 'Renaming phenotype_observation_generated to %', pog_old_name;
-    EXECUTE 'ALTER TABLE phenotype_observation_generated RENAME TO ' || pog_old_name;
-
-    -- Free the canonical index/constraint names for the incoming table.
-    EXECUTE 'ALTER INDEX IF EXISTS phenotype_observation_generated_pkey RENAME TO ' || pog_old_name || '_pkey';
-    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT phenotype_warehouse_foreign_key TO ' || pog_old_name || '_wh_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT marker_foreign_key TO ' || pog_old_name || '_mrkr_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e1a_foreign_key TO ' || pog_old_name || '_e1a_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e1b_foreign_key TO ' || pog_old_name || '_e1b_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e2a_foreign_key TO ' || pog_old_name || '_e2a_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e2b_foreign_key TO ' || pog_old_name || '_e2b_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT quality_foreign_key TO ' || pog_old_name || '_q_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
-END IF;
-
--- phenotype_source_generated (parent)
-IF EXISTS (SELECT 1 FROM information_schema.tables
-           WHERE table_name = 'phenotype_source_generated' AND table_schema = 'public') THEN
-    psg_old_name := 'phenotype_source_generated_old_' || ts;
-    RAISE NOTICE 'Renaming phenotype_source_generated to %', psg_old_name;
-    EXECUTE 'ALTER TABLE phenotype_source_generated RENAME TO ' || psg_old_name;
-
-    EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_pkey RENAME TO ' || psg_old_name || '_pkey';
-    EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_genox RENAME TO ' || psg_old_name || '_genox';
-    EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_fig RENAME TO ' || psg_old_name || '_fig';
-    EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_start RENAME TO ' || psg_old_name || '_start';
-    EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_end RENAME TO ' || psg_old_name || '_end';
-    BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk1 TO ' || psg_old_name || '_fk1'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk2 TO ' || psg_old_name || '_fk2'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk3 TO ' || psg_old_name || '_fk3'; EXCEPTION WHEN undefined_object THEN NULL; END;
-    BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk4 TO ' || psg_old_name || '_fk4'; EXCEPTION WHEN undefined_object THEN NULL; END;
-END IF;
-
 -- Drop any *_new tables left behind by a previously failed run (a failed run
 -- rolls back atomically, so these only appear if someone left them manually).
 -- Drop the child (FK) table before its parent.
@@ -218,6 +164,60 @@ CREATE TABLE phenotype_generated_curated_mapping_new (LIKE phenotype_generated_c
 
 insert into phenotype_generated_curated_mapping_new (pgcm_pg_id, pgcm_source_id, pgcm_id_type)
  select pgcm_pg_id, pgcm_source_id, pgcm_id_type from phenotype_generated_curated_mapping_temp;
+
+-- =========================================================================
+-- PHASE B -- fast metadata swap. This is the ONLY part that takes an
+-- AccessExclusiveLock on the live tables; every statement below is a
+-- metadata-only rename, so the lock is held just until the commit that
+-- immediately follows.
+-- =========================================================================
+
+-- 1. Rename the current live tables OUT to *_old_<ts>, freeing the canonical
+--    table / index / constraint names. Left for regen_cleanup_renamed_tables().
+
+-- phenotype_generated_curated_mapping (no FKs pointing to it, simplest)
+IF EXISTS (SELECT 1 FROM information_schema.tables
+           WHERE table_name = 'phenotype_generated_curated_mapping' AND table_schema = 'public') THEN
+    pgcm_old_name := 'phenotype_generated_curated_mapping_old_' || ts;
+    RAISE NOTICE 'Renaming phenotype_generated_curated_mapping to %', pgcm_old_name;
+    EXECUTE 'ALTER TABLE phenotype_generated_curated_mapping RENAME TO ' || pgcm_old_name;
+END IF;
+
+-- phenotype_observation_generated (child of phenotype_source_generated)
+IF EXISTS (SELECT 1 FROM information_schema.tables
+           WHERE table_name = 'phenotype_observation_generated' AND table_schema = 'public') THEN
+    pog_old_name := 'phenotype_observation_generated_old_' || ts;
+    RAISE NOTICE 'Renaming phenotype_observation_generated to %', pog_old_name;
+    EXECUTE 'ALTER TABLE phenotype_observation_generated RENAME TO ' || pog_old_name;
+
+    -- Free the canonical index/constraint names for the incoming table.
+    EXECUTE 'ALTER INDEX IF EXISTS phenotype_observation_generated_pkey RENAME TO ' || pog_old_name || '_pkey';
+    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT phenotype_warehouse_foreign_key TO ' || pog_old_name || '_wh_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT marker_foreign_key TO ' || pog_old_name || '_mrkr_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e1a_foreign_key TO ' || pog_old_name || '_e1a_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e1b_foreign_key TO ' || pog_old_name || '_e1b_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e2a_foreign_key TO ' || pog_old_name || '_e2a_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT e2b_foreign_key TO ' || pog_old_name || '_e2b_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN EXECUTE 'ALTER TABLE ' || pog_old_name || ' RENAME CONSTRAINT quality_foreign_key TO ' || pog_old_name || '_q_fk'; EXCEPTION WHEN undefined_object THEN NULL; END;
+END IF;
+
+-- phenotype_source_generated (parent)
+IF EXISTS (SELECT 1 FROM information_schema.tables
+           WHERE table_name = 'phenotype_source_generated' AND table_schema = 'public') THEN
+    psg_old_name := 'phenotype_source_generated_old_' || ts;
+    RAISE NOTICE 'Renaming phenotype_source_generated to %', psg_old_name;
+    EXECUTE 'ALTER TABLE phenotype_source_generated RENAME TO ' || psg_old_name;
+
+    EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_pkey RENAME TO ' || psg_old_name || '_pkey';
+    EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_genox RENAME TO ' || psg_old_name || '_genox';
+    EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_fig RENAME TO ' || psg_old_name || '_fig';
+    EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_start RENAME TO ' || psg_old_name || '_start';
+    EXECUTE 'ALTER INDEX IF EXISTS phenotype_source_generated_end RENAME TO ' || psg_old_name || '_end';
+    BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk1 TO ' || psg_old_name || '_fk1'; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk2 TO ' || psg_old_name || '_fk2'; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk3 TO ' || psg_old_name || '_fk3'; EXCEPTION WHEN undefined_object THEN NULL; END;
+    BEGIN EXECUTE 'ALTER TABLE ' || psg_old_name || ' RENAME CONSTRAINT constraint_fk4 TO ' || psg_old_name || '_fk4'; EXCEPTION WHEN undefined_object THEN NULL; END;
+END IF;
 
 -- 2. Rename the *_new tables IN to the canonical live names, restoring the
 --    canonical index/constraint names so the next run's rename-out matches.

--- a/server_apps/DB_maintenance/warehouse/phenotypeMart/runPhenotypeMart.sh
+++ b/server_apps/DB_maintenance/warehouse/phenotypeMart/runPhenotypeMart.sh
@@ -24,10 +24,10 @@ set phenotypeMartScripts=( begin.sql \
 	     commit.sql \
 	    );
  
-set regenPhenotypeMartScripts=( begin.sql \
-	     refreshPhenotypeMart.sql \
-	     commit.sql \
-	     );
+# refreshPhenotypeMart.sql manages its own transactions (it runs the slow
+# rebuild and the fast lock-timeout-guarded swap as two separate transactions),
+# so it must NOT be wrapped in an outer begin/commit here.
+set regenPhenotypeMartScripts=( refreshPhenotypeMart.sql );
 
 touch $FULL_SCRIPT_FILE
 touch $CONVERT_PHENOTYPEMART_FILE

--- a/server_apps/DB_maintenance/warehouse/regenPhenotypeMart.sh
+++ b/server_apps/DB_maintenance/warehouse/regenPhenotypeMart.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -e
+# pipefail so a psql failure in a "psql ... | tee" pipeline still aborts the
+# script -- tee always exits 0, which would otherwise mask the failure.
+set -o pipefail
 
 # rm old reports
 date;
@@ -40,7 +43,10 @@ echo "done with phenotype mart building public" ;
 
 # move the current table data to backup, move the new data to current.
 
-${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DB_NAME < $ROOT_PATH/server_apps/DB_maintenance/warehouse/phenotypeMart/phenotypeMartRegen.sql &> $ROOT_PATH/server_apps/DB_maintenance/warehouse/phenotypeMart/regenPhenotypeMartReportPostgres.txt
+# tee so the swap's transaction markers / NOTICEs (rename-out, *_new drops,
+# any lock_timeout retries) show on the Jenkins console as well as the report
+# file. pipefail (above) keeps a psql failure from being masked by tee.
+${PGBINDIR}/psql -v ON_ERROR_STOP=1 $DB_NAME < $ROOT_PATH/server_apps/DB_maintenance/warehouse/phenotypeMart/phenotypeMartRegen.sql 2>&1 | tee $ROOT_PATH/server_apps/DB_maintenance/warehouse/phenotypeMart/regenPhenotypeMartReportPostgres.txt
 
 if [ $? -ne 0 ]; then
  echo "refresh phenotype mart (the public tables) failed and was rolled back";


### PR DESCRIPTION
refactors the `refreshPhenotypeMart.sql` process to improve reliability and minimize downtime when swapping phenotype mart tables. The main change is restructuring the refresh into two separate transactions: a slow build phase (with no exclusive locks on live tables) and a fast, lock-timeout-guarded swap phase. 