### PR TITLE
ZFIN-10435: Fix three 500s on term, publication, and phenotype pages

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -78,7 +78,8 @@ services:
     # configuration that contributed to repeated container OOMs during heavy
     # DIH workloads on a 32g host. Dial back up if you have a clearly RAM-rich
     # host and a workload that benefits.
-    command: -c 'max_connections=7500' -c 'shared_buffers=4GB' -c 'huge_pages=try' -c 'temp_buffers=256MB' -c 'work_mem=256MB' -c 'maintenance_work_mem=1GB' -c 'max_wal_size=10GB' -c 'timezone=America/Los_Angeles' -c 'shared_preload_libraries="pg_stat_statements"'
+    # work_mem is 128MB, paired with the 2g shm_size below -- the two have to be chosen together.
+    command: -c 'max_connections=7500' -c 'shared_buffers=4GB' -c 'huge_pages=try' -c 'temp_buffers=256MB' -c 'work_mem=128MB' -c 'maintenance_work_mem=1GB' -c 'max_wal_size=10GB' -c 'timezone=America/Los_Angeles' -c 'shared_preload_libraries="pg_stat_statements"'
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD_FILE: /run/secrets/pg_pass
@@ -86,7 +87,7 @@ services:
       POSTGRES_DB: zfindb
       POSTGRES_HOST_AUTH_METHOD: trust
       TZ: ${TZ}
-    shm_size: 1g
+    shm_size: 2g
     ports:
       - "${DOCKER_DB_PORT:-127.0.0.1:5432}:5432"
     volumes:

