### PR TITLE
ZFIN-10080 download OBO into job.output.basedir so the load reads the…

### DIFF
--- a/server_apps/data_transfer/LoadOntology/build.xml
+++ b/server_apps/data_transfer/LoadOntology/build.xml
@@ -467,7 +467,7 @@
         <echo>Downloading OBO file: ${oboFileURL}</echo>
 
         <java classname="org.zfin.ontology.datatransfer.DownloadOntology" fork="yes"
-              failonerror="true">
+              failonerror="true" dir="${job.output.basedir}">
             <classpath refid="combined.classpath"/>
             <arg value="-localOboFileName"/>
             <arg value="${run-directory}/${localOboFile}"/>


### PR DESCRIPTION
… freshly downloaded file

The DownloadOntology fork ran in ant basedir (SOURCEROOT) and wrote ./obo-files/<file>, but the LoadOntology fork runs with dir=job.output.basedir (TARGETROOT once the -Djob.output.basedir flag is set) and reads the same relative path. The two diverged, so the load picked up a stale obo in TARGETROOT/obo-files instead of the fresh download in SOURCEROOT/obo-files. Give the download fork the same working directory so both resolve obo-files to one tree; also lands the obo where Jenkins archives artifacts from.