### PR TITLE
ZFIN-10350: cascade pheno_term_fast_search foreign key deletes

### DIFF
--- a/server_apps/DB_maintenance/pheno/pheno_term_regen.sql
+++ b/server_apps/DB_maintenance/pheno/pheno_term_regen.sql
@@ -229,15 +229,8 @@ ALTER TABLE pheno_term_fast_search ADD PRIMARY KEY (ptfs_pk_id);
 ALTER SEQUENCE IF EXISTS pheno_term_fast_search_ptfs_pk_id_seq
     OWNED BY NONE;
 
--- Add foreign key constraints.
--- ON DELETE CASCADE: phenotype_observation_generated is now maintained by an
--- incremental apply (regen_phenotype_mart, ZFIN-10350) that DELETEs gone psg
--- rows in place. This fast-search table is still rebuilt wholesale and is
--- rebuilt LATER in the same regen run, so between the mart apply and this
--- rebuild its FK still points at the prior run's psg rows. Without the cascade
--- the incremental POG deletes violate this constraint. The orphaned search
--- rows the cascade drops are rebuilt by this very script moments later, so
--- cascading them is safe.
+-- Add foreign key constraints (ON DELETE CASCADE): 
+-- phenotype_observation_generated deletes should cascade through to pheno_term_fast_search
 ALTER TABLE pheno_term_fast_search ADD CONSTRAINT pheno_term_fast_search_psg_fk
     FOREIGN KEY (ptfs_psg_id) REFERENCES phenotype_observation_generated (psg_id)
     ON DELETE CASCADE;

--- a/server_apps/DB_maintenance/pheno/pheno_term_regen.sql
+++ b/server_apps/DB_maintenance/pheno/pheno_term_regen.sql
@@ -1,6 +1,15 @@
 -- Regenerate pheno_term_fast_search using rename-and-recreate pattern
 -- to avoid deadlocks with the indexer during the swap.
 -- Old tables are renamed with a timestamp suffix for later cleanup.
+--
+-- TODO(ZFIN-10350): consider converting this to an incremental apply like the
+-- phenotype mart tables (regen_phenotype_mart). This table still rebuilds
+-- wholesale every run while its FK parent (phenotype_observation_generated) is
+-- now mutated incrementally, which is the mismatch that forced the ON DELETE
+-- CASCADE on pheno_term_fast_search_psg_fk below. An incremental rebuild
+-- (insert new / update changed / delete gone, matched on natural key) would
+-- keep ptfs_psg_id stable across runs and remove the cross-run FK churn, so the
+-- cascade would no longer be load-bearing.
 
 DO $$
 DECLARE
@@ -220,9 +229,18 @@ ALTER TABLE pheno_term_fast_search ADD PRIMARY KEY (ptfs_pk_id);
 ALTER SEQUENCE IF EXISTS pheno_term_fast_search_ptfs_pk_id_seq
     OWNED BY NONE;
 
--- Add foreign key constraints
+-- Add foreign key constraints.
+-- ON DELETE CASCADE: phenotype_observation_generated is now maintained by an
+-- incremental apply (regen_phenotype_mart, ZFIN-10350) that DELETEs gone psg
+-- rows in place. This fast-search table is still rebuilt wholesale and is
+-- rebuilt LATER in the same regen run, so between the mart apply and this
+-- rebuild its FK still points at the prior run's psg rows. Without the cascade
+-- the incremental POG deletes violate this constraint. The orphaned search
+-- rows the cascade drops are rebuilt by this very script moments later, so
+-- cascading them is safe.
 ALTER TABLE pheno_term_fast_search ADD CONSTRAINT pheno_term_fast_search_psg_fk
-    FOREIGN KEY (ptfs_psg_id) REFERENCES phenotype_observation_generated (psg_id);
+    FOREIGN KEY (ptfs_psg_id) REFERENCES phenotype_observation_generated (psg_id)
+    ON DELETE CASCADE;
 ALTER TABLE pheno_term_fast_search ADD CONSTRAINT pheno_term_fast_search_term_fk
     FOREIGN KEY (ptfs_term_zdb_id) REFERENCES term (term_zdb_id);
 

