### PR TITLE
ZFIN-10202: Adding DOCKER_ARCH env variable to enable arm64 images.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -857,6 +857,19 @@ task pushLatestGHCRImages() {
     }
 }
 
+task pushArm64Images() {
+    doLast {
+        println 'Pushing arm64 images to Github Container Registry'
+        for (container in containerList) {
+            println container
+            exec {
+                commandLine 'docker','push',"ghcr.io/zfin/zfin-"+container+":main-arm64"
+                workingDir 'docker/'
+            }
+        }
+    }
+}
+
 task dumpTomcatStack() {
     doLast {
         exec {

--- a/docker/compile/Dockerfile
+++ b/docker/compile/Dockerfile
@@ -1,5 +1,6 @@
-ARG ZFIN_RELEASE
-FROM ghcr.io/zfin/zfin-base:${ZFIN_RELEASE}
+ARG ZFIN_RELEASE=main
+ARG DOCKER_ARCH=''
+FROM ghcr.io/zfin/zfin-base:${ZFIN_RELEASE}${DOCKER_ARCH}
 
 USER root
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   base:
     build: ./base/
-    image: ghcr.io/zfin/zfin-base:${ZFIN_RELEASE}
+    image: ghcr.io/zfin/zfin-base:${ZFIN_RELEASE}${DOCKER_ARCH:-}
     environment:
       TZ: ${TZ}
   compile:
@@ -9,7 +9,8 @@ services:
       context: ./compile/
       args:
         ZFIN_RELEASE: ${ZFIN_RELEASE}
-    image: ghcr.io/zfin/zfin-compile:${ZFIN_RELEASE}
+        DOCKER_ARCH: ${DOCKER_ARCH:-}
+    image: ghcr.io/zfin/zfin-compile:${ZFIN_RELEASE}${DOCKER_ARCH:-}
     profiles:
       - compile
     environment:
@@ -73,7 +74,7 @@ services:
       - gradle_cache:/home/gradle/.gradle
   db:
     build: ./postgresql/
-    image: ghcr.io/zfin/zfin-db:${ZFIN_RELEASE}
+    image: ghcr.io/zfin/zfin-db:${ZFIN_RELEASE}${DOCKER_ARCH:-}
     # Memory settings sized down from a prior 16g shared_buffers / 8g work_mem
     # configuration that contributed to repeated container OOMs during heavy
     # DIH workloads on a 32g host. Dial back up if you have a clearly RAM-rich
@@ -97,7 +98,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
   solr:
     build: ./solr/
-    image: ghcr.io/zfin/zfin-solr:${ZFIN_RELEASE}
+    image: ghcr.io/zfin/zfin-solr:${ZFIN_RELEASE}${DOCKER_ARCH:-}
     # Cap memory at heap + ~4g headroom (direct buffers, metaspace, jit code
     # cache, stack, native libs). Without this the kernel chooses which
     # container to OOM when the host gets tight, and Solr is always the
@@ -136,7 +137,7 @@ services:
   httpd:
     hostname: zfin.org
     build: ./httpd/
-    image: ghcr.io/zfin/zfin-httpd:${ZFIN_RELEASE}
+    image: ghcr.io/zfin/zfin-httpd:${ZFIN_RELEASE}${DOCKER_ARCH:-}
     environment:
       LETSENCRYPT_HOST: ${DOCKER_VIRTUAL_HOST}
       VIRTUAL_HOST: ${DOCKER_VIRTUAL_HOST}
@@ -169,7 +170,7 @@ services:
       - www_data:/opt/zfin/www_homes/zfin.org
   tomcat:
     build: ./tomcat/
-    image: ghcr.io/zfin/zfin-tomcat:${ZFIN_RELEASE}
+    image: ghcr.io/zfin/zfin-tomcat:${ZFIN_RELEASE}${DOCKER_ARCH:-}
     environment:
       CATALINA_BASE: /opt/zfin/catalina_bases/zfin.org
       INSTANCE: docker
@@ -242,7 +243,8 @@ services:
       context: ./jenkins/
       args:
         ZFIN_RELEASE: ${ZFIN_RELEASE}
-    image: ghcr.io/zfin/zfin-jenkins:${ZFIN_RELEASE}
+        DOCKER_ARCH: ${DOCKER_ARCH:-}
+    image: ghcr.io/zfin/zfin-jenkins:${ZFIN_RELEASE}${DOCKER_ARCH:-}
     ports:
       - "${DOCKER_JENKINS_HTTP_PORT:-9499-9509}:9499"
     environment:
@@ -288,7 +290,7 @@ services:
       - gradle_cache:/home/gradle/.gradle
   fail2ban:
     build: ./fail2ban/
-    image: ghcr.io/zfin/zfin-fail2ban:${ZFIN_RELEASE}
+    image: ghcr.io/zfin/zfin-fail2ban:${ZFIN_RELEASE}${DOCKER_ARCH:-}
     cap_add:
       - NET_ADMIN
       - NET_RAW
@@ -307,7 +309,7 @@ services:
       context: ./elasticsearch/
       args:
         ELK_VERSION: ${ELK_VERSION}
-    image: ghcr.io/zfin/zfin-elasticsearch:${ZFIN_RELEASE}
+    image: ghcr.io/zfin/zfin-elasticsearch:${ZFIN_RELEASE}${DOCKER_ARCH:-}
     profiles:
       - logging
     environment:
@@ -325,7 +327,7 @@ services:
       context: ./filebeat/
       args:
         ELK_VERSION: ${ELK_VERSION}
-    image: ghcr.io/zfin/zfin-filebeat:${ZFIN_RELEASE}
+    image: ghcr.io/zfin/zfin-filebeat:${ZFIN_RELEASE}${DOCKER_ARCH:-}
     profiles:
       - logging
     environment:
@@ -337,7 +339,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro      
   metricbeat:
-    image: ghcr.io/zfin/zfin-metricbeat:${ZFIN_RELEASE}  
+    image: ghcr.io/zfin/zfin-metricbeat:${ZFIN_RELEASE}${DOCKER_ARCH:-}
     build:
       context: ./metricbeat/
       args:
@@ -358,7 +360,7 @@ services:
       context: ./kibana/
       args:
         ELK_VERSION: ${ELK_VERSION}
-    image: ghcr.io/zfin/zfin-kibana:${ZFIN_RELEASE}
+    image: ghcr.io/zfin/zfin-kibana:${ZFIN_RELEASE}${DOCKER_ARCH:-}
     profiles:
       - logging
     environment:

--- a/docker/jenkins/Dockerfile
+++ b/docker/jenkins/Dockerfile
@@ -1,5 +1,6 @@
 ARG ZFIN_RELEASE=main
-FROM ghcr.io/zfin/zfin-base:${ZFIN_RELEASE}
+ARG DOCKER_ARCH=''
+FROM ghcr.io/zfin/zfin-base:${ZFIN_RELEASE}${DOCKER_ARCH}
 
 USER root
 


### PR DESCRIPTION
Added a DOCKER_ARCH environment variable. Add 'DOCKER_ARCH='-arm64' to your .env for an instance on Mac to use. (Note: The '-' is required to make it work because of limitations in Docker labeling/docker compose.)