### PR TITLE
ZFIN-10357: Fix PMC "Original Article" PDF classification

### DIFF
--- a/home/WEB-INF/jsp/publication/publication-view-summary.jsp
+++ b/home/WEB-INF/jsp/publication/publication-view-summary.jsp
@@ -103,7 +103,7 @@
             <c:forEach items="${publication.files}" var="file" varStatus="loop">
                 <a href="${ZfinPropertiesEnum.PDF_LOAD.value()}/${file.fileName}">
                     <c:choose>
-                        <c:when test="${file.type.name == 'ORIGINAL_ARTICLE'}"><b>${file.originalFileName}</b></c:when>
+                        <c:when test="${file.type.name == 'ORIGINAL_ARTICLE'}"><b>Original Article</b></c:when>
                         <c:otherwise>${file.originalFileName}</c:otherwise>
                     </c:choose>
                 </a>${loop.last ? " &mdash; " : ", "}

--- a/home/WEB-INF/jsp/publication/publication-view-summary.jsp
+++ b/home/WEB-INF/jsp/publication/publication-view-summary.jsp
@@ -102,7 +102,10 @@
         <z:attributeListItem label="Files">
             <c:forEach items="${publication.files}" var="file" varStatus="loop">
                 <a href="${ZfinPropertiesEnum.PDF_LOAD.value()}/${file.fileName}">
-                        ${file.originalFileName}
+                    <c:choose>
+                        <c:when test="${file.type.name == 'ORIGINAL_ARTICLE'}"><b>${file.originalFileName}</b></c:when>
+                        <c:otherwise>${file.originalFileName}</c:otherwise>
+                    </c:choose>
                 </a>${loop.last ? " &mdash; " : ", "}
             </c:forEach>
             <a href="/action/publication/${publication.zdbID}/edit#files">Add/Update Files</a>

--- a/home/WEB-INF/jsp/publication/publication-view-summary.jsp
+++ b/home/WEB-INF/jsp/publication/publication-view-summary.jsp
@@ -103,7 +103,7 @@
             <c:forEach items="${publication.files}" var="file" varStatus="loop">
                 <a href="${ZfinPropertiesEnum.PDF_LOAD.value()}/${file.fileName}">
                     <c:choose>
-                        <c:when test="${file.type.name == 'ORIGINAL_ARTICLE'}"><b>Original Article</b></c:when>
+                        <c:when test="${file.type.name == 'ORIGINAL_ARTICLE'}">Original Article</c:when>
                         <c:otherwise>${file.originalFileName}</c:otherwise>
                     </c:choose>
                 </a>${loop.last ? " &mdash; " : ", "}

--- a/server_apps/data_transfer/PUBMED/getPDFandImages.groovy
+++ b/server_apps/data_transfer/PUBMED/getPDFandImages.groovy
@@ -8,7 +8,6 @@
  */
 
 import groovy.transform.Field
-import groovy.io.FileType
 import groovy.time.TimeCategory
 import groovy.time.TimeDuration
 import groovy.xml.slurpersupport.GPathResult
