### PR TITLE
ZIRC: Refactor to cleaner code -- replace hand-written Options "withers" with Lombok @With

### DIFF
--- a/source/org/zfin/zirc/api/ZircAssayFormSchema.java
+++ b/source/org/zfin/zirc/api/ZircAssayFormSchema.java
@@ -153,16 +153,16 @@ public final class ZircAssayFormSchema {
         // including the placement of the attachment buckets (e.g. SSLP
         // shows the gel-image upload right after the primers, before the
         // SSLP-specific fields).
-        Options actgnHelp = Options.of().helpText("ACTGN only.");
+        Options actgnHelp = Options.of().withHelpText("ACTGN only.");
         return new VerticalLayout(List.of(
                 Group.of(null, List.of(
                         new Control("#/properties/assayType",
                                 Options.of()
-                                        .widget("selectWithOther")
-                                        .standardValues(ASSAY_TYPES)
-                                        .standardLabels(ASSAY_TYPE_LABELS)
-                                        .noOther(true)
-                                        .refreshesParent(true),
+                                        .withWidget("selectWithOther")
+                                        .withStandardValues(ASSAY_TYPES)
+                                        .withStandardLabels(ASSAY_TYPE_LABELS)
+                                        .withNoOther(true)
+                                        .withRefreshesParent(true),
                                 null)
                 )),
                 // Forward / Reverse primer — shown for the six types that
@@ -196,21 +196,21 @@ public final class ZircAssayFormSchema {
                 )),
                 groupRevealedFor(KASP_TYPES, List.of(
                         new Control("#/properties/kaspGenomicSequence",
-                                Options.of().multi(true), null)
+                                Options.of().withMulti(true), null)
                 )),
                 // RFLP + dCAPS digest block — same fields for both types.
                 groupRevealedFor(DIGEST_TYPES, List.of(
                         new Control("#/properties/restrictionEnzymeName",
-                                Options.of().placeholder("e.g. BsmBI"), null),
+                                Options.of().withPlaceholder("e.g. BsmBI"), null),
                         new Control("#/properties/restrictionEnzymeCatalog",
                                 Options.of()
-                                        .placeholder("vendor + cat #")
-                                        .infoHref("https://international.neb.com/"),
+                                        .withPlaceholder("vendor + cat #")
+                                        .withInfoHref("https://international.neb.com/"),
                                 null),
                         new Control("#/properties/enzymeCleavesWt",
-                                Options.of().widget("checkbox"), null),
+                                Options.of().withWidget("checkbox"), null),
                         new Control("#/properties/enzymeCleavesMut",
-                                Options.of().widget("checkbox"), null),
+                                Options.of().withWidget("checkbox"), null),
                         Control.of("#/properties/expectedWtDigest"),
                         Control.of("#/properties/expectedMutDigest")
                 )),
@@ -226,7 +226,7 @@ public final class ZircAssayFormSchema {
                 // metadata fields all live here.
                 groupRevealedFor(SSLP_TYPES, List.of(
                         new Control("#/properties/sslpMarkerName",
-                                Options.of().placeholder("Search ZFIN SSLP markers…"), null),
+                                Options.of().withPlaceholder("Search ZFIN SSLP markers…"), null),
                         Control.of("#/properties/sslpDistance"),
                         Control.of("#/properties/sslpGenomicLocation"),
                         Control.of("#/properties/sslpInducedBackground"),
@@ -237,7 +237,7 @@ public final class ZircAssayFormSchema {
                 // Additional info — last row in every variant.
                 Group.of(null, List.of(
                         new Control("#/properties/additionalInfo",
-                                Options.of().multi(true), null)
+                                Options.of().withMulti(true), null)
                 ))
         ));
     }
@@ -252,11 +252,11 @@ public final class ZircAssayFormSchema {
         return new Group(null,
                 List.of(new Control("#/properties/attachments",
                         Options.of()
-                                .widget("attachmentsList")
-                                .managesOwnPersistence(true)
-                                .label(label),
+                                .withWidget("attachmentsList")
+                                .withManagesOwnPersistence(true)
+                                .withLabel(label),
                         null)),
-                Options.of().layout("plain"),
+                Options.of().withLayout("plain"),
                 Rule.showWhenIn("#/properties/assayType", assayTypes));
     }
 

