### PR TITLE
ZFIN-10371: Override auto-calculated fields in feature edit

### DIFF
--- a/source/org/zfin/gwt/curation/ui/feature/AbstractFeaturePresenter.java
+++ b/source/org/zfin/gwt/curation/ui/feature/AbstractFeaturePresenter.java
@@ -188,6 +188,27 @@ public abstract class AbstractFeaturePresenter implements HandlesError {
 
     }
 
+    /**
+     * True when the curator has recorded that the genome assembly location is not (yet) known,
+     * i.e. the "Assembly information not known as of" date is filled in. In that case the
+     * normally auto-calculated fields (reference sequence, deletion length) are entered by hand
+     * and must not be overwritten or cleared by the auto-calc routines.
+     */
+    protected boolean isAssemblyInfoNotKnown() {
+        String date = view.assemblyInfoDate.getText();
+        return date != null && !date.trim().isEmpty();
+    }
+
+    /**
+     * Auto-calculated fields are read-only while the assembly location is known and editable once
+     * the assembly location is marked as not known, so a curator can supply the values by hand.
+     */
+    public void updateAutoCalcEditability() {
+        boolean manualEntry = isAssemblyInfoNotKnown();
+        view.mutationDetailDnaView.setDeletionLengthEditable(manualEntry);
+        view.genomicMutationDetailView.setReferenceSequenceEditable(manualEntry);
+    }
+
     public void fetchReferenceSequenceIfReady() {
         String featureType = view.featureTypeBox.getSelected();
         if (featureType == null) return;
@@ -197,6 +218,9 @@ public abstract class AbstractFeaturePresenter implements HandlesError {
                 || featureType.equals(FeatureTypeEnum.INDEL.getName())
                 || featureType.equals(FeatureTypeEnum.MNV.getName());
         if (!needsRefSeq) return;
+
+        // Assembly location not known: the reference sequence is entered manually - leave it be.
+        if (isAssemblyInfoNotKnown()) return;
 
         String chromosome = view.featureChromosome.getText();
         String assembly = view.featureAssembly.getSelectedItemText();
@@ -208,10 +232,15 @@ public abstract class AbstractFeaturePresenter implements HandlesError {
             endLoc = view.featureEndLoc.getBoxValue();
         }
 
-        if (chromosome == null || chromosome.trim().isEmpty()) return;
-        if (assembly == null || assembly.trim().isEmpty()) return;
-        if (startLoc == null || endLoc == null) return;
-        if (!assembly.equals("GRCz11") && !assembly.equals("GRCz12tu")) return;
+        // Location incomplete: clear any previously auto-calculated value rather than keeping it stale.
+        boolean locationComplete = chromosome != null && !chromosome.trim().isEmpty()
+                && assembly != null && !assembly.trim().isEmpty()
+                && startLoc != null && endLoc != null
+                && (assembly.equals("GRCz11") || assembly.equals("GRCz12tu"));
+        if (!locationComplete) {
+            view.genomicMutationDetailView.setReferenceSequence("");
+            return;
+        }
 
         view.genomicMutationDetailView.setReferenceSequenceLoading();
 
@@ -240,9 +269,16 @@ public abstract class AbstractFeaturePresenter implements HandlesError {
                 || featureType.equals(FeatureTypeEnum.MNV.getName());
         if (!hasDeletionLength) return;
 
+        // Assembly location not known: the deletion length is entered manually - leave it be.
+        if (isAssemblyInfoNotKnown()) return;
+
         Integer start = view.featureStartLoc.getBoxValue();
         Integer end = view.featureEndLoc.getBoxValue();
-        if (start == null || end == null || end < start) return;
+        // Location incomplete: clear any previously auto-calculated value rather than keeping it stale.
+        if (start == null || end == null || end < start) {
+            view.mutationDetailDnaView.setDeletionLength(null);
+            return;
+        }
 
         view.mutationDetailDnaView.setDeletionLength(end - start + 1);
     }

--- a/source/org/zfin/gwt/curation/ui/feature/AbstractFeatureView.java
+++ b/source/org/zfin/gwt/curation/ui/feature/AbstractFeatureView.java
@@ -181,6 +181,11 @@ public abstract class AbstractFeatureView extends Composite implements Revertibl
 
     @UiHandler("assemblyInfoDate")
     void onKeyUpDate(@SuppressWarnings("unused") KeyUpEvent event) {
+        // Toggle the auto-calculated fields between read-only and manual entry. When switching
+        // back to auto (date cleared) re-run the calculations from the current location.
+        presenter.updateAutoCalcEditability();
+        presenter.autoCalcDeletionLength();
+        presenter.fetchReferenceSequenceIfReady();
         handleChanges();
     }
 
@@ -414,6 +419,7 @@ public abstract class AbstractFeatureView extends Composite implements Revertibl
         }
 
         presenter.updateMutagenOnFeatureTypeChange(featureTypeSelected);
+        presenter.updateAutoCalcEditability();
         presenter.autoCalcDeletionLength();
     }
 

--- a/source/org/zfin/gwt/curation/ui/feature/FeatureEditPresenter.java
+++ b/source/org/zfin/gwt/curation/ui/feature/FeatureEditPresenter.java
@@ -228,6 +228,10 @@ public class FeatureEditPresenter extends AbstractFeaturePresenter {
         mutationDetailPresenter.setDtoSet(dto.getTranscriptChangeDTOSet());
         view.genomicMutationDetailView.populateFields(dto.getFgmdChangeDTO(),dto.getFeatureType(),dto.getKnownInsertionSite());
 
+        // The assembly-info date is set above, so now reconcile whether the auto-calculated
+        // fields should be read-only (assembly known) or hand-editable (assembly not known).
+        updateAutoCalcEditability();
+
         // Recalculate dirty state after all fields are populated
         handleDirty();
     }

--- a/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.java
+++ b/source/org/zfin/gwt/curation/ui/feature/GenomicMutationDetailView.java
@@ -249,6 +249,15 @@ public class GenomicMutationDetailView extends AbstractViewComposite {
         seqReferenceSmall.setText("Loading...");
     }
 
+    /**
+     * When {@code editable} is true the (normally auto-calculated) reference sequence may be typed
+     * in by hand - used when the genome assembly location is not known.
+     */
+    public void setReferenceSequenceEditable(boolean editable) {
+        seqReference.setReadOnly(!editable);
+        seqReferenceSmall.setReadOnly(!editable);
+    }
+
     public void populateFields(FeatureGenomeMutationDetailChangeDTO dto, FeatureTypeEnum type, Boolean knownInsSite) {
         if (dto == null) {
             seqReference.setText("");

--- a/source/org/zfin/gwt/curation/ui/feature/MutationDetailDNAView.java
+++ b/source/org/zfin/gwt/curation/ui/feature/MutationDetailDNAView.java
@@ -253,6 +253,14 @@ public class MutationDetailDNAView extends AbstractViewComposite {
         minusBasePair.setNumber(length);
     }
 
+    /**
+     * When {@code editable} is true the (normally auto-calculated) deletion length may be typed
+     * in by hand - used when the genome assembly location is not known.
+     */
+    public void setDeletionLengthEditable(boolean editable) {
+        minusBasePair.setReadOnly(!editable);
+    }
+
     public MutationDetailDnaChangeDTO getDto() {
         if (!hasEnteredValues())
             return null;


### PR DESCRIPTION
If a feature does not have assembly information, allow the otherwise auto-calculated fields to be entered manually:
- Sequence of Reference
- deletion size