@@ -78,18 +77,6 @@ if (specificPubZdbIDs.size() > 0) {
     """
 }
 
-def addSummaryPDF(String zdbId, String pmcId, pubYear) {
-
-    def dir = new File("${System.getenv()['LOADUP_FULL_PATH']}/$pubYear/$zdbId/")
-
-    dir.eachFileRecurse(FileType.FILES) { file ->
-        if (file.name.endsWith('.pdf')) {
-            ADD_BASIC_PDFS_TO_DB.add([zdbId, pmcId, pubYear + "/" + zdbId + "/" + file.name, file.name].join('|'))
-        }
-    }
-
-}
-
 @Field final Set<String> DOWNLOADABLE_EXTENSIONS = ['pdf', 'jpg', 'jpeg', 'png', 'gif', 'tif', 'tiff'] as Set
 
 def downloadS3FilesForArticle(List<String> s3Keys, String zdbId, String pubYear) {
@@ -134,6 +121,42 @@ def recordPdfFromS3(String s3PdfKey, String pmcId, String zdbId, String pubYear)
     }
 }
 
+/**
+ * Classify the PDFs in a PMC Open Access package into the single "main article" PDF
+ * and any supplemental PDFs.
+ *
+ * The robust signal (the same one used by the Alliance literature pipeline) is that the
+ * main article PDF shares its basename with the article's full-text XML/NXML — both are
+ * named after the accession+version, e.g. PMC4679720.1.pdf <-> PMC4679720.1.xml. Supplements
+ * (NIHMS688930-supplement-N.pdf) and figures never match that basename.
+ *
+ * Returns a map: [main: <key or null>, supplements: [<key>...], fellBack: <boolean>].
+ * If no XML/NXML basename match is found but PDFs exist, falls back to the first PDF as the
+ * main article (fellBack=true) so we never silently drop an article.
+ */
+def classifyPdfs(List<String> s3Keys) {
+    def xmlKey = s3Keys.find { def l = it.toLowerCase(); l.endsWith('.xml') || l.endsWith('.nxml') }
+    def xmlBase = xmlKey ? FilenameUtils.getBaseName(xmlKey) : null
+    def pdfKeys = s3Keys.findAll { it.toLowerCase().endsWith('.pdf') }
+
+    def mainPdfKey = xmlBase ? pdfKeys.find { FilenameUtils.getBaseName(it) == xmlBase } : null
+    boolean fellBack = false
+    if (!mainPdfKey && !pdfKeys.isEmpty()) {
+        mainPdfKey = pdfKeys.first()
+        fellBack = true
+    }
+
+    def supplementPdfKeys = pdfKeys.findAll { it != mainPdfKey }
+    return [main: mainPdfKey, supplements: supplementPdfKeys, fellBack: fellBack]
+}
+
+def recordSupplementFromS3(String s3Key, String pmcId, String zdbId, String pubYear) {
+    // Supplement PDFs were already downloaded under their own S3 filename and keep it.
+    // load_pub_files.sql records these as Supplemental Material (file type 3).
+    def filename = s3Key.split('/').last()
+    PUB_FILES_TO_LOAD.add([zdbId, pmcId, pubYear + "/" + zdbId + "/" + filename, filename].join('|'))
+}
+
 def recordNonOpenPub(String pmcId, String zdbId) {
     def ncbiUrl = "https://www.ncbi.nlm.nih.gov/pmc/articles/${pmcId.toString().replace("PMC", "")}/"
     def zfinUrl = "https://zfin.org/${zdbId}"
@@ -158,30 +181,11 @@ def processPMCText(GPathResult pmcTextArticle, String zdbId, String pmcId, Strin
 
     if (tagMatch.size() == 1) {
 
-        def tag = tagMatch[0][1]  // extract the XML namespace tag pattern for use in extracting supplements, figures, images downstream.
+        def tag = tagMatch[0][1]  // extract the XML namespace tag pattern for use in extracting figures, images downstream.
 
-        def supplimentPattern = "<${tag}:supplementary-material content-type=(.*?)</${tag}:supplementary-material>"
-        def supplimentMatches = markedUpBody =~ /${supplimentPattern}/
-        if (supplimentMatches.size() > 0) {
-            supplimentMatches.each {
-                def supplement = it
-                if (pmcId == 'PMC:4679720') {
-                    println(it)
-                }
-                def filenamePattern = "<${tag}:media xlink:href='(.*?)'"
-                def filenameMatch = supplimentMatches =~ /${filenamePattern}/
-                if (filenameMatch.size() > 0) {
-                    def filename = filenameMatch[0][1]
-                    if (filename.endsWith(".avi") || filename.endsWith(".mp4") || filename.endsWith(".mov") || filename.endsWith(".wmv")) {
-                        parseLabelCaptionImage(supplement,zdbId,pmcId,imageFilePath,pubYear, tag)
-                        println("videos")
-                        println(filename)
-                    } else {
-                        PUB_FILES_TO_LOAD.add([zdbId, pmcId, pubYear + "/" + zdbId + "/" + filename, filename].join('|'))
-                    }
-                }
-            }
-        }
+        // Supplemental PDFs are classified directly from the S3 package listing (see classifyPdfs);
+        // we no longer parse them out of the OAI XML body here.
+
         // extract figures one by one from the grouping 'fig' tags
         def figPattern = "<${tag}:fig(.*?)>(.*?)</${tag}:fig>"
         def figMatches = markedUpBody =~ /${figPattern}/
@@ -205,7 +209,6 @@ def processPMCText(GPathResult pmcTextArticle, String zdbId, String pmcId, Strin
                 }
             }
         }
-        addSummaryPDF(zdbId, pmcId, pubYear)
     }
 }
 
@@ -353,10 +356,23 @@ def fetchBundlesForExistingPubs(Map idsToGrab) {
             downloadS3FilesForArticle(s3Files, zdbId, pubYear)
             PUBS_WITH_PDFS_TO_UPDATE.add("s3://${s3Files[0].split('/')[0]}")
 
-            // Check for PDF
-            def pdfKey = s3Files.find { it.toLowerCase().endsWith('.pdf') }
+            // Classify PDFs: the single main article PDF vs. supplemental PDFs, using the
+            // XML/NXML-basename rule (see classifyPdfs). The main article is marked Original
+            // Article (file type 1); every other PDF is marked Supplemental Material (type 3).
+            def classification = classifyPdfs(s3Files)
+            def pdfKey = classification.main
             if (pdfKey) {
+                if (classification.fellBack) {
+                    println("  WARNING: no XML/NXML basename match in S3 package for $pmcId ($zdbId); " +
+                            "fell back to first PDF (${pdfKey.split('/').last()}) as the main article — review.")
+                }
                 recordPdfFromS3(pdfKey, pmcId, zdbId, pubYear)
+                classification.supplements.each { suppKey ->
+                    recordSupplementFromS3(suppKey, pmcId, zdbId, pubYear)
+                }
+                if (classification.supplements.size() > 0) {
+                    println("  Supplements: ${classification.supplements.size()} PDF(s) → Supplemental Material")
+                }
             } else {
                 noPdfIds << [pmcId: pmcId, zdbId: zdbId]
                 recordNonOpenPub(pmcId, zdbId)

--- a/source/org/zfin/db/postGmakePostloaddb/1184/migrations/0010-ZFIN-10357-fix-mislabeled-original-article-pdfs.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1184/migrations/0010-ZFIN-10357-fix-mislabeled-original-article-pdfs.sql
@@ -1,0 +1,55 @@
+--liquibase formatted sql
+
+-- ZFIN-10357: repair publication PDFs wrongly marked as 'Original Article'.
+--
+-- The PMC/EuropePMC acquisition job used to pick an arbitrary PDF from the Open Access
+-- package as the main article and additionally mark *every* PDF in the package as
+-- 'Original Article' (file type 1). As a result many publications accumulated several
+-- type-1 PDF rows when only one is the real article; the rest are supplemental PDFs (and,
+-- in some cases, duplicate copies of the article itself). The ingest path has since been
+-- fixed to classify the main article by its XML/NXML basename; these changesets repair the
+-- historical rows already in the database.
+--
+-- Only the two unambiguous cases are fixed automatically:
+--   A. duplicate rows pointing at the same physical file  -> delete the redundant row(s).
+--   B. one genuine main + clearly-named supplement PDFs    -> demote the supplements.
+-- Duplicate *original* articles (journal-named auto-load + a curator's ZDB-PUB-named
+-- re-upload), companion papers, and unrecognised naming are intentionally left untouched
+-- for curator review.
+
+--changeset rtaylor:fix-original-article-delete-duplicate-file-rows
+-- A. Collapse redundant 'Original Article' rows that point at the exact same physical file
+--    (same publication, same pf_file_name); keep the lowest pf_pk_id. Deleting a row that
+--    references an identical file is loss-free.
+DELETE FROM publication_file pf
+USING (
+    SELECT pf_pub_zdb_id, pf_file_name, min(pf_pk_id) AS keep_id
+    FROM publication_file
+    WHERE pf_file_type_id = (SELECT pft_pk_id FROM publication_file_type WHERE pft_type = 'Original Article')
+    GROUP BY pf_pub_zdb_id, pf_file_name
+    HAVING count(*) > 1
+) dup
+WHERE pf.pf_pub_zdb_id = dup.pf_pub_zdb_id
+  AND pf.pf_file_name  = dup.pf_file_name
+  AND pf.pf_pk_id     <> dup.keep_id
+  AND pf.pf_file_type_id = (SELECT pft_pk_id FROM publication_file_type WHERE pft_type = 'Original Article');
+
+--changeset rtaylor:fix-original-article-demote-supplement-pdfs
+-- B. Demote supplement-named PDFs to 'Supplemental Material', but only for publications
+--    where exactly one non-supplement 'main' row remains, so the sole article is never
+--    demoted. The supplement-name pattern matches the common conventions seen in PMC/journal
+--    packages (supplement, -SD2, -s001, -sf001/-st001, supp1, .s015, Image_1, .f1, etc.).
+UPDATE publication_file pf
+SET pf_file_type_id = (SELECT pft_pk_id FROM publication_file_type WHERE pft_type = 'Supplemental Material')
+WHERE pf.pf_file_type_id = (SELECT pft_pk_id FROM publication_file_type WHERE pft_type = 'Original Article')
+  AND lower(pf.pf_original_file_name) ~ '(supplement|supp[-_ ]?[0-9]|[-_]s[0-9]|[-_]sd[0-9]|[-_]sf[0-9]|[-_]st[0-9]|\.s[0-9]|_figure|_table|_file|figure[ _]s|table[ _]s|image[_ ][0-9]|\.f[0-9]|datas[0-9]|movie|video)'
+  AND pf.pf_pub_zdb_id IN (
+      SELECT pf_pub_zdb_id
+      FROM publication_file
+      WHERE pf_file_type_id = (SELECT pft_pk_id FROM publication_file_type WHERE pft_type = 'Original Article')
+      GROUP BY pf_pub_zdb_id
+      HAVING count(*) > 1
+         AND count(*) FILTER (
+                WHERE NOT (lower(pf_original_file_name) ~ '(supplement|supp[-_ ]?[0-9]|[-_]s[0-9]|[-_]sd[0-9]|[-_]sf[0-9]|[-_]st[0-9]|\.s[0-9]|_figure|_table|_file|figure[ _]s|table[ _]s|image[_ ][0-9]|\.f[0-9]|datas[0-9]|movie|video)')
+             ) = 1
+  );

--- a/source/org/zfin/db/postGmakePostloaddb/1184/migrations/0020-ZFIN-10357-promote-unflagged-original-article-pdfs.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1184/migrations/0020-ZFIN-10357-promote-unflagged-original-article-pdfs.sql
@@ -1,0 +1,32 @@
+--liquibase formatted sql
+
+-- ZFIN-10357 (follow-up): promote main-article PDFs that were never flagged 'Original Article'.
+--
+-- The same PMC/EuropePMC acquisition regression that over-labeled supplements (fixed in
+-- 0010) also left some publications with the opposite problem: the genuine main article was
+-- typed as 'Supplemental Material' or 'Other' and the publication ended up with NO
+-- 'Original Article' row at all (e.g. ZDB-PUB-260414-12, ZDB-PUB-180418-36).
+--
+-- The acquisition pipeline renames the single main article PDF to exactly <zdbId>.pdf
+-- (getPDFandImages.groovy recordPdfFromS3), and the curator upload path is the only other
+-- writer of pf_file_name -- it gives every non-original file a '<zdbId>-' prefix and reserves
+-- the bare '<zdbId>.pdf' name for 'Original Article'. So a publication_file row whose
+-- pf_file_name basename is exactly '<zdbId>.pdf' is unambiguously the main article, whatever
+-- (wrong) type it currently carries. This changeset promotes those rows.
+--
+-- Publications whose main article is stored under an irregular name (no '<zdbId>.pdf' row)
+-- are intentionally left for curator review -- they cannot be disambiguated from genuinely
+-- supplement-only or annotated-only publications.
+
+--changeset rtaylor:fix-original-article-promote-main-named-pdfs
+-- Promote the '<zdbId>.pdf' main-article row to 'Original Article', but only for publications
+-- that currently have no 'Original Article' row, so we never create a second main article.
+UPDATE publication_file pf
+SET pf_file_type_id = (SELECT pft_pk_id FROM publication_file_type WHERE pft_type = 'Original Article')
+WHERE pf.pf_file_name LIKE '%/' || pf.pf_pub_zdb_id || '.pdf'
+  AND pf.pf_file_type_id <> (SELECT pft_pk_id FROM publication_file_type WHERE pft_type = 'Original Article')
+  AND NOT EXISTS (
+      SELECT 1 FROM publication_file o
+      WHERE o.pf_pub_zdb_id = pf.pf_pub_zdb_id
+        AND o.pf_file_type_id = (SELECT pft_pk_id FROM publication_file_type WHERE pft_type = 'Original Article')
+  );

--- a/source/org/zfin/publication/Publication.java
+++ b/source/org/zfin/publication/Publication.java
@@ -116,8 +116,8 @@ public class Publication implements Comparable<Publication>, Serializable, Entit
 
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "pf_pub_zdb_id")
-    @OrderBy("originalFileName")
-    private Set<PublicationFile> files;
+    @org.hibernate.annotations.SortNatural
+    private SortedSet<PublicationFile> files;
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "pth_pub_zdb_id")
     private Set<PublicationTrackingHistory> statusHistory;

--- a/source/org/zfin/publication/PublicationFile.java
+++ b/source/org/zfin/publication/PublicationFile.java
@@ -52,6 +52,12 @@ public class PublicationFile implements Comparable<PublicationFile> {
         if (typeCompare != 0) {
             return typeCompare;
         }
-        return ObjectUtils.compare(originalFileName, o.getOriginalFileName());
+        int nameCompare = ObjectUtils.compare(originalFileName, o.getOriginalFileName());
+        if (nameCompare != 0) {
+            return nameCompare;
+        }
+        // Final tiebreaker on the PK so distinct rows that share a type and filename
+        // (e.g. duplicate Original Article uploads) are never collapsed when held in a SortedSet.
+        return Long.compare(id, o.getId());
     }
 }


### PR DESCRIPTION
## Problem

When the PMC/EuropePMC document-acquisition job (`getPDFandImages.groovy`) moved off FTP to the Open Access S3 API, the "Original Article" marking broke. The job:
- picked an arbitrary PDF as the main article (`s3Files.find { endsWith('.pdf') }` lands on a supplement, since S3 keys sort lexicographically — e.g. `NIHMS…-supplement-10.pdf` before `PMC….pdf`), and


## Ingest fix (`getPDFandImages.groovy`)

- `classifyPdfs()`: identify the main article PDF as the one whose basename matches the package `.xml`/`.nxml` basename (the accession) — the same robust signal the Alliance literature pipeline uses. All other PDFs are supplements.
- Record only the main as Original Article; route the rest through `recordSupplementFromS3()` → Supplemental Material. Falls back to the first PDF (with a logged warning) only when no XML match exists, so an article is never silently dropped.


## Historical cleanup

One-time repair for rows already mislabeled. Auto-fixes only the unambiguous cases:
- **A**: duplicate rows pointing at the same physical file → delete the redundant row.
- **B**: one genuine main + clearly-named supplements all marked type 1 → demote the supplements (only when exactly one main remains, so the sole article is never demoted).