--- a/source/org/zfin/zirc/api/ZircFormSchema.java
+++ b/source/org/zfin/zirc/api/ZircFormSchema.java
@@ -115,20 +115,20 @@ public final class ZircFormSchema {
                 Group.of("Overview", List.of(
                         new Control("#/properties/name",
                                 Options.of()
-                                        .placeholder("e.g. nasl1zf123")
-                                        .helpText("Line name as it should appear in publications."),
+                                        .withPlaceholder("e.g. nasl1zf123")
+                                        .withHelpText("Line name as it should appear in publications."),
                                 null),
                         new Control("#/properties/previousNames",
                                 Options.of()
-                                        .widget("stringList")
-                                        .placeholder("Previous name")
-                                        .addLabel("+ Add previous name")
-                                        .helpText("Useful when this line was previously known by a different designation."),
+                                        .withWidget("stringList")
+                                        .withPlaceholder("Previous name")
+                                        .withAddLabel("+ Add previous name")
+                                        .withHelpText("Useful when this line was previously known by a different designation."),
                                 null),
                         new Control("#/properties/acceptance",
                                 Options.of()
-                                        .widget("multipleChoiceWithOther")
-                                        .label("Acceptance Reasons"),
+                                        .withWidget("multipleChoiceWithOther")
+                                        .withLabel("Acceptance Reasons"),
                                 null)
                 )),
                 // Mutations is structurally different from the field sections —
@@ -136,39 +136,39 @@ public final class ZircFormSchema {
                 // layout option tells SectionRenderer to drop the table wrapper.
                 new Group("Mutations",
                         List.of(new Control("#/properties/mutations",
-                                Options.of().widget("mutationsList").managesOwnPersistence(true),
+                                Options.of().withWidget("mutationsList").withManagesOwnPersistence(true),
                                 null)),
-                        Options.of().layout("plain"),
+                        Options.of().withLayout("plain"),
                         null),
                 // Linked features: pairwise links between mutations on the
                 // same submission. List-of-cards layout like Mutations.
                 new Group("Linked Features",
                         List.of(new Control("#/properties/linkedFeatures",
-                                Options.of().widget("linkedFeaturesList").managesOwnPersistence(true),
+                                Options.of().withWidget("linkedFeaturesList").withManagesOwnPersistence(true),
                                 null)),
-                        Options.of().layout("plain"),
+                        Options.of().withLayout("plain"),
                         null),
                 Group.of("Background", List.of(
                         new Control("#/properties/background/properties/singleAllelic",
-                                Options.of().widget("yesNoRadio"), null),
+                                Options.of().withWidget("yesNoRadio"), null),
                         new Control("#/properties/background/properties/maternalBackground",
-                                Options.of().widget("selectWithOther").standardValues(backgroundValues),
+                                Options.of().withWidget("selectWithOther").withStandardValues(backgroundValues),
                                 null),
                         new Control("#/properties/background/properties/paternalBackground",
-                                Options.of().widget("selectWithOther").standardValues(backgroundValues),
+                                Options.of().withWidget("selectWithOther").withStandardValues(backgroundValues),
                                 null),
                         new Control("#/properties/background/properties/backgroundChangeable",
-                                Options.of().widget("yesNoRadio"), null)
+                                Options.of().withWidget("yesNoRadio"), null)
                 )),
                 Group.of("Additional Info", List.of(
                         new Control("#/properties/additionalInfo/properties/unreportedFeaturesDetails",
-                                Options.of().multi(true), null),
+                                Options.of().withMulti(true), null),
                         new Control("#/properties/additionalInfo/properties/husbandryInfo",
-                                Options.of().multi(true)
-                                        .placeholder("Husbandry-specific information, e.g. special feeding regime"),
+                                Options.of().withMulti(true)
+                                        .withPlaceholder("Husbandry-specific information, e.g. special feeding regime"),
                                 null),
                         new Control("#/properties/additionalInfo/properties/additionalInfo",
-                                Options.of().multi(true), null)
+                                Options.of().withMulti(true), null)
                 ))
         ));
     }

