### PR TITLE
ZFIN-10405 set job.output.basedir on ontology-load Jenkins jobs so re…

### DIFF
--- a/server_apps/jenkins/jobs/Load-Anatomy-Ontology/config.xml
+++ b/server_apps/jenkins/jobs/Load-Anatomy-Ontology/config.xml
@@ -31,7 +31,7 @@
             <command>cd $TARGETROOT/server_apps/data_transfer/LoadOntology</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Ant plugin="ant@1.2">
-            <targets>load-anatomy -DJobName=Load-Anatomy-Ontology</targets>
+            <targets>load-anatomy -DJobName=Load-Anatomy-Ontology -Djob.output.basedir=$TARGETROOT/server_apps/data_transfer/LoadOntology</targets>
             <buildFile>$SOURCEROOT/server_apps/data_transfer/LoadOntology/build.xml</buildFile>
         </hudson.tasks.Ant>
     </builders>

--- a/server_apps/jenkins/jobs/Load-Cell-Ontology/config.xml
+++ b/server_apps/jenkins/jobs/Load-Cell-Ontology/config.xml
@@ -31,7 +31,7 @@
             <command>cd $TARGETROOT/server_apps/data_transfer/LoadOntology</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Ant plugin="ant@1.2">
-            <targets>load-cell -DJobName=Load-Cell-Ontology</targets>
+            <targets>load-cell -DJobName=Load-Cell-Ontology -Djob.output.basedir=$TARGETROOT/server_apps/data_transfer/LoadOntology</targets>
             <buildFile>$SOURCEROOT/server_apps/data_transfer/LoadOntology/build.xml</buildFile>
         </hudson.tasks.Ant>
     </builders>

--- a/server_apps/jenkins/jobs/Load-Chebi-Ontology_m/config.xml
+++ b/server_apps/jenkins/jobs/Load-Chebi-Ontology_m/config.xml
@@ -31,7 +31,7 @@
             <command>cd $SOURCEROOT/server_apps/data_transfer/LoadOntology</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Ant plugin="ant@1.2">
-            <targets>load-chebi -DJobName=Load-Chebi-Ontology_m</targets>
+            <targets>load-chebi -DJobName=Load-Chebi-Ontology_m -Djob.output.basedir=$TARGETROOT/server_apps/data_transfer/LoadOntology</targets>
             <buildFile>$SOURCEROOT/server_apps/data_transfer/LoadOntology/build.xml</buildFile>
         </hudson.tasks.Ant>
     </builders>

--- a/server_apps/jenkins/jobs/Load-Disease-Ontology_d/config.xml
+++ b/server_apps/jenkins/jobs/Load-Disease-Ontology_d/config.xml
@@ -31,7 +31,7 @@
             <command>cd $TARGETROOT/server_apps/data_transfer/LoadOntology</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Ant plugin="ant@1.2">
-            <targets>load-disease -DJobName=Load-Disease-Ontology_d</targets>
+            <targets>load-disease -DJobName=Load-Disease-Ontology_d -Djob.output.basedir=$TARGETROOT/server_apps/data_transfer/LoadOntology</targets>
             <buildFile>$SOURCEROOT/server_apps/data_transfer/LoadOntology/build.xml</buildFile>
         </hudson.tasks.Ant>
     </builders>

--- a/server_apps/jenkins/jobs/Load-Eco-Ontology_d/config.xml
+++ b/server_apps/jenkins/jobs/Load-Eco-Ontology_d/config.xml
@@ -31,7 +31,7 @@
             <command>cd $TARGETROOT/server_apps/data_transfer/LoadOntology</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Ant plugin="ant@1.2">
-            <targets>load-eco -DJobName=Load-Eco-Ontology_d</targets>
+            <targets>load-eco -DJobName=Load-Eco-Ontology_d -Djob.output.basedir=$TARGETROOT/server_apps/data_transfer/LoadOntology</targets>
             <buildFile>$SOURCEROOT/server_apps/data_transfer/LoadOntology/build.xml</buildFile>
         </hudson.tasks.Ant>
     </builders>

--- a/server_apps/jenkins/jobs/Load-Gene-Ontology_d/config.xml
+++ b/server_apps/jenkins/jobs/Load-Gene-Ontology_d/config.xml
@@ -31,7 +31,7 @@
             <command>cd $TARGETROOT/server_apps/data_transfer/LoadOntology</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Ant plugin="ant@1.2">
-            <targets>load-gene -DJobName=Load-Gene-Ontology_d</targets>
+            <targets>load-gene -DJobName=Load-Gene-Ontology_d -Djob.output.basedir=$TARGETROOT/server_apps/data_transfer/LoadOntology</targets>
             <buildFile>$SOURCEROOT/server_apps/data_transfer/LoadOntology/build.xml</buildFile>
         </hudson.tasks.Ant>
     </builders>

--- a/server_apps/jenkins/jobs/Load-Measurements-And-Methods-Ontology_d/config.xml
+++ b/server_apps/jenkins/jobs/Load-Measurements-And-Methods-Ontology_d/config.xml
@@ -31,7 +31,7 @@
             <command>cd $TARGETROOT/server_apps/data_transfer/LoadOntology</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Ant plugin="ant@1.2">