--- a/source/org/zfin/publication/repository/HibernatePublicationRepository.java
+++ b/source/org/zfin/publication/repository/HibernatePublicationRepository.java
@@ -955,10 +955,18 @@ public class HibernatePublicationRepository extends PaginationUtil implements Pu
             """;
         Query query = session.createQuery(hql);
         query.setParameter("pubID", pubID);
-        setTupleResultTransformer(query, (Object[] tuple, String[] aliases) -> tuple[0]);
 
-        PaginationResult<Ortholog> paginationResult = PaginationResultFactory.createResultFromScrollableResultAndClose(
-            searchBean.getFirstRecordOnPage() - 1, searchBean.getLastRecordOnPage(), query.scroll());
+        // list(), not scroll(): a tuple transformer combined with scroll() throws
+        // "You can't operate on a closed ResultSet" under Hibernate 6 -- see the note on
+        // HibernateUpgradeHelper.setTupleResultAndListTransformer. An ortholog list for one
+        // publication is small, so paginating the materialized list costs nothing.
+        List<Ortholog> orthologs = new ArrayList<>(new LinkedHashSet<>(
+            (List<Ortholog>) setTupleResultTransformer(query, (Object[] tuple, String[] aliases) -> tuple[0]).list()));
+
+        int fromIndex = Math.min(Math.max(searchBean.getFirstRecordOnPage() - 1, 0), orthologs.size());
+        int toIndex = Math.min(Math.max(searchBean.getLastRecordOnPage(), fromIndex), orthologs.size());
+        PaginationResult<Ortholog> paginationResult =
+            new PaginationResult<>(orthologs.size(), orthologs.subList(fromIndex, toIndex));
         paginationResult.setStart(searchBean.getFirstRecord());
 
         return paginationResult;

--- a/source/org/zfin/ui/repository/HibernateDiseasePageRepository.java
+++ b/source/org/zfin/ui/repository/HibernateDiseasePageRepository.java
@@ -19,7 +19,6 @@ import org.zfin.ontology.OmimPhenotypeDisplay;
 import org.zfin.repository.PaginationResultFactory;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
@@ -29,22 +28,25 @@ import static org.zfin.util.ZfinCollectionUtils.firstInEachGrouping;
 @Log4j2
 public class HibernateDiseasePageRepository implements DiseasePageRepository {
 
+    // "Including substructures" predicate: the row's own term is the queried term or any of its
+    // descendants. all_term_contains (TransitiveClosure) includes the self row, so this covers the
+    // direct matches too, and it binds exactly ONE parameter regardless of how many rows match.
+    //
+    // Do NOT go back to fetching the matching row ids in Java and binding them with `id in :ids`:
+    // a wide term produces tens of thousands of ids and Postgres rejects the statement outright --
+    // "PreparedStatement can have at most 65,535 parameters ... Given query has 86,604 parameters".
+    // Eleven terms currently exceed that limit, which made these endpoints 500 in production.
+    private static final String DESCENDANT_TERMS =
+        " in (select closure.child.zdbID from TransitiveClosure as closure where closure.root.zdbID = :ancestorTermID) ";
+
     @Override
     public PaginationResult<OmimPhenotypeDisplay> getGenesInvolved(GenericTerm term, Pagination pagination, boolean includeChildren) {
         PaginationBean bean = PaginationBean.getPaginationBean(pagination);
-        List<Long> matchingIds = null;
-        if (includeChildren) {
-            matchingIds = findIdsByAncestor("ui.omim_phenotype_display", "opd_id", "opd_ancestor_term_ids", term.getZdbID());
-            if (matchingIds.isEmpty()) {
-                return new PaginationResult<>(0, Collections.emptyList());
-            }
-        }
-        String hql;
+        String hql = "select omimPhenotype from OmimPhenotypeDisplay as omimPhenotype join omimPhenotype.zfinGene as zfinGene ";
         if (!includeChildren) {
-            hql = "select omimPhenotype from OmimPhenotypeDisplay as omimPhenotype join omimPhenotype.zfinGene as zfinGene where omimPhenotype.disease = :disease ";
+            hql += "where omimPhenotype.disease = :disease ";
         } else {
-            hql = "select omimPhenotype from OmimPhenotypeDisplay as omimPhenotype join omimPhenotype.zfinGene as zfinGene " +
-                  "where omimPhenotype.id in :ids ";
+            hql += "where omimPhenotype.disease.zdbID" + DESCENDANT_TERMS;
         }
         if (MapUtils.isNotEmpty(pagination.getFilterMap())) {
             for (var entry : pagination.getFilterMap().entrySet()) {
@@ -55,7 +57,7 @@ public class HibernateDiseasePageRepository implements DiseasePageRepository {
         hql += "order by omimPhenotype.homoSapiensGene.symbol";
         Query<OmimPhenotypeDisplay> query = HibernateUtil.currentSession().createQuery(hql, OmimPhenotypeDisplay.class);
         if (includeChildren) {
-            query.setParameterList("ids", matchingIds);
+            query.setParameter("ancestorTermID", term.getZdbID());
         } else {
             query.setParameter("disease", term);
         }
@@ -65,36 +67,19 @@ public class HibernateDiseasePageRepository implements DiseasePageRepository {
     @Override
     public PaginationResult<FishStatistics> getPhenotype(GenericTerm term, Pagination pagination, Boolean includeChildren, Boolean isIncludeNormalPhenotype) {
         PaginationBean bean = PaginationBean.getPaginationBean(pagination);
-        List<Long> matchingIds = null;
-        if (includeChildren) {
-            matchingIds = findIdsByAncestor("ui.term_phenotype_display", "tpd_id", "tpd_ancestor_term_ids", term.getZdbID());
-            if (matchingIds.isEmpty()) {
-                return new PaginationResult<>(0, Collections.emptyList());
-            }
-        }
-        String hql;
+        String hql = """
+            select distinct fishStat from FishStatistics as fishStat
+            left join fetch fishStat.fish
+            left join fetch fishStat.term
+            left join fetch fishStat.figure
+            left join fetch fishStat.publication
+            left join fetch fishStat.affectedGenes
+            left join fetch fishStat.phenotypeStatements as phenoStats
+            """;
         if (!includeChildren) {
-            hql = """
-                select distinct fishStat from FishStatistics as fishStat
-                left join fetch fishStat.fish
-                left join fetch fishStat.term
-                left join fetch fishStat.figure
-                left join fetch fishStat.publication
-                left join fetch fishStat.affectedGenes
-                left join fetch fishStat.phenotypeStatements as phenoStats
-                where fishStat.term = :term
-                """;
+            hql += "where fishStat.term = :term ";
         } else {
-            hql = """
-                select distinct fishStat from FishStatistics as fishStat
-                left join fetch fishStat.fish
-                left join fetch fishStat.term
-                left join fetch fishStat.figure
-                left join fetch fishStat.publication
-                left join fetch fishStat.affectedGenes
-                left join fetch fishStat.phenotypeStatements as phenoStats
-                where fishStat.id in :ids
-                   """;
+            hql += "where fishStat.term.zdbID" + DESCENDANT_TERMS;
         }
         if (!isIncludeNormalPhenotype) {
             hql += "AND phenoStats.tag = 'abnormal'";
@@ -109,7 +94,7 @@ public class HibernateDiseasePageRepository implements DiseasePageRepository {
                "fishStat.fish.zdbID, fishStat.figure.zdbID, fishStat.publication.zdbID, fishStat.term.zdbID";
         Query<FishStatistics> query = HibernateUtil.currentSession().createQuery(hql, FishStatistics.class);
         if (includeChildren) {
-            query.setParameterList("ids", matchingIds);
+            query.setParameter("ancestorTermID", term.getZdbID());
         } else {
             query.setParameter("term", term);
         }
@@ -119,19 +104,11 @@ public class HibernateDiseasePageRepository implements DiseasePageRepository {
     @Override
     public PaginationResult<FishModelDisplay> getFishDiseaseModels(GenericTerm term, Pagination pagination, boolean includeChildren) {
         PaginationBean bean = PaginationBean.getPaginationBean(pagination);
-        List<Long> matchingIds = null;
-        if (includeChildren) {
-            matchingIds = findIdsByAncestor("ui.zebrafish_models_display", "zmd_id", "zmd_ancestor_term_ids", term.getZdbID());
-            if (matchingIds.isEmpty()) {
-                return new PaginationResult<>(0, Collections.emptyList());
-            }
-        }
-        String hql;
+        String hql = "select fishModelDisplay from FishModelDisplay as fishModelDisplay ";
         if (!includeChildren) {
-            hql = "select fishModelDisplay from FishModelDisplay as fishModelDisplay where fishModelDisplay.disease = :term ";
+            hql += "where fishModelDisplay.disease = :term ";
         } else {
-            hql = "select fishModelDisplay from FishModelDisplay as fishModelDisplay " +
-                  "where fishModelDisplay.id in :ids ";
+            hql += "where fishModelDisplay.disease.zdbID" + DESCENDANT_TERMS;
         }
         if (MapUtils.isNotEmpty(pagination.getFilterMap())) {
             for (var entry : pagination.getFilterMap().entrySet()) {
@@ -143,7 +120,7 @@ public class HibernateDiseasePageRepository implements DiseasePageRepository {
                "fishModelDisplay.fish.zdbID, fishModelDisplay.experiment.zdbID, fishModelDisplay.singlePublication.zdbID, fishModelDisplay.disease.zdbID ";
         Query<FishModelDisplay> query = HibernateUtil.currentSession().createQuery(hql, FishModelDisplay.class);
         if (includeChildren) {
-            query.setParameterList("ids", matchingIds);
+            query.setParameter("ancestorTermID", term.getZdbID());
         } else {
             query.setParameter("term", term);
         }
@@ -152,26 +129,17 @@ public class HibernateDiseasePageRepository implements DiseasePageRepository {
 
     @Override
     public List<ChebiFishModelDisplay> getFishDiseaseChebiModels(GenericTerm term, boolean includeChildren) {
-        List<Long> matchingIds = null;
-        if (includeChildren) {
-            matchingIds = findIdsByAncestor("ui.zebrafish_models_chebi_association", "omca_id", "omca_ancestor_term_ids", term.getZdbID());
-            if (matchingIds.isEmpty()) {
-                return Collections.emptyList();
-            }
-        }
-        String hql;
+        String hql = "select chebiDisplay from ChebiFishModelDisplay as chebiDisplay ";
         if (!includeChildren) {
-            hql = "select chebiDisplay from ChebiFishModelDisplay as chebiDisplay " +
-                  "where chebiDisplay.chebi = :chebiTerm ";
+            hql += "where chebiDisplay.chebi = :chebiTerm ";
         } else {
-            hql = "select chebiDisplay from ChebiFishModelDisplay as chebiDisplay " +
-                  "where chebiDisplay.id in :ids ";
+            hql += "where chebiDisplay.chebi.zdbID" + DESCENDANT_TERMS;
         }
         hql += " order by chebiDisplay.fishModelDisplay.order, chebiDisplay.fishModelDisplay.fish.order, upper(chebiDisplay.fishModelDisplay.fish.displayName), " +
-               "chebiDisplay.fishModelDisplay.fish.zdbID, chebiDisplay.fishModelDisplay.experiment.zdbID, chebiDisplay.fishModelDisplay.singlePublication.zdbID, chebiDisplay.term.zdbID ";
+               "chebiDisplay.fishModelDisplay.fish.zdbID, chebiDisplay.fishModelDisplay.experiment.zdbID, chebiDisplay.fishModelDisplay.singlePublication.zdbID, chebiDisplay.chebi.zdbID ";
         Query<ChebiFishModelDisplay> query = HibernateUtil.currentSession().createQuery(hql, ChebiFishModelDisplay.class);
         if (includeChildren) {
-            query.setParameterList("ids", matchingIds);
+            query.setParameter("ancestorTermID", term.getZdbID());
         } else {
             query.setParameter("chebiTerm", term);
         }
@@ -190,24 +158,16 @@ public class HibernateDiseasePageRepository implements DiseasePageRepository {
     @Override
     public PaginationResult<ChebiPhenotypeDisplay> getPhenotypeChebi(GenericTerm term, Pagination pagination, String filterPhenotype, boolean includeChildren) {
         PaginationBean bean = PaginationBean.getPaginationBean(pagination);
-        List<Long> matchingIds = null;
-        if (includeChildren) {
-            matchingIds = findIdsByAncestor("ui.chebi_phenotype_display", "cpd_id", "cpd_ancestor_term_ids", term.getZdbID());
-            if (matchingIds.isEmpty()) {
-                return new PaginationResult<>(0, Collections.emptyList());
-            }
-        }
-        String hql;
         String fetchJoins = " join fetch chebiPhenotype.fish" +
                 " join fetch chebiPhenotype.term" +
                 " left join fetch chebiPhenotype.figure" +
                 " left join fetch chebiPhenotype.publication" +
                 " left join fetch chebiPhenotype.experiment";
+        String hql = "select chebiPhenotype from ChebiPhenotypeDisplay as chebiPhenotype" + fetchJoins;
         if (!includeChildren) {
-            hql = "select chebiPhenotype from ChebiPhenotypeDisplay as chebiPhenotype" + fetchJoins + " where chebiPhenotype.term = :term ";
+            hql += " where chebiPhenotype.term = :term ";
         } else {
-            hql = "select chebiPhenotype from ChebiPhenotypeDisplay as chebiPhenotype" + fetchJoins +
-                  " where chebiPhenotype.id in :ids ";
+            hql += " where chebiPhenotype.term.zdbID" + DESCENDANT_TERMS;
         }
         if (MapUtils.isNotEmpty(pagination.getFilterMap())) {
             for (var entry : pagination.getFilterMap().entrySet()) {
@@ -231,7 +191,7 @@ public class HibernateDiseasePageRepository implements DiseasePageRepository {
                "chebiPhenotype.fish.zdbID, chebiPhenotype.figure.zdbID, chebiPhenotype.publication.zdbID, chebiPhenotype.experiment.zdbID, chebiPhenotype.term.zdbID";
         Query<ChebiPhenotypeDisplay> query = HibernateUtil.currentSession().createQuery(hql, ChebiPhenotypeDisplay.class);
         if (includeChildren) {
-            query.setParameterList("ids", matchingIds);
+            query.setParameter("ancestorTermID", term.getZdbID());
         } else {
             query.setParameter("term", term);
         }
@@ -246,20 +206,6 @@ public class HibernateDiseasePageRepository implements DiseasePageRepository {
             chebiPhenotypeDisplay.setPhenotypeStatements(psws);
         });
         return result;
-    }
-
-    // Returns PKs of rows whose ancestor-term-ids array contains termId. Native SQL with an
-    // explicit text[] cast (CAST(...) form, NOT ::text[] — the latter confuses Hibernate's
-    // named-parameter parser since `:` is the parameter prefix). Hibernate 6's HQL array_contains
-    // binds the wrap as varchar[], which Postgres refuses to coerce to text[] for the @> operator.
-    private List<Long> findIdsByAncestor(String tableName, String pkColumn, String ancestorColumn, String termId) {
-        String sql = "SELECT " + pkColumn + " FROM " + tableName +
-                     " WHERE " + ancestorColumn + " @> CAST(ARRAY[:termId] AS text[])";
-        List<?> rows = HibernateUtil.currentSession()
-            .createNativeQuery(sql)
-            .setParameter("termId", termId)
-            .getResultList();
-        return rows.stream().map(r -> ((Number) r).longValue()).toList();
     }
 
     // empty out fast search tables (starting with ui.)

--- a/test/org/zfin/ui/repository/DiseasePageRepositoryTest.java
+++ b/test/org/zfin/ui/repository/DiseasePageRepositoryTest.java
@@ -1,0 +1,179 @@
+package org.zfin.ui.repository;
+
+import org.junit.Test;
+import org.zfin.AbstractDatabaseTest;
+import org.zfin.framework.HibernateUtil;
+import org.zfin.framework.api.Pagination;
+import org.zfin.ontology.GenericTerm;
+import org.zfin.repository.RepositoryFactory;
+
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeFalse;
+
+/**
+ * Guards the HQL in {@link HibernateDiseasePageRepository} against attribute paths Hibernate
+ * cannot resolve. Two of these queries have failed in production with
+ * org.hibernate.query.sqm.UnknownPathException -- fishModelDisplay.publication (#1933) and
+ * chebiDisplay.term (ZFIN-10412) -- both because an order-by referenced a getter that is not a
+ * mapped attribute. createQuery() parses the entire HQL string, so merely calling each method
+ * catches that whole class of bug; the assertions on the returned results are secondary.
+ * <p>
+ * Each query is exercised in three shapes, because each builds a different HQL string:
+ * the direct branch (where ... = :term), the include-children branch (where ... in :ids), and
+ * the direct branch with a populated filter map -- whose keys are themselves HQL paths appended
+ * as LOWER(key) like '...', using the same keys TermAPIController passes.
+ * <p>
+ * Terms are discovered from the ui.* tables rather than hardcoded: the direct branch needs a
+ * term some row points at, and the include-children branch needs one that appears in a row's
+ * ancestor array (otherwise findIdsByAncestor short-circuits and the HQL is never built). Both
+ * helpers pick the term matching the FEWEST rows so the queries stay cheap. If the ui.* table
+ * is empty (unloaded database) the test skips rather than fails.
+ */
+public class DiseasePageRepositoryTest extends AbstractDatabaseTest {
+
+    private final DiseasePageRepository repository = RepositoryFactory.getDiseasePageRepository();
+
+    @Test
+    public void getGenesInvolvedResolvesAllPaths() {
+        GenericTerm term = directTerm("ui.omim_phenotype_display", "opd_term_zdb_id");
+        assertNotNull(repository.getGenesInvolved(term, new Pagination(), false));
+        assertNotNull(repository.getGenesInvolved(term, filterOn(
+                "omimPhenotype.homoSapiensGene.symbol",
+                "omimPhenotype.name",
+                "omimPhenotype.disease.termName",
+                "omimPhenotype.omimAccession",
+                "zfinGene.abbreviation"), false));
+
+        GenericTerm ancestor = ancestorTerm("ui.omim_phenotype_display", "opd_ancestor_term_ids");
+        assertNotNull(repository.getGenesInvolved(ancestor, new Pagination(), true));
+    }
+
+    @Test
+    public void getPhenotypeResolvesAllPaths() {
+        GenericTerm term = directTerm("ui.term_phenotype_display", "tpd_term_zdb_id");
+        // isIncludeNormalPhenotype toggles an extra "AND phenoStats.tag = 'abnormal'" clause.
+        assertNotNull(repository.getPhenotype(term, new Pagination(), false, false));
+        assertNotNull(repository.getPhenotype(term, new Pagination(), false, true));
+        assertNotNull(repository.getPhenotype(term, filterOn(
+                "fishStat.geneSymbolSearch",
+                "fishStat.fish.name",
+                "fishStat.phenotypeStatementSearch",
+                "fishStat.term.termName"), false, false));
+
+        GenericTerm ancestor = ancestorTerm("ui.term_phenotype_display", "tpd_ancestor_term_ids");
+        assertNotNull(repository.getPhenotype(ancestor, new Pagination(), true, false));
+    }
+
+    @Test
+    public void getFishDiseaseModelsResolvesAllPaths() {
+        GenericTerm term = directTerm("ui.zebrafish_models_display", "zmd_term_zdb_id");
+        assertNotNull(repository.getFishDiseaseModels(term, new Pagination(), false));
+        assertNotNull(repository.getFishDiseaseModels(term, filterOn(
+                "fishModelDisplay.fish.displayName",
+                "fishModelDisplay.disease.termName",
+                "fishModelDisplay.conditionSearch"), false));
+
+        GenericTerm ancestor = ancestorTerm("ui.zebrafish_models_display", "zmd_ancestor_term_ids");
+        assertNotNull(repository.getFishDiseaseModels(ancestor, new Pagination(), true));
+    }
+
+    /**
+     * The ZFIN-10412 regression: the order-by referenced chebiDisplay.term, but
+     * ChebiFishModelDisplay maps the CHEBI term as `chebi` (omca_term_zdb_id).
+     */
+    @Test
+    public void getFishDiseaseChebiModelsResolvesAllPaths() {
+        GenericTerm term = directTerm("ui.zebrafish_models_chebi_association", "omca_term_zdb_id");
+        assertNotNull(repository.getFishDiseaseChebiModels(term, false));
+
+        GenericTerm ancestor = ancestorTerm("ui.zebrafish_models_chebi_association", "omca_ancestor_term_ids");
+        assertNotNull(repository.getFishDiseaseChebiModels(ancestor, true));
+    }
+
+    @Test
+    public void getPhenotypeChebiResolvesAllPaths() {
+        GenericTerm term = directTerm("ui.chebi_phenotype_display", "cpd_term_zdb_id");
+        assertNotNull(repository.getPhenotypeChebi(term, new Pagination(), null, false));
+        assertNotNull(repository.getPhenotypeChebi(term, filterOn(
+                "chebiPhenotype.conditionSearch",
+                "chebiPhenotype.amelioratedExacerbatedPhenoSearch",
+                "chebiPhenotype.fish.name",
+                "chebiPhenotype.phenotypeStatementSearch",
+                "chebiPhenotype.expConditionChebiSearch"), null, false));
+
+        GenericTerm ancestor = ancestorTerm("ui.chebi_phenotype_display", "cpd_ancestor_term_ids");
+        assertNotNull(repository.getPhenotypeChebi(ancestor, new Pagination(), null, true));
+    }
+
+    /**
+     * The include-children branch must not bind one parameter per matching row: Postgres caps a
+     * PreparedStatement at 65,535 parameters, and the widest ontology terms match far more rows
+     * than that (86,664 for the widest phenotype term when this was written). Binding the ids
+     * individually made /action/api/ontology/<term>/phenotype a hard 500 in production for the 11
+     * terms over the limit, so exercise the WIDEST term in each table rather than a convenient one.
+     * <p>
+     * The all-terms case is the only one that can trip the limit -- the direct branch binds a
+     * single term -- so this test only covers includeChildren=true.
+     */
+    @Test
+    public void includeChildrenDoesNotBindOneParameterPerRow() {
+        assertNotNull(repository.getGenesInvolved(
+            widestTerm("ui.omim_phenotype_display", "opd_ancestor_term_ids"), new Pagination(), true));
+        assertNotNull(repository.getPhenotype(
+            widestTerm("ui.term_phenotype_display", "tpd_ancestor_term_ids"), new Pagination(), true, false));
+        assertNotNull(repository.getFishDiseaseModels(
+            widestTerm("ui.zebrafish_models_display", "zmd_ancestor_term_ids"), new Pagination(), true));
+        assertNotNull(repository.getFishDiseaseChebiModels(
+            widestTerm("ui.zebrafish_models_chebi_association", "omca_ancestor_term_ids"), true));
+        assertNotNull(repository.getPhenotypeChebi(
+            widestTerm("ui.chebi_phenotype_display", "cpd_ancestor_term_ids"), new Pagination(), null, true));
+    }
+
+    /** A Pagination whose filter map holds every given HQL path, so each lands in the query. */
+    private Pagination filterOn(String... hqlPaths) {
+        Pagination pagination = new Pagination();
+        for (String path : hqlPaths) {
+            pagination.addToFilterMap(path, "zzz");
+        }
+        return pagination;
+    }
+
+    /** The term that the fewest rows of this table point at directly. */
+    private GenericTerm directTerm(String table, String termColumn) {
+        return loadTerm(firstValue(
+                "select " + termColumn + " from " + table +
+                " where " + termColumn + " is not null" +
+                " group by " + termColumn + " order by count(*) limit 1"));
+    }
+
+    /** The term appearing in the fewest rows' ancestor arrays -- keeps the query cheap. */
+    private GenericTerm ancestorTerm(String table, String ancestorColumn) {
+        return loadTerm(firstValue(
+                "select t from " + table + ", unnest(" + ancestorColumn + ") t" +
+                " group by t order by count(*) limit 1"));
+    }
+
+    /** The term appearing in the MOST rows' ancestor arrays -- the parameter-limit worst case. */
+    private GenericTerm widestTerm(String table, String ancestorColumn) {
+        return loadTerm(firstValue(
+                "select t from " + table + ", unnest(" + ancestorColumn + ") t" +
+                " group by t order by count(*) desc limit 1"));
+    }
+
+    private GenericTerm loadTerm(String termZdbID) {
+        GenericTerm term = RepositoryFactory.getOntologyRepository().getTermByZdbID(termZdbID);
+        assertNotNull("no term row for " + termZdbID, term);
+        return term;
+    }
+
+    // The SQL carries its own `limit 1`; setMaxResults would append a second limit clause.
+    private String firstValue(String sql) {
+        List<String> rows = HibernateUtil.currentSession()
+                .createNativeQuery(sql, String.class)
+                .getResultList();
+        assumeFalse("no data for: " + sql, rows.isEmpty());
+        return rows.get(0);
+    }
+}


### PR DESCRIPTION
Found by grouping production 500s in Kibana by tomcat.uri: 5,315 events over two days resolved to a handful of endpoints, 87% of them the first bug below.

1. /action/api/ontology/<term>/chebi-zebrafish-models -- every request, 4,601 hits

     https://zfin.org/action/api/ontology/ZDB-TERM-160831-137635/chebi-zebrafish-models
     https://zfin.org/action/api/ontology/ZDB-TERM-160831-150272/chebi-zebrafish-models

   UnknownPathException: the order-by referenced chebiDisplay.term, but ChebiFishModelDisplay maps the CHEBI term as `chebi` (omca_term_zdb_id). Fails at query-parse time, so it broke every term regardless of data. Introduced in ZFIN-10277 (#1893); the follow-up #1933 fixed `publication` -> `singlePublication` on the same line but left `term`.

2. /action/publication/<pub>/orthology-list -- every request, 478 hits over 293 pubs

     https://zfin.org/action/publication/ZDB-PUB-050823-6/orthology-list
     https://zfin.org/action/publication/ZDB-PUB-071129-8/orthology-list

   "You can't operate on a closed ResultSet" -- getOrthologPaginationByPub combined a tuple transformer with query.scroll(), which Hibernate 6 does not support. HibernateUpgradeHelper.setTupleResultAndListTransformer already documents the constraint; this call site was missed in the upgrade. Use list() like the sibling getOrthologListByPub and paginate the materialized list -- an ortholog list for one publication is small.

3. /action/api/ontology/<term>/phenotype -- the 11 widest terms, 15 hits

     https://zfin.org/action/api/ontology/ZDB-TERM-100331-1056/phenotype
     https://zfin.org/action/api/ontology/ZDB-TERM-100331-35/phenotype

   "PreparedStatement can have at most 65,535 parameters ... Given query has 86,604 parameters". The five "including substructures" queries fetched every matching row id and bound them one-per-parameter via `id in :ids`; the widest terms match 86,664 / 86,604 / 82,104 rows. Replace the id round-trip with a descendant-term subquery over TransitiveClosure (all_term_contains), which binds exactly ONE parameter. all_term_contains carries the self row, so semantics are unchanged -- verified per table that the subquery returns counts identical to the ancestor-array predicate it replaces (82,104 = 82,104 for the widest term; 150/61/332/1 for the rest). findIdsByAncestor is now unused.

   That exposed a second wall underneath: `could not resize shared memory segment ... No space left on device`, because Postgres puts parallel-query DSM segments in /dev/shm and the wide plan climbed through 24 segments to 772MB against a 1g shm_size. shm_size and work_mem must be chosen together -- measured peak /dev/shm and runtime on that query:

     work_mem   1 query           2 concurrent
      128MB       35MB,  8.3s       66MB,  6.7s
      192MB     1027MB,  2.7s           --        needs >2g
      256MB     1027MB,  2.2s     2049MB,   err   fastest, but needs ~4g

   shm_size 2g with work_mem 128MB. 256MB picks a faster parallel-hash plan but cannot fit two concurrent wide queries in 2g, and these pages get crawled. Throttling max_parallel_workers_per_gather to 1 keeps 256MB under 2g but measured slower (9.3s). maintenance_work_mem stays at 1GB, so VACUUM / CREATE INDEX are unaffected.

Verified on a feature stack: all three endpoints return data where they returned 500s (chebi models match the table exactly -- ethanol 61/61, pentetrazol 53/53, metronidazole 38/38; phenotype all-terms counts 74,273 / 78,597 / 78,653), and unrelated terms return totals identical to before (150/80/150, 332/332/332, 179/179/179). orthology-list verified across deep and out-of-range pages.

New DiseasePageRepositoryTest covers all five DiseasePageRepository read methods in three shapes each -- direct, include-children, and with a populated filter map -- plus a widest-term case for the parameter ceiling. Nothing covered this repository before, which is how both an unmapped order-by path and the bind-count ceiling reached production. Reverting either fix fails it.

Known limitation: the widest terms still take ~23-28s, because PaginationResult counts by scrolling all 124k rows to fill a 25-row page. That needs a SQL COUNT plus an id-paged fetch.