### PR TITLE
ZFIN-10362 Update STR JBrowse image to GRCz12tu

### DIFF
--- a/home/javascript/react/constants/config-jbrowse2.json
+++ b/home/javascript/react/constants/config-jbrowse2.json
@@ -665,6 +665,36 @@
         },
         {
             "type": "FeatureTrack",
+            "trackId": "zfin_knockdown_reagent12",
+            "name": "Knockdown Reagent",
+            "assemblyNames": ["GRCz12tu"],
+            "formatDetails": {
+                "feature": "jexl:{ ZFIN: '<a href=\"http://zfin.org/'+feature.zdb_id+' \">'+feature.name+'</a>'}"
+            },
+            "adapter": {
+                "type": "NCListAdapter",
+                "rootUrlTemplate": {
+                    "locationType": "UriLocation",
+                    "uri": "https://s3.amazonaws.com/agrjbrowse/MOD-jbrowses/zfin/GRCz12tu/tracks/Knockdown_Reagent/{refseq}/trackData.jsonz"
+                }
+            },
+            "displays": [
+                {
+                    "type": "LinearBasicDisplay",
+                    "displayId": "zfin_knockdown_reagent12-LinearBasicDisplay",
+                    "renderer": {
+                        "type": "SvgFeatureRenderer",
+                        "color1": "#3DB471"
+                    }
+                },
+                {
+                    "type": "LinearArcDisplay",
+                    "displayId": "zfin_knockdown_reagent12-LinearArcDisplay"
+                }
+            ]
+        },
+        {
+            "type": "FeatureTrack",
             "trackId": "GRCz10_zfin_knockdown_reagent",
             "name": "Knockdown Reagent",
             "assemblyNames": ["GRCz10"],

--- a/server_apps/data_transfer/Ensembl/updateSequenceFeatureChromosomeLocation.sql
+++ b/server_apps/data_transfer/Ensembl/updateSequenceFeatureChromosomeLocation.sql
@@ -197,11 +197,20 @@ INSERT INTO sequence_feature_chromosome_location_generated
          AND endval IS NOT NULL;
 
 -- §G. DirectSubmission re-import from sequence_feature_chromosome_location. -
+-- One location can carry more than one attribution (record_attribution), so the
+-- left join fans a single location into one row per pub. The generated table's
+-- uk_sfclg_unique_location key excludes the pub id, so those fan-out rows collide.
+-- (Harmless while sfclg_acc_num was null -- NULLs are distinct in the unique key --
+-- but a hard duplicate-key error once the accession is carried through.) DISTINCT ON
+-- the unique-key columns keeps one row per location, picking the lowest pub id
+-- deterministically; the authoritative attributions still live in record_attribution.
 insert into sequence_feature_chromosome_location_generated (
   sfclg_chromosome, sfclg_data_zdb_id, sfclg_start, sfclg_end, sfclg_acc_num, sfclg_location_source, sfclg_location_subsource, sfclg_assembly, sfclg_pub_zdb_id)
-select sfcl_chromosome, sfcl_feature_zdb_id, sfcl_start_position, sfcl_end_position, sfcl_chromosome_reference_accession_number, 'DirectSubmission', '', sfcl_assembly, recattrib_source_zdb_id
+select distinct on (sfcl_feature_zdb_id, sfcl_assembly, sfcl_chromosome_reference_accession_number, sfcl_start_position, sfcl_end_position)
+       sfcl_chromosome, sfcl_feature_zdb_id, sfcl_start_position, sfcl_end_position, sfcl_chromosome_reference_accession_number, 'DirectSubmission', '', sfcl_assembly, recattrib_source_zdb_id
   from sequence_feature_chromosome_location
-  left outer join record_attribution on recattrib_data_zdb_id = sfcl_zdb_id;
+  left outer join record_attribution on recattrib_data_zdb_id = sfcl_zdb_id
+ order by sfcl_feature_zdb_id, sfcl_assembly, sfcl_chromosome_reference_accession_number, sfcl_start_position, sfcl_end_position, recattrib_source_zdb_id;
 
 -- §H. zmp gbrowse-track tag for ZDB-PUB-130425-4. The warehouse script's §H
 -- re-tags both ZMP pubs (belt-and-suspenders); the additional pub

--- a/server_apps/jenkins/jobs/Refresh-GBrowse-Tracks_d/config.xml
+++ b/server_apps/jenkins/jobs/Refresh-GBrowse-Tracks_d/config.xml
@@ -3,7 +3,7 @@
   <actions/>
   <description>&lt;ul&gt;#xd;
   &lt;li&gt;Merges static Burgess-Lin and ZMP data with active ZFIN data and loads that information into gff3 table.&lt;/li&gt;&#xd;
-  &lt;li&gt;Runs Bowtie alignment on STRs and loads that information into gff3 table.&lt;/li&gt;&#xd;
+  &lt;li&gt;Runs Bowtie alignment on STRs against both GRCz11 and GRCz12tu and loads that information into gff3 table.&lt;/li&gt;&#xd;
   &lt;li&gt;Pulls info from gff3 table into sequence_feature_chromosome_location_generated table&lt;/li&gt;&#xd;
   &lt;li&gt;On success, triggers Regenerate-Chromosome-Mart_d, which adds ENSDARG-fallback rows, tags additional zmp track pubs, and prunes UCSC links whose accession is missing from UCSC's danRer11 refGene track.&lt;/li&gt;&#xd;
 &lt;/ul&gt;</description>
@@ -25,6 +25,7 @@
     <hudson.tasks.Shell>
       <command>cd $TARGETROOT/server_apps/data_transfer/Downloads/GFF3/knockdown_reagents
 ./load_knockdown_reagents.sh
+./load_knockdown_reagents_grcz12tu.sh
       </command>
     </hudson.tasks.Shell>
   </builders>

--- a/source/org/zfin/genomebrowser/GenomeBrowserTrack.java
+++ b/source/org/zfin/genomebrowser/GenomeBrowserTrack.java
@@ -50,6 +50,7 @@ public enum GenomeBrowserTrack {
         Map<GenomeBrowserTrack, String> trackIDMap12 = new HashMap<>();
         trackIDMap12.put(GENES, "zfin-gene12");
         trackIDMap12.put(REFSEQ, "refseq12");
+        trackIDMap12.put(KNOCKDOWN_REAGENT, "zfin_knockdown_reagent12");
         trackMap.put("GRCz12tu", trackIDMap12);
 
         Map<GenomeBrowserTrack, String> trackIDMap10 = new HashMap<>();

--- a/source/org/zfin/marker/presentation/SequenceTargetingReagentViewController.java
+++ b/source/org/zfin/marker/presentation/SequenceTargetingReagentViewController.java
@@ -242,19 +242,31 @@ public class SequenceTargetingReagentViewController {
         ));
         sequenceTargetingReagentBean.setMarkerRelationshipPresentationList(knockdownRelationships);
 
-        // get gbrowse genomic location of each targeted gene
+        // get gbrowse genomic locations of str itself. STR locations exist for both
+        // GRCz11 and GRCz12tu under the same ZFIN (ZfinGbrowseStartEndLoader) source,
+        // distinguished only by assembly. Prefer GRCz12tu; fall back to GRCz11 for STRs
+        // that have no GRCz12tu placement yet (e.g. sequence didn't align to the new assembly).
+        List<MarkerGenomeLocation> allStrLocations = linkageRepository.getGenomeLocation(sequenceTargetingReagent, GenomeLocation.Source.ZFIN);
+        GenomeBrowserBuild genomeBuild = GenomeBrowserBuild.CURRENT;
+        // targeted-gene locations are sourced per assembly: ZFIN_NCBI for GRCz12tu, ZFIN for GRCz11.
+        GenomeLocation.Source geneSource = GenomeLocation.Source.ZFIN_NCBI;
+        List<MarkerGenomeLocation> strLocations = filterByAssembly(allStrLocations, GenomeBrowserBuild.CURRENT.getValue());
+        if (strLocations.isEmpty()) {
+            strLocations = filterByAssembly(allStrLocations, GenomeBrowserBuild.GRCZ11.getValue());
+            genomeBuild = GenomeBrowserBuild.GRCZ11;
+            geneSource = GenomeLocation.Source.ZFIN;
+        }
+
+        // get gbrowse genomic location of each targeted gene on the chosen assembly
         List<MarkerGenomeLocation> targetedGeneLocations = new ArrayList<>();
         for (MarkerRelationshipPresentation knockdownRelationship : knockdownRelationships) {
             Marker targetedGene = markerRepository.getGeneByID(knockdownRelationship.getZdbId());
-            List<MarkerGenomeLocation> locations = linkageRepository.getGenomeLocation(targetedGene, GenomeLocation.Source.ZFIN);
+            List<MarkerGenomeLocation> locations = linkageRepository.getGenomeLocation(targetedGene, geneSource);
             if (CollectionUtils.isNotEmpty(locations)) {
                 // if we have location(s) for targeted gene, just take the first one... i guess
                 targetedGeneLocations.add(locations.get(0));
             }
         }
-
-        // get gbrowse genomic locations of str itself
-        List<MarkerGenomeLocation> strLocations = linkageRepository.getGenomeLocation(sequenceTargetingReagent, GenomeLocation.Source.ZFIN);
 
         // for talens there should be two location that need to be combined into one. it might be better to do this upstream
         // in the GFF3 track generation (e.g. with parent-child relationships), but this works for now.
@@ -285,7 +297,7 @@ public class SequenceTargetingReagentViewController {
                     .withRelativePadding(0.1)
                     .tracks(GenomeBrowserTrack.getGenomeBrowserTracks(GenomeBrowserTrack.Page.GENE_STRS))
                     .highlight(sequenceTargetingReagent)
-                    .genomeBuild(GenomeBrowserBuild.GRCZ11)
+                    .genomeBuild(genomeBuild)
                     .build()
             );
         } else {
@@ -296,12 +308,18 @@ public class SequenceTargetingReagentViewController {
                         .withPadding(10000)
                         .tracks(GBrowseService.getGBrowseTracks(sequenceTargetingReagent))
                         .highlight(sequenceTargetingReagent)
-                        .genomeBuild(GenomeBrowserBuild.GRCZ11)
+                        .genomeBuild(genomeBuild)
                         .build()
                 );
             }
         }
 