-            <targets>load-mmo -DJobName=Load-Measurements-And-Methods-Ontology_d</targets>
+            <targets>load-mmo -DJobName=Load-Measurements-And-Methods-Ontology_d -Djob.output.basedir=$TARGETROOT/server_apps/data_transfer/LoadOntology</targets>
             <buildFile>$SOURCEROOT/server_apps/data_transfer/LoadOntology/build.xml</buildFile>
         </hudson.tasks.Ant>
     </builders>

--- a/server_apps/jenkins/jobs/Load-Mouse-Pathology-Ontology_d/config.xml
+++ b/server_apps/jenkins/jobs/Load-Mouse-Pathology-Ontology_d/config.xml
@@ -21,7 +21,7 @@
             <command>cd $TARGETROOT/server_apps/data_transfer/LoadOntology</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Ant plugin="ant@1.2">
-            <targets>load-mpath -DJobName=Load-Mouse-Pathology-Ontology_d</targets>
+            <targets>load-mpath -DJobName=Load-Mouse-Pathology-Ontology_d -Djob.output.basedir=$TARGETROOT/server_apps/data_transfer/LoadOntology</targets>
             <buildFile>$SOURCEROOT/server_apps/data_transfer/LoadOntology/build.xml</buildFile>
         </hudson.tasks.Ant>
     </builders>

--- a/server_apps/jenkins/jobs/Load-PATO-Ontology_d/config.xml
+++ b/server_apps/jenkins/jobs/Load-PATO-Ontology_d/config.xml
@@ -31,7 +31,7 @@
             <command>cd $TARGETROOT/server_apps/data_transfer/LoadOntology</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Ant plugin="ant@1.2">
-            <targets>load-quality -DJobName=Load-PATO-Ontology_d</targets>
+            <targets>load-quality -DJobName=Load-PATO-Ontology_d -Djob.output.basedir=$TARGETROOT/server_apps/data_transfer/LoadOntology</targets>
             <buildFile>$SOURCEROOT/server_apps/data_transfer/LoadOntology/build.xml</buildFile>
         </hudson.tasks.Ant>
     </builders>

--- a/server_apps/jenkins/jobs/Load-SO-Ontology_d/config.xml
+++ b/server_apps/jenkins/jobs/Load-SO-Ontology_d/config.xml
@@ -31,7 +31,7 @@
       <command>cd $TARGETROOT/server_apps/data_transfer/LoadOntology</command>
     </hudson.tasks.Shell>
     <hudson.tasks.Ant plugin="ant@1.2">
-      <targets>load-so -DJobName=Load-SO-Ontology_d</targets>
+      <targets>load-so -DJobName=Load-SO-Ontology_d -Djob.output.basedir=$TARGETROOT/server_apps/data_transfer/LoadOntology</targets>
       <buildFile>$SOURCEROOT/server_apps/data_transfer/LoadOntology/build.xml</buildFile>
     </hudson.tasks.Ant>
   </builders>

--- a/server_apps/jenkins/jobs/Load-Spatial-Ontology_d/config.xml
+++ b/server_apps/jenkins/jobs/Load-Spatial-Ontology_d/config.xml
@@ -31,7 +31,7 @@
             <command>cd $TARGETROOT/server_apps/data_transfer/LoadOntology</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Ant plugin="ant@1.2">
-            <targets>load-spatial -DJobName=Load-Spatial-Ontology_d</targets>
+            <targets>load-spatial -DJobName=Load-Spatial-Ontology_d -Djob.output.basedir=$TARGETROOT/server_apps/data_transfer/LoadOntology</targets>
             <buildFile>$SOURCEROOT/server_apps/data_transfer/LoadOntology/build.xml</buildFile>
         </hudson.tasks.Ant>
     </builders>

--- a/server_apps/jenkins/jobs/Load-Zeco-Ontology/config.xml
+++ b/server_apps/jenkins/jobs/Load-Zeco-Ontology/config.xml
@@ -31,7 +31,7 @@
             <command>cd $TARGETROOT/server_apps/data_transfer/LoadOntology</command>
         </hudson.tasks.Shell>
         <hudson.tasks.Ant plugin="ant@1.2">
-            <targets>load-zeco -DJobName=Load-Zeco-Ontology</targets>
+            <targets>load-zeco -DJobName=Load-Zeco-Ontology -Djob.output.basedir=$TARGETROOT/server_apps/data_transfer/LoadOntology</targets>
             <buildFile>$SOURCEROOT/server_apps/data_transfer/LoadOntology/build.xml</buildFile>
         </hudson.tasks.Ant>
     </builders>


### PR DESCRIPTION
…port artifacts are archived

buildFile was pointed at $SOURCEROOT (dcbca0073b, for the classpath), which moved ant's basedir and the report output under SOURCEROOT while the Jenkins workspace-relative artifact/HTML/email patterns look under $TARGETROOT. Pass -Djob.output.basedir=$TARGETROOT/server_apps/data_transfer/LoadOntology so the per-job report directory lands in the workspace, matching Load-Zeco-Taxonomy-Ontology.