--- a/source/org/zfin/zirc/api/ZircGeneFormSchema.java
+++ b/source/org/zfin/zirc/api/ZircGeneFormSchema.java
@@ -57,29 +57,29 @@ public final class ZircGeneFormSchema {
                 Group.of(null, java.util.List.of(
                         new Control("#/properties/mutatedGeneZdbID",
                                 Options.of()
-                                        .widget("autocomplete")
+                                        .withWidget("autocomplete")
                                         // Searches the markers endpoint
                                         // narrowed to GENEDOM (gene/pseudogene/
                                         // miRNA etc.) so non-gene markers like
                                         // SSLPs or BACs don't pollute the
                                         // dropdown. The selected item's value
                                         // (ZDB-ID) is what we PATCH back.
-                                        .searchEndpoint("markers")
-                                        .typeGroup("GENEDOM")
-                                        .placeholder("Start typing a gene name…")
-                                        .helpText("Resolves to the ZFIN marker ZDB-ID. Leave blank if unknown.")
+                                        .withSearchEndpoint("markers")
+                                        .withTypeGroup("GENEDOM")
+                                        .withPlaceholder("Start typing a gene name…")
+                                        .withHelpText("Resolves to the ZFIN marker ZDB-ID. Leave blank if unknown.")
                                         // The parent gene card shows the denormalized marker
                                         // abbreviation derived from this id — refresh it on change.
-                                        .refreshesParent(true),
+                                        .withRefreshesParent(true),
                                 null),
                         new Control("#/properties/linkageGroup",
-                                Options.of().placeholder("e.g. 5"),
+                                Options.of().withPlaceholder("e.g. 5"),
                                 null),
                         new Control("#/properties/genbankGenomicDna",
-                                Options.of().placeholder("Accession, e.g. NC_007112.7"),
+                                Options.of().withPlaceholder("Accession, e.g. NC_007112.7"),
                                 null),
                         new Control("#/properties/genbankCdna",
-                                Options.of().placeholder("Accession, e.g. NM_001077291"),
+                                Options.of().withPlaceholder("Accession, e.g. NM_001077291"),
                                 null)
                 ))
         ));