+    }
+
+    private static List<MarkerGenomeLocation> filterByAssembly(List<MarkerGenomeLocation> locations, String assembly) {
+        return locations.stream()
+                .filter(location -> assembly.equals(location.getAssembly()))
+                .toList();
     }
 }
 


### PR DESCRIPTION
## ZFIN-10362 — Update STR JBrowse image to GRCz12tu

Moves the genome-browser image on STR (Sequence Targeting Reagent) pages from GRCz11 to GRCz12tu, with a per-reagent GRCz11 fallback. Three layers:

### 1. Data pipeline — produce GRCz12tu STR coordinates
`Refresh-GBrowse-Tracks_d` now also runs `load_knockdown_reagents_grcz12tu.sh`, so the `ZFIN_knockdown_reagent_GRCz12tu` gff3 source is generated and §J of `updateSequenceFeatureChromosomeLocation.sql` writes GRCz12tu STR rows into `sequence_feature_chromosome_location_generated` (previously zero).

### 2. §G bug fix (surfaced while running the job)
§G's `DirectSubmission` re-import left-joins `record_attribution`, fanning one location into one row per pub; `uk_sfclg_unique_location` excludes the pub id. This was silently tolerated while `sfclg_acc_num` was null (NULLs are distinct in the unique key), but became a hard duplicate-key failure once commit `e040299b16` carried the accession through (137 GRCz11 locations), failing every job run. Fixed with `DISTINCT ON` the unique-key columns (keeps one row per location; authoritative attributions remain in `record_attribution`).

### 3. App layer
- `SequenceTargetingReagentViewController` builds the STR image on GRCz12tu, falling back to GRCz11 per reagent when no z12tu placement exists. STR locations read from the ZFIN source and filtered by assembly (z11/z12tu share the source); targeted-gene locations from ZFIN_NCBI (z12tu) or ZFIN (z11).
- New GRCz12tu "Knockdown Reagent" track in `config-jbrowse2.json` (S3-backed: `.../zfin/GRCz12tu/tracks/Knockdown_Reagent/{refseq}/trackData.jsonz`).
- Registered its id in `GenomeBrowserTrack.trackMap["GRCz12tu"]` for the full-browser link.

### Verification (test.zfin.org)
- Job ran green; gff3 z12tu source = 45,563 rows → exactly 45,563 sfclg STR rows (perfect 1:1: 27,985 CRISPR / 15,688 MO / 1,890 TALEN).
- Reagent coverage ≥ GRCz11 (18,089 CRISPR / 11,340 MO / 946 TALEN distinct — no placements lost).
- z11 STR rows unchanged; §G dedupe held.

Note: `config-jbrowse2.json` is bundled by webpack (imported in `Jbrowse2Image.js`), so deploying requires `npm run compile`, not a JSP-only copy.
