### PR TITLE
ZFIN-10286: soften diff highlight + add gene-symbol columns to report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,13 @@ docker/elasticsearch/state/
 .idea
 *.iml
 
+# Eclipse things
+.classpath
+.project
+.factorypath
+.settings/
+bin/
+
 # Mac cruft
 .DS_Store
 ._*

--- a/server_apps/data_transfer/ORTHO/reportOrthoNameChanges.pl
+++ b/server_apps/data_transfer/ORTHO/reportOrthoNameChanges.pl
@@ -392,8 +392,8 @@ foreach $zdbGeneId (sort {$symbolsZFgene{$a} cmp $symbolsZFgene{$b}} (keys %symb
        $ctUpdatedOrthNames++;
        print ORTHNAMEREPORT "$zdbGeneId     $symbolsZFgene{$zdbGeneId}\n";
        print ORTHNAMEREPORT "human orthology name at ZFIN: $namesHumanOrthZFIN{$zdbGeneId}\n";
-       print ORTHNAMEREPORT "human orthology name at NCBI: $namesHumanOrthNCBI{$zdbGeneId}\n\n";  
-       print ORTHNAMEUPDATE "$zdbGeneId|Human|$namesHumanOrthZFIN{$zdbGeneId}|$namesHumanOrthNCBI{$zdbGeneId}|\n";
+       print ORTHNAMEREPORT "human orthology name at NCBI: $namesHumanOrthNCBI{$zdbGeneId}\n\n";
+       print ORTHNAMEUPDATE "$zdbGeneId|$symbolsZFgene{$zdbGeneId}|Human|$namesHumanOrthZFIN{$zdbGeneId}|$namesHumanOrthNCBI{$zdbGeneId}|\n";
    }
    
    if(exists($namesMouseOrthZFIN{$zdbGeneId}) && exists($namesMouseOrthNCBI{$zdbGeneId}) && $namesMouseOrthZFIN{$zdbGeneId} ne $namesMouseOrthNCBI{$zdbGeneId}) {
@@ -401,7 +401,7 @@ foreach $zdbGeneId (sort {$symbolsZFgene{$a} cmp $symbolsZFgene{$b}} (keys %symb
        print ORTHNAMEREPORT "$zdbGeneId     $symbolsZFgene{$zdbGeneId}\n";
        print ORTHNAMEREPORT "mouse orthology name at ZFIN: $namesMouseOrthZFIN{$zdbGeneId}\n";
        print ORTHNAMEREPORT "mouse orthology name at NCBI: $namesMouseOrthNCBI{$zdbGeneId}\n\n";
-       print ORTHNAMEUPDATE "$zdbGeneId|Mouse|$namesMouseOrthZFIN{$zdbGeneId}|$namesMouseOrthNCBI{$zdbGeneId}|\n";
+       print ORTHNAMEUPDATE "$zdbGeneId|$symbolsZFgene{$zdbGeneId}|Mouse|$namesMouseOrthZFIN{$zdbGeneId}|$namesMouseOrthNCBI{$zdbGeneId}|\n";
    }   
    
    if(exists($namesFlyOrthZFIN{$zdbGeneId}) && exists($namesFlyOrthNCBI{$zdbGeneId}) && $namesFlyOrthZFIN{$zdbGeneId} ne $namesFlyOrthNCBI{$zdbGeneId}) {
@@ -409,7 +409,7 @@ foreach $zdbGeneId (sort {$symbolsZFgene{$a} cmp $symbolsZFgene{$b}} (keys %symb
        print ORTHNAMEREPORT "$zdbGeneId     $symbolsZFgene{$zdbGeneId}\n";
        print ORTHNAMEREPORT "fly orthology name at ZFIN: $namesFlyOrthZFIN{$zdbGeneId}\n";
        print ORTHNAMEREPORT "fly orthology name at NCBI: $namesFlyOrthNCBI{$zdbGeneId}\n\n";
-       print ORTHNAMEUPDATE "$zdbGeneId|Fruit fly|$namesFlyOrthZFIN{$zdbGeneId}|$namesFlyOrthNCBI{$zdbGeneId}|\n";
+       print ORTHNAMEUPDATE "$zdbGeneId|$symbolsZFgene{$zdbGeneId}|Fruit fly|$namesFlyOrthZFIN{$zdbGeneId}|$namesFlyOrthNCBI{$zdbGeneId}|\n";
    }      
 }
 

--- a/source/org/zfin/orthology/jobs/OrthoUpdateReportJob.java
+++ b/source/org/zfin/orthology/jobs/OrthoUpdateReportJob.java
@@ -205,23 +205,34 @@ public class OrthoUpdateReportJob extends AbstractValidateDataReportTask {
     private ReportTable inconsistencyTable(List<IncRow> rows, String schema, String title, boolean dated) {
         ReportTable table = new ReportTable().schemaRef(schema).title(title);
         for (IncRow r : rows) {
-            // Diff the ZFIN gene name against whichever ortholog name is present.
+            // Diff the ZFIN gene name/symbol against whichever ortholog value is
+            // present (a row carries human, mouse, or both). Symbols get their
+            // own columns because sometimes only the abbreviation differs.
             String hName = orEmpty(r.hName);
             String mName = orEmpty(r.mName);
             String zName = orEmpty(r.zName);
+            String hSym  = orEmpty(r.hSym);
+            String mSym  = orEmpty(r.mSym);
+            String zSym  = orEmpty(r.symbol);
+            String otherName = !hName.isEmpty() ? hName : mName;
+            String otherSym  = !hSym.isEmpty()  ? hSym  : mSym;
             if (dated) {
                 table.addRow(
                     "firstSeen", orEmpty(r.firstSeen),
                     "zdbID",     r.zdbId,
-                    "symbol",    orEmpty(r.symbol),
-                    "zfinName",  OrthoNameDiff.highlightOld(zName, !hName.isEmpty() ? hName : mName),
+                    "zfinSym",   otherSym.isEmpty() ? zSym : OrthoNameDiff.highlightOld(zSym, otherSym),
+                    "humanSym",  hSym.isEmpty() ? "" : OrthoNameDiff.highlightNew(zSym, hSym),
+                    "mouseSym",  mSym.isEmpty() ? "" : OrthoNameDiff.highlightNew(zSym, mSym),
+                    "zfinName",  OrthoNameDiff.highlightOld(zName, otherName),
                     "humanName", hName.isEmpty() ? "" : OrthoNameDiff.highlightNew(zName, hName),
                     "mouseName", mName.isEmpty() ? "" : OrthoNameDiff.highlightNew(zName, mName));
             } else {
                 table.addRow(
                     "zdbID",     r.zdbId,
-                    "symbol",    orEmpty(r.symbol),
-                    "zfinName",  OrthoNameDiff.highlightOld(zName, !hName.isEmpty() ? hName : mName),
+                    "zfinSym",   otherSym.isEmpty() ? zSym : OrthoNameDiff.highlightOld(zSym, otherSym),
+                    "humanSym",  hSym.isEmpty() ? "" : OrthoNameDiff.highlightNew(zSym, hSym),
+                    "mouseSym",  mSym.isEmpty() ? "" : OrthoNameDiff.highlightNew(zSym, mSym),
+                    "zfinName",  OrthoNameDiff.highlightOld(zName, otherName),
                     "humanName", hName.isEmpty() ? "" : OrthoNameDiff.highlightNew(zName, hName),
                     "mouseName", mName.isEmpty() ? "" : OrthoNameDiff.highlightNew(zName, mName));
             }
@@ -303,17 +314,21 @@ public class OrthoUpdateReportJob extends AbstractValidateDataReportTask {
                 .addColumn(ReportTable.Column.of("gene",     "GENE links"))
                 .addColumn(ReportTable.Column.of("flybase",  "FLYBASE links")))
             .tableSchema(SCHEMA_INCONSISTENT, new Report.TableSchema()
-                .description("ZFIN gene names inconsistent with the NCBI ortholog name — new since the last run.")
+                .description("ZFIN gene names/symbols inconsistent with the NCBI ortholog — new since the last run.")
                 .addColumn(ReportTable.Column.of("zdbID",     "ZDB ID", "zdbID"))
-                .addColumn(ReportTable.Column.of("symbol",    "Symbol"))
+                .addColumn(ReportTable.Column.of("zfinSym",   "ZFIN symbol", "htmlCell"))
+                .addColumn(ReportTable.Column.of("humanSym",  "Human symbol", "htmlCell"))
+                .addColumn(ReportTable.Column.of("mouseSym",  "Mouse symbol", "htmlCell"))
                 .addColumn(ReportTable.Column.of("zfinName",  "ZFIN gene name", "htmlCell"))
                 .addColumn(ReportTable.Column.of("humanName", "Human ortholog name", "htmlCell"))
                 .addColumn(ReportTable.Column.of("mouseName", "Mouse ortholog name", "htmlCell")))
             .tableSchema(SCHEMA_INCONSISTENT_DATED, new Report.TableSchema()
-                .description("Full current set of ZFIN/ortholog name inconsistencies, newest first.")
+                .description("Full current set of ZFIN/ortholog name & symbol inconsistencies, newest first.")
                 .addColumn(ReportTable.Column.of("firstSeen", "First seen"))
                 .addColumn(ReportTable.Column.of("zdbID",     "ZDB ID", "zdbID"))
-                .addColumn(ReportTable.Column.of("symbol",    "Symbol"))
+                .addColumn(ReportTable.Column.of("zfinSym",   "ZFIN symbol", "htmlCell"))
+                .addColumn(ReportTable.Column.of("humanSym",  "Human symbol", "htmlCell"))
+                .addColumn(ReportTable.Column.of("mouseSym",  "Mouse symbol", "htmlCell"))
                 .addColumn(ReportTable.Column.of("zfinName",  "ZFIN gene name", "htmlCell"))
                 .addColumn(ReportTable.Column.of("humanName", "Human ortholog name", "htmlCell"))
                 .addColumn(ReportTable.Column.of("mouseName", "Mouse ortholog name", "htmlCell")))

--- a/source/org/zfin/orthology/jobs/OrthoUpdateReportJob.java
+++ b/source/org/zfin/orthology/jobs/OrthoUpdateReportJob.java
@@ -241,18 +241,19 @@ public class OrthoUpdateReportJob extends AbstractValidateDataReportTask {
     }
 
     private ReportNode buildNamesUpdatedNode() {
-        // orthoNamesUpdateList.txt: zdbId|species|oldName|newName|
+        // orthoNamesUpdateList.txt: zdbId|zfinSym|species|oldName|newName|
         List<String[]> rows = readDelimited(orthoDir, FILE_NAMES_UPDATED, "\\|");
         ReportNode node = new ReportNode().id("namesUpdated").title("Ortholog names updated");
         ReportTable table = new ReportTable()
             .schemaRef(SCHEMA_NAMES_UPDATED)
             .title("Ortholog names changed to match NCBI (" + rows.size() + ")");
         for (String[] r : rows) {
-            String oldName = col(r, 2);
-            String newName = col(r, 3);
+            String oldName = col(r, 3);
+            String newName = col(r, 4);
             table.addRow(
                 "zdbID",   col(r, 0),
-                "species", col(r, 1),
+                "zfinSym", col(r, 1),
+                "species", col(r, 2),
                 "oldName", OrthoNameDiff.highlightOld(oldName, newName),
                 "newName", OrthoNameDiff.highlightNew(oldName, newName));
         }
@@ -335,6 +336,7 @@ public class OrthoUpdateReportJob extends AbstractValidateDataReportTask {
             .tableSchema(SCHEMA_NAMES_UPDATED, new Report.TableSchema()
                 .description("Ortholog names that were changed to match NCBI.")
                 .addColumn(ReportTable.Column.of("zdbID",   "ZDB ID", "zdbID"))
+                .addColumn(ReportTable.Column.of("zfinSym", "ZFIN symbol"))
                 .addColumn(ReportTable.Column.of("species", "Species"))
                 .addColumn(ReportTable.Column.of("oldName", "Old name (ZFIN)", "htmlCell"))
                 .addColumn(ReportTable.Column.of("newName", "New name (NCBI)", "htmlCell")))

--- a/source/org/zfin/report/report-template.html
+++ b/source/org/zfin/report/report-template.html
@@ -240,7 +240,7 @@
         /* Inline diff highlights: producers emit <u>…</u> around character ranges
            that differ from a paired cell (see OrthoNameDiff). The underline is what
            Excel preserves on export; the yellow background is the in-browser cue. */
-        .data-table u { background-color: #ffeb3b; text-decoration-thickness: 1.5px; }
+        .data-table u { background-color: #fff3a3; text-decoration-thickness: 1.5px; }
         /* The children-list is the main navigation surface for a structural
            node; keep it full width so titles + columns line up across siblings. */
         .children-list .data-table { width: 100%; }

--- a/test/org/zfin/orthology/jobs/OrthoUpdateReportJobTest.java
+++ b/test/org/zfin/orthology/jobs/OrthoUpdateReportJobTest.java
@@ -33,17 +33,18 @@ public class OrthoUpdateReportJobTest {
     @Test
     public void readDelimitedSplitsPipesAndKeepsTrailingEmptyField() throws Exception {
         write("orthoNamesUpdateList.txt",
-            "ZDB-GENE-001|Human|old name|new name|\n" +
-            "ZDB-GENE-002|Mouse|foo|bar|\n");
+            "ZDB-GENE-001|myga|Human|old name|new name|\n" +
+            "ZDB-GENE-002|mygb|Mouse|foo|bar|\n");
 
         List<String[]> rows = OrthoUpdateReportJob.readDelimited(
             tmp.getRoot(), "orthoNamesUpdateList.txt", "\\|");
 
         assertEquals(2, rows.size());
         // -1 split limit keeps the trailing empty field after the last pipe.
-        assertEquals(5, rows.get(0).length);
+        assertEquals(6, rows.get(0).length);
         assertEquals("ZDB-GENE-001", rows.get(0)[0]);
-        assertEquals("new name",     rows.get(0)[3]);
+        assertEquals("myga",         rows.get(0)[1]);
+        assertEquals("new name",     rows.get(0)[4]);
     }
 
     @Test
@@ -148,7 +149,7 @@ public class OrthoUpdateReportJobTest {
             "# header\n\nfirst seen: 2026-06-09\nZDB-GENE-123     myga\n" +
             "gene name (z): my gene a\ngene name (h): MY GENE ALPHA\n" +
             "gene symbol (h): MYGA\ngene name (m):\ngene symbol (m):\n\n");
-        write("orthoNamesUpdateList.txt", "ZDB-GENE-999|Human|old name|new name|\n");
+        write("orthoNamesUpdateList.txt", "ZDB-GENE-999|mygz|Human|old name|new name|\n");
         write("ortho_obsolete.txt",
             "ZDB-GENE-777|abc|gene abc|ABC|12345|gene ABC|IEA|ZDB-PUB-1\n");
         write("orthoNcbiIdsNotFoundReport.txt", "ZDB-GENE-555\tdef\t67890\tMouse\n");
@@ -181,6 +182,8 @@ public class OrthoUpdateReportJobTest {
         assertTrue(json.contains("Mouse symbol"));
         // The parsed human ortholog symbol made it into a row cell.
         assertTrue(json.contains("MYGA"));
+        // The ZFIN gene symbol reached the "Ortholog names updated" table too.
+        assertTrue(json.contains("mygz"));
     }
 
     /** Extract and gunzip the {@code window.REPORT_DATA_GZ} payload from rendered report HTML. */

--- a/test/org/zfin/orthology/jobs/OrthoUpdateReportJobTest.java
+++ b/test/org/zfin/orthology/jobs/OrthoUpdateReportJobTest.java
@@ -174,6 +174,13 @@ public class OrthoUpdateReportJobTest {
         assertTrue(json.contains("Inconsistent ZF gene names"));
         // Diff highlighting reached the output (OrthoNameDiff wraps changes in <u>).
         assertTrue(json.contains("<u>"));
+        // Gene-symbol columns are present (ZFIN + human + mouse abbreviations) so
+        // curators can spot abbreviation-only changes.
+        assertTrue(json.contains("ZFIN symbol"));
+        assertTrue(json.contains("Human symbol"));
+        assertTrue(json.contains("Mouse symbol"));
+        // The parsed human ortholog symbol made it into a row cell.
+        assertTrue(json.contains("MYGA"));
     }
 
     /** Extract and gunzip the {@code window.REPORT_DATA_GZ} payload from rendered report HTML. */


### PR DESCRIPTION
Feedback on the orthology-inconsistency report:

- Tone down the diff-highlight color from #ffeb3b (vivid Material yellow) to a paler #fff3a3 — less aggressive on screen while still clearly yellow and still preserving the <u> underline Excel relies on for export.

- Add gene-abbreviation columns to the weekly Update-Orthology_w report's inconsistency tables. The human/mouse symbols were already parsed from the Perl output (hSym/mSym) but never rendered; now both tables show ZFIN / Human / Mouse symbol columns alongside the name columns, character-diff highlighted the same way, so abbreviation-only changes stand out. The one-time OrthoInconsistencyReportJob already had both symbol columns.

