### PR TITLE
ZFIN-10443: match CHEBI CAS xrefs case-insensitively in the CTD load

### DIFF
--- a/console.gradle
+++ b/console.gradle
@@ -122,7 +122,14 @@ task imageThumbnailFixTask(type: JavaExec) {
 task runMeshChebiGenerator(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'org.zfin.datatransfer.ctd.LoadCtdData'
+    // LoadCtdData writes its downloads and its <JobName> report directory relative to the working
+    // directory, which is the git checkout because Jenkins runs "cd $SOURCEROOT && gradle
+    // runMeshChebiGenerator". The artifact archiver, the html publisher and the email's
+    // ${FILE,path=...} all read workspace-relative paths, and the workspace is $TARGETROOT, so run
+    // from there instead. -Djob.output.basedir overrides it the way the ontology loads do.
+    workingDir = file(System.getProperty('job.output.basedir') ?: System.getenv('TARGETROOT') ?: projectDir)
     doFirst {
+        workingDir.mkdirs()
         args JobName
     }
 }

--- a/server_apps/jenkins/jobs/Load-CTD-Data_m/config.xml
+++ b/server_apps/jenkins/jobs/Load-CTD-Data_m/config.xml
@@ -22,15 +22,18 @@
     </builders>
     <publishers>
         <hudson.tasks.ArtifactArchiver>
-            <artifacts>CTD*</artifacts>
+            <!-- the load writes everything into <workspace>/Load-CTD-Data_m; skip the full CTD
+                 chemicals dump, which is a bulky input rather than a result -->
+            <artifacts>Load-CTD-Data_m/*</artifacts>
+            <excludes>Load-CTD-Data_m/CTD_chemicals.csv</excludes>
             <latestOnly>false</latestOnly>
-            <allowEmptyArchive>true</allowEmptyArchive>
+            <allowEmptyArchive>false</allowEmptyArchive>
         </hudson.tasks.ArtifactArchiver>
         <htmlpublisher.HtmlPublisher plugin="htmlpublisher@1.3">
             <reportTargets>
                 <htmlpublisher.HtmlPublisherTarget>
                     <reportName>Report</reportName>
-                    <reportDir>LoadCTD-Data_m</reportDir>
+                    <reportDir>Load-CTD-Data_m</reportDir>
                     <reportFiles>statistics.html</reportFiles>
                     <keepAll>false</keepAll>
                     <allowMissing>true</allowMissing>
@@ -45,7 +48,7 @@
                     <email>
                         <recipientList>@SUCCESS-RECIPIENT-LIST@</recipientList>
                         <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-                        <body>${FILE,path=&quot;statistics.html&quot;}</body>
+                        <body>${FILE,path=&quot;Load-CTD-Data_m/statistics.html&quot;}</body>
                         <sendToDevelopers>false</sendToDevelopers>
                         <sendToRequester>false</sendToRequester>
                         <includeCulprits>false</includeCulprits>
@@ -77,7 +80,7 @@
             <contentType>default</contentType>
             <defaultSubject>[Jenkins][${INSTANCE}]: ${PROJECT_NAME}: ${BUILD_STATUS}</defaultSubject>
             <defaultContent>$DEFAULT_CONTENT</defaultContent>
-            <attachmentsPattern>LoadCTD-Data_m/*</attachmentsPattern>
+            <attachmentsPattern>Load-CTD-Data_m/statistics.*</attachmentsPattern>
             <presendScript></presendScript>
             <attachBuildLog>false</attachBuildLog>
             <compressBuildLog>false</compressBuildLog>

--- a/source/org/zfin/datatransfer/ctd/CreateMeshChebiMappingFile.java
+++ b/source/org/zfin/datatransfer/ctd/CreateMeshChebiMappingFile.java
@@ -250,8 +250,9 @@ public class CreateMeshChebiMappingFile extends AbstractScriptWrapper {
             MeshCasChebiRelation relation = new MeshCasChebiRelation();
             relation.setChebi(reference.getTerm().getOboID());
             relation.setChebiName(reference.getTerm().getTermName());
-            if (reference.getPrefix().equals("CAS")) {
-                relation.setCas(reference.getPrefix() + ":" + reference.getAccessionNumber());
+            // CTD reports CAS IDs as CAS:<accession>, so normalize the obo prefix casing to match
+            if (reference.getPrefix().equalsIgnoreCase("CAS")) {
+                relation.setCas("CAS:" + reference.getAccessionNumber());
             }
             relations.add(relation);
         });

--- a/source/org/zfin/datatransfer/ctd/LoadCtdData.java
+++ b/source/org/zfin/datatransfer/ctd/LoadCtdData.java
@@ -42,6 +42,9 @@ public class LoadCtdData extends AbstractScriptWrapper {
     }
 
     private String jobName;
+    // every file this load writes -- downloads, mapping csvs and the statistics report -- goes in
+    // here, so a single directory under the Jenkins workspace holds everything that gets archived
+    private File outputDirectory;
     private MeshCasChebiMappings mapping = new MeshCasChebiMappings();
 
     public static void main(String[] arguments) throws IOException {
@@ -55,6 +58,10 @@ public class LoadCtdData extends AbstractScriptWrapper {
 
     private void execute() throws IOException {
         initAll();
+        outputDirectory = new File(jobName);
+        if (!outputDirectory.isDirectory() && !outputDirectory.mkdirs()) {
+            throw new IOException("Could not create output directory " + outputDirectory.getAbsolutePath());
+        }
         dao = new MeshChebiDAO(HibernateUtil.currentSession());
         vocabularyDao = new VocabularyDAO(HibernateUtil.currentSession());
         vocabularyTermDao = new VocabularyTermDAO(HibernateUtil.currentSession());
@@ -74,7 +81,7 @@ public class LoadCtdData extends AbstractScriptWrapper {
         Map<String, Object> summary = new LinkedHashMap<>();
         reportEntries.forEach(reportEntry -> summary.put(reportEntry.entryName, reportEntry.entryValue));
         stats.addSummaryTable("Statistics", summary);
-        stats.writeFiles(new File(jobName), "statistics");
+        stats.writeFiles(outputDirectory, "statistics");
 /*
         reportOneToNRelations();
 */
@@ -261,7 +268,7 @@ public class LoadCtdData extends AbstractScriptWrapper {
         String fileName = "CTD_references.csv";
         String url = "https://ctdbase.org/query.go?type=reference&d-1340579-e=1&action=Search&taxon=TAXON%3A7955&reviewStatus=curated&6578706f7274=1";
         try {
-            downloadedPublicationFile = downloadService.downloadFile(new File(fileName), new URL(url), false);
+            downloadedPublicationFile = downloadService.downloadFile(outputFile(fileName), new URL(url), false);
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
@@ -271,10 +278,14 @@ public class LoadCtdData extends AbstractScriptWrapper {
         String fileName = "CTD_chemicals.csv";
         String url = "https://ctdbase.org/reports/" + fileName + ".gz";
         try {
-            downloadedChemicalFile = downloadService.downloadFile(new File(fileName), new URL(url), false);
+            downloadedChemicalFile = downloadService.downloadFile(outputFile(fileName), new URL(url), false);
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private File outputFile(String fileName) {
+        return new File(outputDirectory, fileName);
     }
 
     private MeshChebiDAO dao;
@@ -327,7 +338,7 @@ public class LoadCtdData extends AbstractScriptWrapper {
     }
 
     private void writeOutMultipleFile(List<String> multipleList, String fileName) {
-        Path file = Path.of(fileName);
+        Path file = outputFile(fileName).toPath();
         StringBuffer buffer = new StringBuffer();
         multipleList.forEach(id -> {
             buffer.append(id);
@@ -369,8 +380,8 @@ public class LoadCtdData extends AbstractScriptWrapper {
         return record.toString();
     }
 
-    private static void writeOutFile(Map<String, List<String>> map, String fileName) {
-        Path file = Path.of(fileName);
+    private void writeOutFile(Map<String, List<String>> map, String fileName) {
+        Path file = outputFile(fileName).toPath();
         StringBuffer buffer = new StringBuffer();
         map.forEach((s, strings) -> {
             buffer.append(s + "," + String.join("|", strings));
@@ -383,8 +394,8 @@ public class LoadCtdData extends AbstractScriptWrapper {
         }
     }
 
-    private static void writeOutFile(Collection<String> list, String fileName) {
-        Path file = Path.of(fileName);
+    private void writeOutFile(Collection<String> list, String fileName) {
+        Path file = outputFile(fileName).toPath();
         StringBuffer buffer = new StringBuffer();
         list.forEach(id -> {
             buffer.append(id);
@@ -397,8 +408,8 @@ public class LoadCtdData extends AbstractScriptWrapper {
         }
     }
 
-    private static void writeFile(Collection<MeshCasChebiRelation> list, String fileName) {
-        Path file = Path.of(fileName);
+    private void writeFile(Collection<MeshCasChebiRelation> list, String fileName) {
+        Path file = outputFile(fileName).toPath();
         StringBuffer buffer = new StringBuffer();
         list.forEach(relation -> {
             StringJoiner joiner = new StringJoiner("\t");
@@ -417,8 +428,8 @@ public class LoadCtdData extends AbstractScriptWrapper {
         }
     }
 
-    private static void writeMappingToFile(Collection<MeshChebiMapping> list, String fileName) {
-        Path file = Path.of(fileName);
+    private void writeMappingToFile(Collection<MeshChebiMapping> list, String fileName) {
+        Path file = outputFile(fileName).toPath();
         StringBuffer buffer = new StringBuffer();
         list.forEach(relation -> {
             StringJoiner joiner = new StringJoiner("\t");
@@ -436,8 +447,8 @@ public class LoadCtdData extends AbstractScriptWrapper {
         }
     }
 
-    private static void writeOneToOneFile1(Collection<MeshChebiMapping> list, String fileName) {
-        Path file = Path.of(fileName);
+    private void writeOneToOneFile1(Collection<MeshChebiMapping> list, String fileName) {
+        Path file = outputFile(fileName).toPath();
         StringBuffer buffer = new StringBuffer();
         list.forEach(relation -> {
             StringJoiner joiner = new StringJoiner("\t");

--- a/source/org/zfin/datatransfer/ctd/LoadCtdData.java
+++ b/source/org/zfin/datatransfer/ctd/LoadCtdData.java
@@ -287,14 +287,21 @@ public class LoadCtdData extends AbstractScriptWrapper {
     private List<MeshCasChebiRelation> getChebiToCasMapping() {
 
         List<TermExternalReference> referenceList = getOntologyRepository().getAllCasReferences();
+        if (referenceList.isEmpty()) {
+            // without any CAS xrefs the mapping below is empty, which would delete every
+            // existing mesh-chebi mapping record, so stop before that happens
+            throw new RuntimeException("No CAS cross references found on CHEBI terms. " +
+                "Check that the CHEBI ontology load populated term_xref with CAS accessions.");
+        }
         List<MeshCasChebiRelation> relations = new ArrayList<>();
 
         referenceList.forEach(reference -> {
             MeshCasChebiRelation relation = new MeshCasChebiRelation();
             relation.setChebi(reference.getTerm().getOboID());
             relation.setChebiName(reference.getTerm().getTermName());
-            if (reference.getPrefix().equals("CAS")) {
-                relation.setCas(reference.getPrefix() + ":" + reference.getAccessionNumber());
+            // CTD reports CAS IDs as CAS:<accession>, so normalize the obo prefix casing to match
+            if (reference.getPrefix().equalsIgnoreCase("CAS")) {
+                relation.setCas("CAS:" + reference.getAccessionNumber());
             }
             relations.add(relation);
         });

--- a/source/org/zfin/ontology/repository/HibernateOntologyRepository.java
+++ b/source/org/zfin/ontology/repository/HibernateOntologyRepository.java
@@ -1337,13 +1337,15 @@ public class HibernateOntologyRepository implements OntologyRepository {
     public Map<String, List<TermExternalReference>> getAllTermExternalReference() {
         if (casMap != null)
             return casMap;
+        // the prefix is taken verbatim from the obo xrefs, and its case varies by ontology release
+        // (ChEBI switched from 'CAS:' to 'cas:'), so match and key on the upper-cased prefix
         String hql = """
-            from TermExternalReference where prefix in (:prefix)
+            from TermExternalReference where upper(prefix) in (:prefix)
             """;
         org.hibernate.query.Query<TermExternalReference> query = HibernateUtil.currentSession().createQuery(hql, TermExternalReference.class);
         query.setParameterList("prefix", List.of("CAS", "MESH"));
         List<TermExternalReference> list = query.list();
-        casMap = list.stream().collect(groupingBy(TermExternalReference::getPrefix));
+        casMap = list.stream().collect(groupingBy(reference -> reference.getPrefix().toUpperCase()));
         return casMap;
     }
 
@@ -1375,7 +1377,7 @@ public class HibernateOntologyRepository implements OntologyRepository {
 
     @Override
     public List<TermExternalReference> getAllCasReferences() {
-        return getAllTermExternalReference().get("CAS");
+        return getAllTermExternalReference().getOrDefault("CAS", List.of());
     }
 
     @Override


### PR DESCRIPTION
ChEBI now emits its OBO xrefs as 'cas:' rather than 'CAS:', and term_xref stores the prefix verbatim, so getAllCasReferences() returned null and load-ctd-data_m died with an NPE in getChebiToCasMapping().

Match and key on the upper-cased prefix, and always build the join key with the canonical 'CAS:' prefix so the CHEBI side still lines up with the CAS IDs from CTD_chemicals.csv. Without that second part the load would have joined nothing and deleted every mesh_chebi_mapping record, so also fail fast when no CAS xrefs are found at all.