### PR TITLE
ZFIN-10421: Merge GBrowse-tracks refresh fixes from release-1183

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,0 +1,79 @@
+TODO
+====
+
+OPEN QUESTION -- 3742 'la' insertion locations will display without a citation
+-----------------------------------------------------------------------------
+Needs a curator decision before release. Blocks nothing mechanically; the rows
+load fine. The question is what pub, if any, they should cite.
+
+What happens:
+  source/org/zfin/db/postGmakePostloaddb/1184/migrations/
+    0030-la-insertion-grcz12tu-liftover.sql
+mints GRCz12tu sequence_feature_chromosome_location rows for 3742 'la'
+transgenic-insertion features (UCSC liftOver of their Zv9 coordinates). It
+writes no record_attribution.
+
+Refresh-GBrowse-Tracks_d §G
+(server_apps/data_transfer/Ensembl/updateSequenceFeatureChromosomeLocation.sql)
+re-imports sfcl into sequence_feature_chromosome_location_generated with
+
+    left outer join record_attribution on recattrib_data_zdb_id = sfcl_zdb_id
+
+so an unattributed sfcl row lands with sfclg_pub_zdb_id NULL and the location
+renders on the feature page with no citation.
+
+Why the sibling changeset does not cover them:
+  0030-grcz12tu-liftover-record-attribution.sql
+inherits each lifted row's pub(s) from the feature's GRCz11 sfcl row. Measured
+against the 2026-07-31 production snapshot, all 3742 'la' features have NO sfcl
+row on ANY assembly -- not GRCz11, not Zv9. So that join matches nothing for
+them, at any changeset ordering. (Do not renumber it hoping to fix this; that
+was tried and it does not help.)
+
+Not a regression, which is why this is a question and not a bug: these features
+already display uncited locations today. Their existing generated rows carry
+zero pubs --
+    ZfinGbrowseZv9StartEndLoader / Zv9      3742 rows, 3742 features, 0 with pub
+    'other map location'        / GRCz11    5850 rows, 3625 features, 0 with pub
+The new GRCz12tu rows join an already-uncited set rather than creating a new
+class of defect.
+
+An attribution source does exist: all 3742 features have feature-level
+record_attribution (the pub that described the allele). Whether to reuse it is
+the decision. Reusing it asserts that pub made a GRCz12tu placement claim, which
+it did not -- the coordinates are computationally lifted. Options:
+  a) leave uncited (status quo for this feature set)
+  b) inherit the feature-level pub, accepting the overclaim
+  c) attribute to a ZFIN-internal / computational-analysis pub, if one is
+     appropriate for liftOver-derived placements
+  d) surface the placement as computational in the UI instead of via a pub
+     (sfcl_evidence_code is already ZDB-TERM-170419-312, 'evidence used in
+     automatic assertion')
+
+To re-measure after 0030-la-insertion has run:
+  select count(*) from sequence_feature_chromosome_location z12
+   where z12.sfcl_assembly = 'GRCz12tu'
+     and not exists (select 1 from record_attribution
+                      where recattrib_data_zdb_id = z12.sfcl_zdb_id);
+
+
+CONTEXT -- why the GBrowse refresh fixes in this branch matter
+-------------------------------------------------------------
+Back-ported from release-1183 (0aa07919ee), which fixed a Refresh-GBrowse-
+Tracks_d production outage: nightly failures from 2026-07-07 01:00 through
+2026-07-31 00:50.
+
+  - Root cause: §G's left join fans one location into a row per pub, and
+    uk_sfclg_unique_location excludes the pub id, so the fan-out rows collide
+    once sfclg_acc_num is non-null. Harmless while it was NULL (NULLs are
+    distinct in a unique key); e040299b16 started carrying the accession through
+    and armed it. Fixed by §G's DISTINCT ON, which reached main in ac1f157271
+    but was not cherry-picked to release-1183 for 23 days -- hence the long
+    failure run.
+  - Still load-bearing: 269 colliding fan-out groups (273 surplus rows) exist in
+    the 2026-07-31 snapshot. Removing the DISTINCT ON re-breaks the job today.
+  - Second fix: both knockdown-reagent callers now append commit.sql. The SQL
+    opens 'begin work;' with no COMMIT by design (the caller decides), so
+    running it with -f alone left the transaction open and psql's disconnect
+    rolled the whole refresh back -- the job exited 0 while the table never
+    moved.

--- a/server_apps/data_transfer/Downloads/GFF3/knockdown_reagents/load_knockdown_reagents.sh
+++ b/server_apps/data_transfer/Downloads/GFF3/knockdown_reagents/load_knockdown_reagents.sh
@@ -38,6 +38,12 @@ ${PGBINDIR}/psql -v ON_ERROR_STOP=1 -d $DBNAME -f load_knockdown_reagents.sql
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # update sequence_feature_chromosome_location_generated table
-psql -v ON_ERROR_STOP=1 -d $DB_NAME -a -f ../../../Ensembl/updateSequenceFeatureChromosomeLocation.sql
+# updateSequenceFeatureChromosomeLocation.sql opens 'begin work;' and contains no
+# COMMIT -- the caller decides, which is why fetch_ensdarg.sh appends commit.sql.
+# Running it with -f alone left the transaction open, so psql's disconnect rolled
+# the whole refresh back: the job exited 0 while sfclg kept its previous contents.
+cat ../../../Ensembl/updateSequenceFeatureChromosomeLocation.sql \
+    ../../../Ensembl/commit.sql \
+  | psql -v ON_ERROR_STOP=1 -d $DB_NAME -a
 
 

--- a/server_apps/data_transfer/Downloads/GFF3/knockdown_reagents/load_knockdown_reagents_grcz12tu.sh
+++ b/server_apps/data_transfer/Downloads/GFF3/knockdown_reagents/load_knockdown_reagents_grcz12tu.sh
@@ -39,4 +39,8 @@ ${PGBINDIR}/psql -v ON_ERROR_STOP=1 -d $DBNAME -f load_knockdown_reagents_grcz12
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # update sequence_feature_chromosome_location_generated table
-psql -v ON_ERROR_STOP=1 -d $DB_NAME -a -f ../../../Ensembl/updateSequenceFeatureChromosomeLocation.sql
+# See load_knockdown_reagents.sh: the SQL opens 'begin work;' with no COMMIT, so
+# commit.sql has to be appended or the refresh is rolled back on disconnect.
+cat ../../../Ensembl/updateSequenceFeatureChromosomeLocation.sql \
+    ../../../Ensembl/commit.sql \
+  | psql -v ON_ERROR_STOP=1 -d $DB_NAME -a

--- a/source/org/zfin/db/postGmakePostloaddb/1184/migrations/0030-grcz12tu-liftover-record-attribution.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1184/migrations/0030-grcz12tu-liftover-record-attribution.sql
@@ -1,25 +1,18 @@
 --liquibase formatted sql
---changeset cmpich:0040-grcz12tu-liftover-record-attribution.sql splitStatements:false
+--changeset cmpich:0030-grcz12tu-liftover-record-attribution.sql splitStatements:false
 
--- Attribute the GRCz12tu sequence_feature_chromosome_location rows inserted by the
--- liftover changesets in this directory:
---   0020-grcz11-to-grcz12tu-liftover-welltested.sql
---   0030-la-insertion-grcz12tu-liftover.sql
+-- Attribute the GRCz12tu sequence_feature_chromosome_location rows inserted by
+-- 0020-grcz11-to-grcz12tu-liftover-welltested.sql.
 --
--- Both mint sfcl rows and register them in zdb_active_data, but neither writes
--- record_attribution. That matters for display: Refresh-GBrowse-Tracks_d §G
--- (server_apps/data_transfer/Ensembl/updateSequenceFeatureChromosomeLocation.sql)
+-- 0020 minted the sfcl rows and registered them in zdb_active_data, but did not
+-- write record_attribution. That matters for display: Refresh-GBrowse-Tracks_d
+-- §G (server_apps/data_transfer/Ensembl/updateSequenceFeatureChromosomeLocation.sql)
 -- re-imports sfcl into sequence_feature_chromosome_location_generated with
 --     left outer join record_attribution on recattrib_data_zdb_id = sfcl_zdb_id
 -- so an unattributed sfcl row propagates with sfclg_pub_zdb_id NULL and the
 -- location renders on the feature page without a citation. Every other sfcl row
 -- in the table is attributed (GRCz11 42464/42464, GRCz12tu 36811/36811 before
 -- 0020), so the unattributed lifted rows are the anomaly.
---
--- Numbered 0040 rather than 0030 deliberately. The 1184 changelog uses
--- <includeAll>, which orders by filename, so a 0030-grcz12tu-* name would sort
--- ahead of 0030-la-insertion-* and run before the rows it needs to attribute
--- exist. 0040 runs after every liftover changeset here.
 --
 -- A lifted GRCz12tu placement is the same assertion as its GRCz11 source
 -- placement expressed in new coordinates, so it inherits that row's pub(s).
@@ -28,16 +21,9 @@
 -- (recattrib_data_zdb_id, recattrib_source_zdb_id, recattrib_source_type)
 -- collapses duplicates.
 --
--- Scope limit: attribution is inherited from the feature's GRCz11 sfcl row, so a
--- lifted row whose feature has no attributed GRCz11 sfcl row is left alone and
--- still propagates a NULL pub through §G. That is expected to be the case for
--- 0030's 'la' insertions, which 0030's own header describes as having had a
--- genomic position only on Zv9. Verify the remaining unattributed GRCz12tu count
--- after this runs; sourcing a pub for the Zv9-only set is separate work.
---
--- Targeting: GRCz12tu rows with NO attribution at all. That is exactly the
--- 0020 + 0030 set; pre-existing GRCz12tu rows are already attributed and are
--- left alone. recattrib_pk_id comes from record_attribution_recattrib_pk_id_seq.
+-- Targeting: GRCz12tu rows with NO attribution at all. That is exactly the 0020
+-- set; pre-existing GRCz12tu rows are already attributed and are left alone.
+-- recattrib_pk_id comes from record_attribution_recattrib_pk_id_seq.
 -- ON CONFLICT DO NOTHING + the NOT EXISTS guard make this safe to re-run.
 
 insert into record_attribution

--- a/source/org/zfin/db/postGmakePostloaddb/1184/migrations/0040-grcz12tu-liftover-record-attribution.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1184/migrations/0040-grcz12tu-liftover-record-attribution.sql
@@ -1,0 +1,57 @@
+--liquibase formatted sql
+--changeset cmpich:0040-grcz12tu-liftover-record-attribution.sql splitStatements:false
+
+-- Attribute the GRCz12tu sequence_feature_chromosome_location rows inserted by the
+-- liftover changesets in this directory:
+--   0020-grcz11-to-grcz12tu-liftover-welltested.sql
+--   0030-la-insertion-grcz12tu-liftover.sql
+--
+-- Both mint sfcl rows and register them in zdb_active_data, but neither writes
+-- record_attribution. That matters for display: Refresh-GBrowse-Tracks_d §G
+-- (server_apps/data_transfer/Ensembl/updateSequenceFeatureChromosomeLocation.sql)
+-- re-imports sfcl into sequence_feature_chromosome_location_generated with
+--     left outer join record_attribution on recattrib_data_zdb_id = sfcl_zdb_id
+-- so an unattributed sfcl row propagates with sfclg_pub_zdb_id NULL and the
+-- location renders on the feature page without a citation. Every other sfcl row
+-- in the table is attributed (GRCz11 42464/42464, GRCz12tu 36811/36811 before
+-- 0020), so the unattributed lifted rows are the anomaly.
+--
+-- Numbered 0040 rather than 0030 deliberately. The 1184 changelog uses
+-- <includeAll>, which orders by filename, so a 0030-grcz12tu-* name would sort
+-- ahead of 0030-la-insertion-* and run before the rows it needs to attribute
+-- exist. 0040 runs after every liftover changeset here.
+--
+-- A lifted GRCz12tu placement is the same assertion as its GRCz11 source
+-- placement expressed in new coordinates, so it inherits that row's pub(s).
+-- Where a feature has several GRCz11 sfcl rows citing different pubs, all
+-- distinct pubs carry over -- the unique alternate key
+-- (recattrib_data_zdb_id, recattrib_source_zdb_id, recattrib_source_type)
+-- collapses duplicates.
+--
+-- Scope limit: attribution is inherited from the feature's GRCz11 sfcl row, so a
+-- lifted row whose feature has no attributed GRCz11 sfcl row is left alone and
+-- still propagates a NULL pub through §G. That is expected to be the case for
+-- 0030's 'la' insertions, which 0030's own header describes as having had a
+-- genomic position only on Zv9. Verify the remaining unattributed GRCz12tu count
+-- after this runs; sourcing a pub for the Zv9-only set is separate work.
+--
+-- Targeting: GRCz12tu rows with NO attribution at all. That is exactly the
+-- 0020 + 0030 set; pre-existing GRCz12tu rows are already attributed and are
+-- left alone. recattrib_pk_id comes from record_attribution_recattrib_pk_id_seq.
+-- ON CONFLICT DO NOTHING + the NOT EXISTS guard make this safe to re-run.
+
+insert into record_attribution
+  (recattrib_data_zdb_id, recattrib_source_zdb_id, recattrib_source_type)
+select distinct z12.sfcl_zdb_id, r11.recattrib_source_zdb_id, 'standard'
+  from sequence_feature_chromosome_location z12
+  join sequence_feature_chromosome_location z11
+       on z11.sfcl_feature_zdb_id = z12.sfcl_feature_zdb_id
+      and z11.sfcl_assembly = 'GRCz11'
+  join record_attribution r11
+       on r11.recattrib_data_zdb_id = z11.sfcl_zdb_id
+ where z12.sfcl_assembly = 'GRCz12tu'
+   and not exists (select 1
+                     from record_attribution existing
+                    where existing.recattrib_data_zdb_id = z12.sfcl_zdb_id)
+on conflict (recattrib_data_zdb_id, recattrib_source_zdb_id, recattrib_source_type)
+   do nothing;


### PR DESCRIPTION
Back-port the two pieces of 0aa07919ee that never reached main. §G's DISTINCT ON is already here via ac1f157271; these are the rest.

updateSequenceFeatureChromosomeLocation.sql opens 'begin work;' and contains no COMMIT on purpose -- the caller decides, which is why fetch_ensdarg.sh appends commit.sql. The two knockdown-reagent callers that Refresh-GBrowse-Tracks_d runs invoked it with -f alone, so the transaction stayed open and psql's disconnect rolled the whole refresh back: the job exited 0 while sfclg kept its previous contents. §A's deletes rolled back with everything else, so nothing was lost, but the table never moved. Both callers now append commit.sql.

The liftover changesets in 1184/migrations mint GRCz12tu sfcl rows without record_attribution, so §G carries a NULL pub forward and the location renders without a citation -- every other sfcl row in the table is attributed. The new changeset inherits each lifted row's pub(s) from its GRCz11 source row.