--- a/source/org/zfin/zirc/api/ZircLesionFormSchema.java
+++ b/source/org/zfin/zirc/api/ZircLesionFormSchema.java
@@ -123,10 +123,10 @@ public final class ZircLesionFormSchema {
         return new VerticalLayout(List.of(
                 Group.of(null, List.of(
                         new Control("#/properties/lesionType",
-                                Options.of().widget("selectWithOther")
-                                        .standardValues(LESION_TYPES)
-                                        .standardLabels(LESION_TYPE_LABELS)
-                                        .refreshesParent(true),
+                                Options.of().withWidget("selectWithOther")
+                                        .withStandardValues(LESION_TYPES)
+                                        .withStandardLabels(LESION_TYPE_LABELS)
+                                        .withRefreshesParent(true),
                                 null)
                 )),
                 // Sizes are always derived (never user-entered) and rendered
@@ -136,71 +136,71 @@ public final class ZircLesionFormSchema {
                 groupRevealedFor(NUCLEOTIDE_CHANGE_TYPES, List.of(
                         new Control("#/properties/nucleotideChange",
                                 Options.of()
-                                        .widget("selectWithOther")
-                                        .standardValues(NUCLEOTIDE_CHANGES)
-                                        .noOther(true),
+                                        .withWidget("selectWithOther")
+                                        .withStandardValues(NUCLEOTIDE_CHANGES)
+                                        .withNoOther(true),
                                 null)
                 )),
                 groupRevealedFor(NUCLEOTIDE_CHANGE_TYPES, List.of(
                         new Control("#/properties/lesionSizeBp",
-                                Options.of().widget("autoSize").constantValue(1).suffix("bp"),
+                                Options.of().withWidget("autoSize").withConstantValue(1).withSuffix("bp"),
                                 null)
                 )),
                 // Deletion / indel: deleted sequence, then its length as the
                 // (auto, read-only) lesion size.
                 groupRevealedFor(DELETED_SEQ_TYPES, List.of(
                         new Control("#/properties/deletedSequence",
-                                Options.of().multi(true), null)
+                                Options.of().withMulti(true), null)
                 )),
                 groupRevealedFor(DELETED_SEQ_TYPES, List.of(
                         new Control("#/properties/lesionSizeBp",
-                                Options.of().widget("autoSize")
-                                        .sourceField("deletedSequence").suffix("bp"),
+                                Options.of().withWidget("autoSize")
+                                        .withSourceField("deletedSequence").withSuffix("bp"),
                                 null)
                 )),
                 // Insertion / indel: inserted sequence, then its length as the
                 // (auto, read-only) insertion size.
                 groupRevealedFor(INSERTED_SEQ_TYPES, List.of(
                         new Control("#/properties/insertedSequence",
-                                Options.of().multi(true), null)
+                                Options.of().withMulti(true), null)
                 )),
                 groupRevealedFor(INSERTED_SEQ_TYPES, List.of(
                         new Control("#/properties/insertionSizeBp",
-                                Options.of().widget("autoSize")
-                                        .sourceField("insertedSequence").suffix("bp"),
+                                Options.of().withWidget("autoSize")
+                                        .withSourceField("insertedSequence").withSuffix("bp"),
                                 null)
                 )),
                 groupRevealedFor(TRANSGENE_TYPES, List.of(
                         new Control("#/properties/transgeneSequence",
-                                Options.of().multi(true), null),
+                                Options.of().withMulti(true), null),
                         new Control("#/properties/hasLargeVariant",
-                                Options.of().widget("yesNoRadio"), null)
+                                Options.of().withWidget("yesNoRadio"), null)
                 )),
                 groupRevealedFor(LOCATION_TYPES, List.of(
                         new Control("#/properties/fivePrimeFlank",
                                 Options.of()
-                                        .helpText("At least 20 nt directly preceding the lesion / transgene.")
-                                        .multi(true)
-                                        .infoHref("https://wiki.zfin.org/display/general/Transgene+Insertion+Sequence+Conventions"),
+                                        .withHelpText("At least 20 nt directly preceding the lesion / transgene.")
+                                        .withMulti(true)
+                                        .withInfoHref("https://wiki.zfin.org/display/general/Transgene+Insertion+Sequence+Conventions"),
                                 null),
                         new Control("#/properties/threePrimeFlank",
                                 Options.of()
-                                        .helpText("At least 20 nt directly following the lesion / transgene.")
-                                        .multi(true)
-                                        .infoHref("https://wiki.zfin.org/display/general/Transgene+Insertion+Sequence+Conventions"),
+                                        .withHelpText("At least 20 nt directly following the lesion / transgene.")
+                                        .withMulti(true)
+                                        .withInfoHref("https://wiki.zfin.org/display/general/Transgene+Insertion+Sequence+Conventions"),
                                 null)
                 )),
                 groupRevealedFor(PROTEIN_TYPES, List.of(
                         new Control("#/properties/mutatedAminoAcids",
-                                Options.of().placeholder("e.g. p.Gly12Val"), null),
+                                Options.of().withPlaceholder("e.g. p.Gly12Val"), null),
                         new Control("#/properties/mutatedAminoAcidsHgvs",
-                                Options.of().placeholder("HGVS protein notation"), null)
+                                Options.of().withPlaceholder("HGVS protein notation"), null)
                 )),
                 // Always-visible, and kept last so it sits below every
                 // per-type field cluster regardless of the lesion type.
                 Group.of(null, List.of(
                         new Control("#/properties/additionalInfo",
-                                Options.of().multi(true), null)
+                                Options.of().withMulti(true), null)
                 ))
         ));
     }