--- a/source/org/zfin/db/postGmakePostloaddb/1183/migrations/0060-ZFIN-10350-pheno-term-fast-search-psg-fk-cascade.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1183/migrations/0060-ZFIN-10350-pheno-term-fast-search-psg-fk-cascade.sql
@@ -3,23 +3,6 @@
 
 -- Convert the live pheno_term_fast_search -> phenotype_observation_generated
 -- foreign key to ON DELETE CASCADE.
---
--- phenotype_observation_generated is now maintained by an incremental apply
--- (regen_phenotype_mart) that DELETEs gone psg rows in place. pheno_term_fast_search
--- is still rebuilt wholesale, later in the same regen run, and carries a hard FK
--- on ptfs_psg_id. Between the mart apply and that rebuild the prior run's
--- fast-search rows still reference psg rows the apply wants to delete, so the
--- non-cascade FK blocks the delete:
---
---   ERROR: update or delete on table "phenotype_observation_generated" violates
---   foreign key constraint "pheno_term_fast_search_psg_fk" on table
---   "pheno_term_fast_search"
---
--- pheno_term_regen.sql now re-adds this FK with ON DELETE CASCADE on every
--- rebuild, but that runs after the failing apply step, so the constraint
--- already on the table must be converted here, once, at deploy. The orphaned
--- search rows a cascade drops are rebuilt by the next pheno_term_regen run, so
--- cascading is safe.
 
 ALTER TABLE pheno_term_fast_search DROP CONSTRAINT IF EXISTS pheno_term_fast_search_psg_fk;
 ALTER TABLE pheno_term_fast_search ADD CONSTRAINT pheno_term_fast_search_psg_fk

--- a/source/org/zfin/db/postGmakePostloaddb/1183/migrations/0060-ZFIN-10350-pheno-term-fast-search-psg-fk-cascade.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1183/migrations/0060-ZFIN-10350-pheno-term-fast-search-psg-fk-cascade.sql
@@ -1,0 +1,27 @@
+--liquibase formatted sql
+--changeset rtaylor:ZFIN-10350-pheno-term-fast-search-psg-fk-cascade
+
+-- Convert the live pheno_term_fast_search -> phenotype_observation_generated
+-- foreign key to ON DELETE CASCADE.
+--
+-- phenotype_observation_generated is now maintained by an incremental apply
+-- (regen_phenotype_mart) that DELETEs gone psg rows in place. pheno_term_fast_search
+-- is still rebuilt wholesale, later in the same regen run, and carries a hard FK
+-- on ptfs_psg_id. Between the mart apply and that rebuild the prior run's
+-- fast-search rows still reference psg rows the apply wants to delete, so the
+-- non-cascade FK blocks the delete:
+--
+--   ERROR: update or delete on table "phenotype_observation_generated" violates
+--   foreign key constraint "pheno_term_fast_search_psg_fk" on table
+--   "pheno_term_fast_search"
+--
+-- pheno_term_regen.sql now re-adds this FK with ON DELETE CASCADE on every
+-- rebuild, but that runs after the failing apply step, so the constraint
+-- already on the table must be converted here, once, at deploy. The orphaned
+-- search rows a cascade drops are rebuilt by the next pheno_term_regen run, so
+-- cascading is safe.
+
+ALTER TABLE pheno_term_fast_search DROP CONSTRAINT IF EXISTS pheno_term_fast_search_psg_fk;
+ALTER TABLE pheno_term_fast_search ADD CONSTRAINT pheno_term_fast_search_psg_fk
+    FOREIGN KEY (ptfs_psg_id) REFERENCES phenotype_observation_generated (psg_id)
+    ON DELETE CASCADE;


### PR DESCRIPTION
- pheno_term_regen.sql: re-add the FK with ON DELETE CASCADE every rebuild, and flag (TODO) that this table could itself go incremental to drop the mismatch.
- 0060 migration: convert the FK already on the live table once at deploy, since the failing apply step runs before pheno_term_regen re-creates it.