### PR TITLE
ZFIN-10358 Accept DOIs as pub IDs in GO loads

### DIFF
--- a/source/org/zfin/datatransfer/go/service/GafService.java
+++ b/source/org/zfin/datatransfer/go/service/GafService.java
@@ -661,6 +661,17 @@ public class GafService {
                 throw new GafValidationError("Goref ID is not known or loaded[" + pubMedID + "]", gafEntry);
             }
         }
+        else if (pubMedID.regionMatches(true, 0, "DOI:", 0, 4)) {
+            String doi = pubMedID.substring(4);
+            List<Publication> publications = RepositoryFactory.getPublicationRepository().getPublicationByDoi(doi);
+            if (publications == null || publications.isEmpty()) {
+                throw new GafValidationError("No pub found for DOI: " + pubMedID, gafEntry);
+            } else if (publications.size() == 1) {
+                publication = publications.getFirst();
+            } else {
+                throw new GafValidationError("Multiple pubs found for DOI: " + pubMedID, gafEntry);
+            }
+        }
 
         if (publication == null) {
             throw new GafValidationError("Unable to find pubmed ID[" + pubMedID + "]", gafEntry);

--- a/source/org/zfin/publication/repository/HibernatePublicationRepository.java
+++ b/source/org/zfin/publication/repository/HibernatePublicationRepository.java
@@ -865,6 +865,13 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
         return query.list();
     }
 
+    public List<Publication> getPublicationByDoi(String doi) {
+        String hql = "from Publication where doi = :doi";
+        Query<Publication> query = HibernateUtil.currentSession().createQuery(hql, Publication.class);
+        query.setParameter("doi", doi);
+        return query.list();
+    }
+
     @Override
     public int getNumberDirectPublications(String zdbID) {
         return Integer.parseInt(HibernateUtil.currentSession().createNativeQuery("""

--- a/source/org/zfin/publication/repository/PublicationRepository.java
+++ b/source/org/zfin/publication/repository/PublicationRepository.java
@@ -267,6 +267,8 @@ public interface PublicationRepository extends PaginationParameter {
 
     List<Publication> getPublicationByPmid(Integer pubMedID);
 
+    List<Publication> getPublicationByDoi(String doi);
+
     int getNumberDirectPublications(String zdbID);
 
     List<Ortholog> getOrthologListByPub(String pubID);


### PR DESCRIPTION
## ZFIN-10358 — Accept DOIs as pub IDs in GO loads

GO Central/Noctua annotations reference a publication in the GAF/GPAD `reference` column. Some pubs were switched from ZDB-PUB IDs to **DOIs** (allowed), and ZFIN's GO load then rejected them with `Unable to find pubmed ID[DOI:…]` because the resolver only understood `ZFIN:`, `PMID:`, and `GO_REF:`. These are typically pubs with no PMID (e.g. a thesis), where the DOI is the only usable citation.

### Change
`GafService.getPublication()` gains a `DOI:` branch that maps the DOI to a ZFIN publication via its `doi` field, only when the mapping is unambiguous — mirroring the existing PMID branch:
- 0 matches → reject (`No pub found for DOI:`)
- 1 match → use it
- >1 matches → reject (`Multiple pubs found for DOI:`)

Prefix match is case-insensitive; a genuinely unmappable DOI still rejects cleanly. Backed by a new `PublicationRepository.getPublicationByDoi(String)` (`from Publication where doi = :doi`), on the `publication.pub_doi` column.

This resolver is shared by GAF, GPAD (Noctua/GO Central), and FP-Inference loads, so the fix covers all of them.

### Verification
- Compiles (`gradle compileJava` — BUILD SUCCESSFUL).
- Against the DB, 7 of the 8 DOIs in the ticket map to a unique ZDB-PUB (e.g. `10.1007/s10695-006-9118-1` → `ZDB-PUB-071023-1`) and now resolve; the 1 not present in ZFIN still rejects, as expected.
- DOIs are not globally unique in `publication` (a few map to 2 pubs), so the >1 guard is required and exercised.

Note: mapping uses the `publication.pub_doi` column. A DOI that exists only as a `pub_db_xref` cross-reference (not on `pub_doi`) would still reject — can extend to that fallback if needed.