--- a/source/org/zfin/zirc/api/ZircMutationFormSchema.java
+++ b/source/org/zfin/zirc/api/ZircMutationFormSchema.java
@@ -128,14 +128,14 @@ public final class ZircMutationFormSchema {
                         // renders, so it comes first in the group.
                         new Control("#/properties/alleleInZfin",
                                 Options.of()
-                                        .widget("yesNoRadio")
-                                        .helpText("When \"Yes\", the field below searches existing ZFIN markers."),
+                                        .withWidget("yesNoRadio")
+                                        .withHelpText("When \"Yes\", the field below searches existing ZFIN markers."),
                                 null),
                         // Plain text input for new alleles.
                         new Control("#/properties/alleleDesignation",
                                 Options.of()
-                                        .placeholder("e.g. zf123")
-                                        .helpText("ZFIN allele designation; leave blank if not yet assigned."),
+                                        .withPlaceholder("e.g. zf123")
+                                        .withHelpText("ZFIN allele designation; leave blank if not yet assigned."),
                                 hideIfInZfin),
                         // Feature autocomplete when the allele is already in
                         // ZFIN — alleles live in the Feature table, not
@@ -143,80 +143,80 @@ public final class ZircMutationFormSchema {
                         // The selected ZDB-ID is what we PATCH back.
                         new Control("#/properties/alleleDesignation",
                                 Options.of()
-                                        .widget("autocomplete")
-                                        .searchEndpoint("features")
-                                        .placeholder("Start typing an allele or ZDB-ID…")
-                                        .helpText("Resolves to the ZFIN feature ZDB-ID."),
+                                        .withWidget("autocomplete")
+                                        .withSearchEndpoint("features")
+                                        .withPlaceholder("Start typing an allele or ZDB-ID…")
+                                        .withHelpText("Resolves to the ZFIN feature ZDB-ID."),
                                 showIfInZfin),
                         new Control("#/properties/mutationType",
-                                Options.of().widget("selectWithOther").standardValues(MUTATION_TYPES),
+                                Options.of().withWidget("selectWithOther").withStandardValues(MUTATION_TYPES),
                                 null),
                         new Control("#/properties/mutationDiscoverer",
-                                Options.of().placeholder("Person who first identified the mutation"),
+                                Options.of().withPlaceholder("Person who first identified the mutation"),
                                 null),
                         new Control("#/properties/mutationInstitution",
-                                Options.of().placeholder("Lab / institution"), null)
+                                Options.of().withPlaceholder("Lab / institution"), null)
                 )),
                 Group.of("Mutagenesis", List.of(
                         new Control("#/properties/mutagenesisStage",
-                                Options.of().widget("selectWithOther").standardValues(MUTAGENESIS_STAGES),
+                                Options.of().withWidget("selectWithOther").withStandardValues(MUTAGENESIS_STAGES),
                                 null),
                         new Control("#/properties/mutagenesisProtocol",
-                                Options.of().widget("selectWithOther").standardValues(MUTAGENESIS_PROTOCOLS),
+                                Options.of().withWidget("selectWithOther").withStandardValues(MUTAGENESIS_PROTOCOLS),
                                 null),
                         new Control("#/properties/molecularlyCharacterized",
-                                Options.of().widget("yesNoRadio"), null)
+                                Options.of().withWidget("yesNoRadio"), null)
                 )),
                 // Genes: same inline-expand pattern as assays.
                 new Group("Genes",
                         List.of(new Control("#/properties/genes",
-                                Options.of().widget("genesList").managesOwnPersistence(true), null)),
-                        Options.of().layout("plain"),
+                                Options.of().withWidget("genesList").withManagesOwnPersistence(true), null)),
+                        Options.of().withLayout("plain"),
                         null),
                 // Lesions: same inline-expand pattern; the per-lesion
                 // form has the lesion-type matrix.
                 new Group("Lesions",
                         List.of(new Control("#/properties/lesions",
-                                Options.of().widget("lesionsList").managesOwnPersistence(true), null)),
-                        Options.of().layout("plain"),
+                                Options.of().withWidget("lesionsList").withManagesOwnPersistence(true), null)),
+                        Options.of().withLayout("plain"),
                         null),
                 // Genotyping Assays is a list of child rows like the
                 // submission's Mutations section — drop the table wrapper.
                 new Group("Genotyping Assays",
                         List.of(new Control("#/properties/assays",
-                                Options.of().widget("assaysList").managesOwnPersistence(true), null)),
-                        Options.of().layout("plain"),
+                                Options.of().withWidget("assaysList").withManagesOwnPersistence(true), null)),
+                        Options.of().withLayout("plain"),
                         null),
                 // Phenotypes: same inline-expand pattern; no type matrix.
                 new Group("Phenotypes",
                         List.of(new Control("#/properties/phenotypes",
-                                Options.of().widget("phenotypesList").managesOwnPersistence(true), null)),
-                        Options.of().layout("plain"),
+                                Options.of().withWidget("phenotypesList").withManagesOwnPersistence(true), null)),
+                        Options.of().withLayout("plain"),
                         null),
                 Group.of("Lethality", List.of(
                         new Control("#/properties/homozygousLethal",
-                                Options.of().widget("yesNoRadio"), null),
+                                Options.of().withWidget("yesNoRadio"), null),
                         new Control("#/properties/lethalityStageTypical",
-                                Options.of().widget("selectWithOther").standardValues(LETHALITY_STAGES),
+                                Options.of().withWidget("selectWithOther").withStandardValues(LETHALITY_STAGES),
                                 showWhenLethal),
                         new Control("#/properties/lethalitySpecificTimepoint",
                                 Options.of()
-                                        .placeholder("e.g. 48 hpf")
-                                        .helpText("Single timepoint when most homozygotes die. Use the window fields below for a range."),
+                                        .withPlaceholder("e.g. 48 hpf")
+                                        .withHelpText("Single timepoint when most homozygotes die. Use the window fields below for a range."),
                                 showWhenLethal),
                         new Control("#/properties/lethalityWindowStart",
-                                Options.of().placeholder("e.g. 24 hpf"), showWhenLethal),
+                                Options.of().withPlaceholder("e.g. 24 hpf"), showWhenLethal),
                         new Control("#/properties/lethalityWindowEnd",
-                                Options.of().placeholder("e.g. 72 hpf"), showWhenLethal),
+                                Options.of().withPlaceholder("e.g. 72 hpf"), showWhenLethal),
                         new Control("#/properties/lethalityAdditionalInfo",
-                                Options.of().multi(true), showWhenLethal)
+                                Options.of().withMulti(true), showWhenLethal)
                 )),
                 Group.of("Publications", List.of(
                         new Control("#/properties/publications",
                                 Options.of()
-                                        .widget("stringList")
-                                        .placeholder("Citation, PMID, DOI, or ZDB Pub ID")
-                                        .addLabel("+ Add publication"),
+                                        .withWidget("stringList")
+                                        .withPlaceholder("Citation, PMID, DOI, or ZDB Pub ID")
+                                        .withAddLabel("+ Add publication"),
                                 null)
                 ))
         ));

