### PR TITLE
ZFIN-10276: Fix Solr upgrade ClassCastException: Long facet counts cast to Integer

### DIFF
--- a/source/org/zfin/expression/service/ExpressionSearchService.java
+++ b/source/org/zfin/expression/service/ExpressionSearchService.java
@@ -422,7 +422,7 @@ public class ExpressionSearchService {
             return response;
         }
 
-        Integer total = (Integer) Optional.of(imagesFacet.get("numBuckets")).orElse(0);
+        Integer total = ((Number) Optional.of(imagesFacet.get("numBuckets")).orElse(0)).intValue();
         @SuppressWarnings("unchecked")
         List<org.apache.solr.common.util.NamedList<Object>> buckets =
                 (List<org.apache.solr.common.util.NamedList<Object>>) imagesFacet.get("buckets");

--- a/source/org/zfin/ontology/service/RibbonService.java
+++ b/source/org/zfin/ontology/service/RibbonService.java
@@ -255,16 +255,16 @@ public class RibbonService {
         NamedList<Object> facets = (NamedList<Object>) response.getResponse().get("facets");
         if (CollectionUtils.isEmpty(includeTermIDs)) {
             RibbonSubjectGroupCounts counts = new RibbonSubjectGroupCounts();
-            counts.setNumberOfAnnotations((Integer) Optional.ofNullable(facets.get("count")).orElse(0));
-            counts.setNumberOfClasses((Integer) Optional.ofNullable(facets.get("num_terms")).orElse(0));
+            counts.setNumberOfAnnotations(((Number) Optional.ofNullable(facets.get("count")).orElse(0)).intValue());
+            counts.setNumberOfClasses(((Number) Optional.ofNullable(facets.get("num_terms")).orElse(0)).intValue());
             termCounts.put(GLOBAL_ALL, counts);
         } else {
             for (String id : includeTermIDs) {
                 NamedList<Object> facet = (NamedList<Object>) facets.get(id);
                 RibbonSubjectGroupCounts counts = new RibbonSubjectGroupCounts();
                 if (facet != null) {
-                    counts.setNumberOfAnnotations((Integer) Optional.ofNullable(facet.get("count")).orElse(0));
-                    counts.setNumberOfClasses((Integer) Optional.ofNullable(facet.get("num_terms")).orElse(0));
+                    counts.setNumberOfAnnotations(((Number) Optional.ofNullable(facet.get("count")).orElse(0)).intValue());
+                    counts.setNumberOfClasses(((Number) Optional.ofNullable(facet.get("num_terms")).orElse(0)).intValue());
                 } else {
                     counts.setNumberOfAnnotations(0);
                     counts.setNumberOfClasses(0);


### PR DESCRIPTION
The Solr upgrade now returns Long (not Integer) for JSON facet count/num_terms/numBuckets values. Cast to Number and call intValue() so both Integer and Long responses work.