--- a/source/org/zfin/zirc/api/ZircPhenotypeFormSchema.java
+++ b/source/org/zfin/zirc/api/ZircPhenotypeFormSchema.java
@@ -102,19 +102,19 @@ public final class ZircPhenotypeFormSchema {
                         // The parent phenotype card shows the description snippet —
                         // refresh it on change.
                         new Control("#/properties/description",
-                                Options.of().multi(true).refreshesParent(true), null)
+                                Options.of().withMulti(true).withRefreshesParent(true), null)
                 )),
                 // Custom timing widget — hpf/dpf unit toggle + read-only
                 // stage echo.
                 Group.of(null, List.of(
                         new Control("#/properties/hpfStart",
-                                Options.of().widget("phenotypeTiming"), null)
+                                Options.of().withWidget("phenotypeTiming"), null)
                 )),
                 Group.of(null, List.of(
                         new Control("#/properties/zfinImagePermission",
-                                Options.of().widget("yesNoRadio"), null),
+                                Options.of().withWidget("yesNoRadio"), null),
                         new Control("#/properties/zircImagePermission",
-                                Options.of().widget("yesNoRadio"), null)
+                                Options.of().withWidget("yesNoRadio"), null)
                 )),
                 // Segregation sits directly below image permissions
                 // (ZFIN-10348). The %/comment fields follow it and only
@@ -122,20 +122,20 @@ public final class ZircPhenotypeFormSchema {
                 Group.of(null, List.of(
                         new Control("#/properties/segregation",
                                 Options.of()
-                                        .widget("selectWithOther")
-                                        .standardValues(SEGREGATION_OPTIONS)
-                                        .noOther(true),
+                                        .withWidget("selectWithOther")
+                                        .withStandardValues(SEGREGATION_OPTIONS)
+                                        .withNoOther(true),
                                 null),
                         new Control("#/properties/nonMendelianPercentage",
-                                Options.of().suffix("%"), showWhenNonMendelian),
+                                Options.of().withSuffix("%"), showWhenNonMendelian),
                         new Control("#/properties/nonMendelianComment",
-                                Options.of().multi(true), showWhenNonMendelian)
+                                Options.of().withMulti(true), showWhenNonMendelian)
                 )),
                 Group.of(null, List.of(
                         new Control("#/properties/type",
                                 Options.of()
-                                        .widget("selectWithOther")
-                                        .standardValues(PHENOTYPE_TYPE_OPTIONS),
+                                        .withWidget("selectWithOther")
+                                        .withStandardValues(PHENOTYPE_TYPE_OPTIONS),
                                 null)
                 ))
         ));

--- a/source/org/zfin/zirc/api/uischema/Options.java
+++ b/source/org/zfin/zirc/api/uischema/Options.java
@@ -1,6 +1,9 @@
 package org.zfin.zirc.api.uischema;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.With;
 
 import java.util.List;
 
@@ -9,19 +12,21 @@ import java.util.List;
  * captured in one place. See {@code reference/zirc-architecture.md} §5
  * for what each one means and which renderers honor it.
  *
- * <p>Mutate via the fluent withers — each one returns a new instance.
- * {@code Options.of()} produces an empty instance to start from.
+ * <p>Mutate via the Lombok-generated {@code withX} withers — each one returns a
+ * new instance. {@code Options.of()} produces an empty instance to start from.
  *
  * <pre>{@code
  * Options.of()
- *     .placeholder("e.g. zf123")
- *     .helpText("ZFIN allele designation; leave blank if not yet assigned.")
+ *     .withPlaceholder("e.g. zf123")
+ *     .withHelpText("ZFIN allele designation; leave blank if not yet assigned.")
  * }</pre>
  *
  * <p>The fields are explicit (not a generic Map) so a typo on a key name
  * fails at compile time instead of silently being ignored at runtime.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@With
+@Builder(access = AccessLevel.PRIVATE)
 public record Options(
         // Layout-on-Group hint: "plain" drops the table wrapper.
         String layout,
@@ -84,27 +89,13 @@ public record Options(
         Integer constantValue
 ) {
 
+    /**
+     * An empty instance to start a wither chain from. Built via the private
+     * Lombok builder so adding a component here costs nothing — the
+     * alternative is a positional list of nulls that has to grow in lockstep
+     * with the record header.
+     */
     public static Options of() {
-        return new Options(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+        return builder().build();
     }
-
-    public Options layout(String v)         { return new Options(v, widget, multi, standardValues, placeholder, helpText, infoHref, suffix, label, searchEndpoint, typeGroup, comments, managesOwnPersistence, refreshesParent, addLabel, standardLabels, noOther, sourceField, constantValue); }
-    public Options widget(String v)         { return new Options(layout, v, multi, standardValues, placeholder, helpText, infoHref, suffix, label, searchEndpoint, typeGroup, comments, managesOwnPersistence, refreshesParent, addLabel, standardLabels, noOther, sourceField, constantValue); }
-    public Options multi(boolean v)         { return new Options(layout, widget, v, standardValues, placeholder, helpText, infoHref, suffix, label, searchEndpoint, typeGroup, comments, managesOwnPersistence, refreshesParent, addLabel, standardLabels, noOther, sourceField, constantValue); }
-    public Options standardValues(List<String> v) { return new Options(layout, widget, multi, v, placeholder, helpText, infoHref, suffix, label, searchEndpoint, typeGroup, comments, managesOwnPersistence, refreshesParent, addLabel, standardLabels, noOther, sourceField, constantValue); }
-    public Options placeholder(String v)    { return new Options(layout, widget, multi, standardValues, v, helpText, infoHref, suffix, label, searchEndpoint, typeGroup, comments, managesOwnPersistence, refreshesParent, addLabel, standardLabels, noOther, sourceField, constantValue); }
-    public Options helpText(String v)       { return new Options(layout, widget, multi, standardValues, placeholder, v, infoHref, suffix, label, searchEndpoint, typeGroup, comments, managesOwnPersistence, refreshesParent, addLabel, standardLabels, noOther, sourceField, constantValue); }
-    public Options infoHref(String v)       { return new Options(layout, widget, multi, standardValues, placeholder, helpText, v, suffix, label, searchEndpoint, typeGroup, comments, managesOwnPersistence, refreshesParent, addLabel, standardLabels, noOther, sourceField, constantValue); }
-    public Options suffix(String v)         { return new Options(layout, widget, multi, standardValues, placeholder, helpText, infoHref, v, label, searchEndpoint, typeGroup, comments, managesOwnPersistence, refreshesParent, addLabel, standardLabels, noOther, sourceField, constantValue); }
-    public Options label(String v)          { return new Options(layout, widget, multi, standardValues, placeholder, helpText, infoHref, suffix, v, searchEndpoint, typeGroup, comments, managesOwnPersistence, refreshesParent, addLabel, standardLabels, noOther, sourceField, constantValue); }
-    public Options searchEndpoint(String v) { return new Options(layout, widget, multi, standardValues, placeholder, helpText, infoHref, suffix, label, v, typeGroup, comments, managesOwnPersistence, refreshesParent, addLabel, standardLabels, noOther, sourceField, constantValue); }
-    public Options typeGroup(String v)      { return new Options(layout, widget, multi, standardValues, placeholder, helpText, infoHref, suffix, label, searchEndpoint, v, comments, managesOwnPersistence, refreshesParent, addLabel, standardLabels, noOther, sourceField, constantValue); }
-    public Options comments(boolean v)      { return new Options(layout, widget, multi, standardValues, placeholder, helpText, infoHref, suffix, label, searchEndpoint, typeGroup, v, managesOwnPersistence, refreshesParent, addLabel, standardLabels, noOther, sourceField, constantValue); }
-    public Options managesOwnPersistence(boolean v) { return new Options(layout, widget, multi, standardValues, placeholder, helpText, infoHref, suffix, label, searchEndpoint, typeGroup, comments, v, refreshesParent, addLabel, standardLabels, noOther, sourceField, constantValue); }
-    public Options refreshesParent(boolean v)       { return new Options(layout, widget, multi, standardValues, placeholder, helpText, infoHref, suffix, label, searchEndpoint, typeGroup, comments, managesOwnPersistence, v, addLabel, standardLabels, noOther, sourceField, constantValue); }
-    public Options addLabel(String v)       { return new Options(layout, widget, multi, standardValues, placeholder, helpText, infoHref, suffix, label, searchEndpoint, typeGroup, comments, managesOwnPersistence, refreshesParent, v, standardLabels, noOther, sourceField, constantValue); }
-    public Options standardLabels(List<String> v) { return new Options(layout, widget, multi, standardValues, placeholder, helpText, infoHref, suffix, label, searchEndpoint, typeGroup, comments, managesOwnPersistence, refreshesParent, addLabel, v, noOther, sourceField, constantValue); }
-    public Options noOther(boolean v)       { return new Options(layout, widget, multi, standardValues, placeholder, helpText, infoHref, suffix, label, searchEndpoint, typeGroup, comments, managesOwnPersistence, refreshesParent, addLabel, standardLabels, v, sourceField, constantValue); }
-    public Options sourceField(String v)    { return new Options(layout, widget, multi, standardValues, placeholder, helpText, infoHref, suffix, label, searchEndpoint, typeGroup, comments, managesOwnPersistence, refreshesParent, addLabel, standardLabels, noOther, v, constantValue); }
-    public Options constantValue(int v)     { return new Options(layout, widget, multi, standardValues, placeholder, helpText, infoHref, suffix, label, searchEndpoint, typeGroup, comments, managesOwnPersistence, refreshesParent, addLabel, standardLabels, noOther, sourceField, v); }
 }

--- a/test/org/zfin/zirc/api/uischema/UiSchemaSerializationTest.java
+++ b/test/org/zfin/zirc/api/uischema/UiSchemaSerializationTest.java
@@ -52,8 +52,8 @@ public class UiSchemaSerializationTest {
     public void controlWithMetadataOptionsSerializesAlphabetized() throws Exception {
         Control c = new Control("#/properties/forwardPrimer",
                 Options.of()
-                        .placeholder("5′ → 3′")
-                        .helpText("Forward primer sequence"),
+                        .withPlaceholder("5′ → 3′")
+                        .withHelpText("Forward primer sequence"),
                 null);
         String json = MAPPER.writeValueAsString(c);
         assertEquals(


### PR DESCRIPTION
The Options record construction is hard to reason about because it takes 19 parameters. This uses lombok to allow creating Options records using the builder pattern.  It means options.widget(...) calls become options.withWidget(...) calls, but overall I think it's much cleaner. The main file that is improved is Options.java